### PR TITLE
Add link to Keycodes reference page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1092,3 +1092,7 @@ input[type='number']::-webkit-outer-spin-button {
 input[type='number'] {
   -moz-appearance: textfield;
 }
+
+.hint {
+  font-size: 12px;
+}

--- a/index.html
+++ b/index.html
@@ -53,6 +53,6 @@ layout: qmk
 </div>
 <p style="clear:both" id="keycodes-section">
   <label>Keycodes:</label>
-  <p class="hint"><a href="https://docs.qmk.fm/keycodes" title="Keycodes reference">Keycodes reference</a></p>
+  <p class="hint"><a href="https://docs.qmk.fm/keycodes" title="Keycodes reference" target="_blank">Keycodes reference</a></p>
   <div id="keycodes"></div>
 </p>

--- a/index.html
+++ b/index.html
@@ -53,5 +53,6 @@ layout: qmk
 </div>
 <p style="clear:both" id="keycodes-section">
   <label>Keycodes:</label>
+  <p class="hint"><a href="https://docs.qmk.fm/keycodes" title="Keycodes reference">Keycodes reference</a></p>
   <div id="keycodes"></div>
 </p>


### PR DESCRIPTION
Add a link to the [Keycodes](https://docs.qmk.fm/keycodes) page of the documentation above the keycodes section of the configurator. Fixes #68.