### PR TITLE
Bug Fixes Issue #53

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -109,8 +109,10 @@ $(document).ready(() => {
     urlRouteChanged();
   });
 
-  var keypressListener = new window.keypress.Listener();
+  var keypressListener = new window.keypress.Listener($visualKeymap[0]);
   keypressListener.register_many(generateKeypressCombos(keycodes));
+
+  var ignoreKeypressListener = _.partial(ignoreKeypressListener, keypressListener);
 
   return;
 
@@ -119,6 +121,12 @@ $(document).ready(() => {
   // Implementation goes here
   //
   ////////////////////////////////////////
+
+  function ignoreKeypressListener(listener, $element) {
+    $element
+      .focus(() => listener.stop_listening())
+      .blur(() => listener.listen());
+  }
 
   // generate keypress combo list from the keycodes list
   function generateKeypressCombos(_keycodes) {
@@ -814,18 +822,26 @@ $(document).ready(() => {
         }
       },
       drop: function(event, ui) {
-        if (!$(t).hasClass('active-key')) {
-          return;
+        var $target;
+        if ($(t).hasClass('active-key')) {
+          $target = $(t);
+        } else {
+          // this is probably a container
+          $target = $(t).find('.active-key');
+          if ($target.length === 0) {
+            return;
+          }
+          $target = $($target[0]);
         }
         var srcKeycode = ui.helper[0];
         $(srcKeycode).draggable('option', 'revertDuration', 0);
-        $(t).removeClass('active-key');
+        $target.removeClass('active-key');
         $('.layer.active').addClass('non-empty');
         if ($(srcKeycode).hasClass('keycode')) {
           $(t).attr('data-code', srcKeycode.dataset.code);
           // $(t).draggable({revert: true, revertDuration: 100});
-          if ($(t).hasClass('key-contents')) {
-            myKeymap.setContents(layer, key, {
+          if ($target.hasClass('key-contents')) {
+            myKeymap.setContents(key, {
               name: srcKeycode.innerHTML,
               code: srcKeycode.dataset.code,
               type: srcKeycode.dataset.type
@@ -924,6 +940,7 @@ $(document).ready(() => {
         var val = $(this).val();
         myKeymap.setKeycodeLayer(_layer, k, val);
       });
+      ignoreKeypressListener(layer_input1);
       $(key).append(layer_input1);
     } else if (keycode.type === 'text') {
       $(key).addClass('key-layer');
@@ -933,6 +950,7 @@ $(document).ready(() => {
       }).on('input', function(/*e*/) {
         myKeymap.setText(layer, k, $(this).val());
       });
+      ignoreKeypressListener(layer_input);
       $(key).append(layer_input);
     } else {
       $(key).removeClass('key-container');
@@ -1476,7 +1494,7 @@ $(document).ready(() => {
     }
 
     function setContents(index, key) {
-      instance.km[instance.l][index] = key;
+      instance.km[instance.l][index].contents = key;
     }
 
     function _changeLayer(newLayer) {


### PR DESCRIPTION
 - Symptom: unable to use input text boxes
 - Cause: keypress library was intercepting all keypresses
 - Fix: narrow scope of keypress lib and turn it off for input fields in
   visual keymap

 - Symptom: unable to drag keys input key-content fields like RSFT_T
 - Cause: wrong API call sent and implementation set data to wrong part
          of keymap. Logic for identifying key_content wasn't correct
          for a contained key.
 - Fix: improve target logic to identify correct element. Fix API call
        so it is same as other instances; removed layer param. Fix API
        implementation so set content actually sets the content field.