### PR TITLE
Add tooltips and accept list for Import JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@ layout: qmk
     <button id="hex" disabled>Download .hex</button>
     <button id="toolbox" disabled>Open in QMK Toolbox</button>
     <button id="source" disabled>Download Source</button>
-    <button id="export" title="Export Keymap to QMK Keymap JSON file">Export Keymap</button>
-    <button id="import" title="Import Keymap from a QMK Keymap JSON file">Import Keymap</button>
+    <button id="export" title="Export QMK Keymap JSON file">Export Keymap</button>
+    <button id="import" title="Import QMK Keymap JSON file">Import Keymap</button>
     <input id="fileImport" type="file" accept="application/json" />
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -19,9 +19,9 @@ layout: qmk
     <button id="hex" disabled>Download .hex</button>
     <button id="toolbox" disabled>Open in QMK Toolbox</button>
     <button id="source" disabled>Download Source</button>
-    <button id="export">Export Keymap</button>
-    <button id="import">Import Keymap</button>
-    <input id="fileImport" type="file" />
+    <button id="export" title="Export Keymap to QMK Keymap JSON file">Export Keymap</button>
+    <button id="import" title="Import Keymap from a QMK Keymap JSON file">Import Keymap</button>
+    <input id="fileImport" type="file" accept="application/json" />
   </div>
 </div>
 <div class="split-content">


### PR DESCRIPTION
@mechmerlin recommended added tooltips to clarify what we are importing

Observed issues:

1. folks importing hex files or keymap.c files accidentally into configurator
2. folks importing kbfirmware config files into configurator

Fixes:

1. add tooltips to the import/export buttons which explain that we are expecting JSON files. Restrict the types of files we accept to application/json
2. see issue #92 