### PR TITLE
Cache keycode lookups

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -28,6 +28,8 @@ $(document).ready(() => {
   setSelectWidth($keyboard);
   setSelectWidth($layout);
 
+  var lookupKeycode = _.memoize(lookupKeycode); // cache lookups
+
   var keycodes = getKeycodes();
   $(window).on('hashchange', urlRouteChanged);
 


### PR DESCRIPTION
 The current keycode lookup code does a linear, O(n), find to search the
 keycode list. Adding memoize to the function wrapper caches the results
 of the search, which we don't expect to change between application
 refreshes, bringing it closer to O(1) in performance. Memory impact
 seems minimal as it's just a dictionary and results in creating less
 garbage due to the reduced searching.