### PR TITLE
Issue #37 two click

### DIFF
--- a/_layouts/qmk.html
+++ b/_layouts/qmk.html
@@ -17,6 +17,7 @@
     <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.5/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/keypress/2.1.5/keypress.min.js"></script>
     <script src="{{ '/assets/js/script.js?v=' | append: site.github.build_revision | relative_url }}"></script>
 
     <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -819,6 +819,7 @@ button {
   border-radius: 5px;
   border: 5px solid #fff;
   box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.3);
+  font-size: 12px;
 }
 
 #visual-keymap {
@@ -847,6 +848,7 @@ button {
   line-height: 100%;
   padding: 1px;
   white-space: pre-line;
+  cursor: pointer;
 }
 
 .key:empty {
@@ -1028,6 +1030,10 @@ button {
 }
 .keycode-6250 {
   width: 226.25px;
+}
+
+.keycode-select {
+  border: solid 2px green;
 }
 
 .space {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -12,6 +12,14 @@ $(document).ready(() => {
   var backend_baseurl = 'https://compile.clueboard.co';
   var backend_keyboards_url = `${backend_baseurl}/v1/keyboards`;
   var backend_compile_url = `${backend_baseurl}/v1/compile`;
+  var defaults = {
+    KEY_WIDTH: 40,
+    KEY_HEIGHT: 40,
+    SWAP_KEY_WIDTH: 30,
+    SWAP_KEY_HEIGHT: 30,
+    KEY_X_SPACING: 45,
+    KEY_Y_SPACING: 45
+  };
 
   var $keyboard = $('#keyboard');
   var $layout = $('#layout');
@@ -362,7 +370,10 @@ $(document).ready(() => {
         var $d = $(d);
         if ($(d).hasClass('key')) {
           // reduce size of dragged key to indicate src
-          $d.css({ height: '30px', width: '30px' });
+          $(d).css({
+            height: `${defaults.SWAP_KEY_HEIGHT}px`,
+            width: `${defaults.SWAP_KEY_WIDTH}px`
+          });
         }
         $d.draggable('option', 'revertDuration', 100);
       },
@@ -375,7 +386,10 @@ $(document).ready(() => {
       },
       stop: function() {
         if ($(d).hasClass('key')) {
-          $(d).css({ height: '40px', width: '40px' });
+          $(d).css({
+            height: `${defaults.KEY_HEIGHT}px`,
+            width: `${defaults.KEY_WIDTH}px`
+          });
         }
       }
     });
@@ -449,10 +463,10 @@ $(document).ready(() => {
   }
 
   function render_layout(_layout) {
-    var key_width = 40;
-    var key_height = 40;
-    var key_x_spacing = 45;
-    var key_y_spacing = 45;
+    var key_width = defaults.KEY_WIDTH;
+    var key_height = defaults.KEY_HEIGHT;
+    var key_x_spacing = defaults.KEY_X_SPACING;
+    var key_y_spacing = defaults.KEY_Y_SPACING;
     $visualKeymap.find('*').remove();
     if (!keymap[layer]) {
       keymap[layer] = {};
@@ -468,16 +482,17 @@ $(document).ready(() => {
       }
       var key = $('<div>', {
         class: 'key disabled',
-        style:
-          'left: ' +
-          d.x * key_x_spacing +
-          'px; top: ' +
-          d.y * key_y_spacing +
-          'px; width: ' +
-          (d.w * key_x_spacing - (key_x_spacing - key_width)) +
-          'px; height: ' +
-          (d.h * key_y_spacing - (key_y_spacing - key_height)) +
-          'px',
+        style: [
+          'left: ',
+          d.x * key_x_spacing,
+          'px; top: ',
+          d.y * key_y_spacing,
+          'px; width: ',
+          d.w * key_x_spacing - (key_x_spacing - key_width),
+          'px; height: ',
+          d.h * key_y_spacing - (key_y_spacing - key_height),
+          'px'
+        ].join(''),
         id: 'key-' + k,
         'data-index': k,
         'data-type': 'key'


### PR DESCRIPTION
     - click to select a visual-keymap location and then click keycode map
     - drag keys between other keys to swap locations
     - esc to deselect a selected key
     - Animate swapping of keys on keymap
       - conveys intent of drop better
       - resize dragged key on keymap to smaller so it's obvious which is src
         - only applies to .key
       - set Z of dragged element to be on top
     - Center dragged element under cursor
     - Get originalPosition from draggable
       - dig inside draggable data and get originalPosition
     - tweak drag to 5px to make it more responsive
     - refactoring
     - add comments
     - introduce defaults object