### PR TITLE
Issue #24 Clearing Status between keyboards

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -107,7 +107,7 @@ $(document).ready(() => {
         render_layout($layout.val());
       });
     } else {
-      $status.append('\n* No default for this keyboard... yet!');
+      $status.append(`\n* Sorry there is no default for the ${$keyboard.val()} keyboard... yet!`);
     }
   }
 
@@ -278,6 +278,7 @@ $(document).ready(() => {
   function switchKeyboardLayout() {
     // reset_keymap();
     window.location.hash = '#/' + $keyboard.val() + '/' + $layout.val();
+    $status.html(''); // clear the DOM not the value otherwise weird things happen
     // load_layouts($keyboard).val());
   }
 


### PR DESCRIPTION
 - use $status.html() to clear DOM. $status.val() causes the DOM to stop
   updating.
 - also provide a slightly friendlier message when we don't have a
   default for a particular keyboard.