### PR TITLE
Issue #98 - unexpected keycode in JSON

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -178,7 +178,7 @@ $(document).ready(() => {
     return {
       keys: keycode.keys,
       on_keydown: () => {
-        var meta = lookupKeycode(keycode.keys);
+        var meta = lookupKeyPressCode(keycode.keys);
         if (meta === undefined) {
           return;
         }
@@ -717,9 +717,13 @@ $(document).ready(() => {
     document.body.removeChild(element);
   }
 
-  function lookupKeycode(searchTerm) {
+  function lookupKeyPressCode(searchTerm) {
+    return lookupKeycode(searchTerm, true);
+  }
+
+  function lookupKeycode(searchTerm, isKeys) {
     var found = keycodes.find(({ code, keys }) => {
-      return code === searchTerm || (keys && keys === searchTerm);
+      return code === searchTerm || isKeys && keys && keys === searchTerm;
     });
     return found;
   }
@@ -744,7 +748,7 @@ $(document).ready(() => {
     return key;
   }
 
-  function parseKeycode(keycode) {
+  function parseKeycode(keycode, stats) {
     var metadata;
 
     // Check if the keycode is a complex/combo keycode ie. contains ()
@@ -783,6 +787,12 @@ $(document).ready(() => {
       }
       var key = newKey(metadata, keycode, { layer: internal });
       return key;
+    }
+
+    if (keycode.length < 4) {
+      // unexpectedly short keycode
+      $status.append(`Found an unexpected keycode \'${_.escape(keycode)}\' on layer ${stats.layers} in keymap. Setting to KC_NO\n`)
+      return lookupKeycode('KC_NO');
     }
 
     // regular keycode


### PR DESCRIPTION
While investigating the issue, we discovered a keymap that contained
invalid keycodes. The keycodes happen to parse because they matched keys
but generated invalid keymaps.

This can be replicated by using an ANY key from keycodes and entering a
'.' or other valid keypress.js value. The UI would display a valid
keycode but the backend would receive a keypress.js value, causing the
compile to fail.

Fixes:

 - As a defensive measure, add another check for the length of the
   keycode. We don't support keycodes shorter than 4 characters in
   length. In those cases set the key to KC_NO and warn the user
   on the console.
 - prevent parsing code from parsing keys values.
   Adds a flag to prevent general non keypress.js uses from
   validating keypress.js aliases as valid keycodes