### PR TITLE
Add two multimedia keys

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1384,9 +1384,11 @@ $(document).ready(() => {
 
       { label: 'Multimedia Keys', width: 'label' },
 
+      { name: 'Previous', code: 'KC_MPRV', title: 'Media Previous' },
       { name: 'Next', code: 'KC_MNXT', title: 'Media Next' },
       { name: 'Vol -', code: 'KC_VOLD', title: 'Volume Down' },
       { name: 'Vol +', code: 'KC_VOLU', title: 'Volume Up' },
+      { name: 'Media Stop', code: 'KC_MSTP', title: 'Media Stop' },
       { name: 'Play', code: 'KC_MPLY', title: 'Play/Pause' }
     ];
   }


### PR DESCRIPTION
Add the following multimedia keys:
- Previous \(Is Windows specific, which follows the convention set by 'Media Next'\)
- Media Stop \(Use 'Media Stop' name to differentiate from the existing application keycode 'KC\_STOP'\)