### PR TITLE
Issue #98 - unexpected keycode

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -744,7 +744,7 @@ $(document).ready(() => {
     return key;
   }
 
-  function parseKeycode(keycode) {
+  function parseKeycode(keycode, stats) {
     var metadata;
 
     // Check if the keycode is a complex/combo keycode ie. contains ()
@@ -783,6 +783,12 @@ $(document).ready(() => {
       }
       var key = newKey(metadata, keycode, { layer: internal });
       return key;
+    }
+
+    if (keycode.length < 4) {
+      // unexpectedly short keycode
+      $status.append(`Found an unexpected keycode \'${_.escape(keycode)}\' on layer ${stats.layers} in keymap. Setting to KC_NO\n`)
+      return lookupKeycode('KC_NO');
     }
 
     // regular keycode


### PR DESCRIPTION
While investigating the issue, we discovered a keymap that contained
invalid keycodes. The keycodes happen to parse because they matched keys
but generated invalid keymaps.

We haven't figured out how to replicate this issue, short of editing the
JSON file itself.

As a defensive measure to prevent importing bad data, add another check
for the length of the keycode. We don't support keycodes shorter than 4
characters in length. In those cases set the key to KC_NO and warn
the user on the console.