### PR TITLE
BUG: Restore download hex

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -707,6 +707,8 @@ $(document).ready(() => {
           $status.append(
             '\n* Finished:\n' + data.result.output.replace(/\[.*m/gi, '')
           );
+          hex_stream = data.result.firmware;
+          hex_filename = data.result.firmware_filename;
           enableCompileButton();
           enableOtherButtons();
           break;


### PR DESCRIPTION
 - When refactoring compile code, I forgot to copy over the file name
   results to globals.
 - issue #107 