### PR TITLE
Issue #101 Export Any keycodes

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -367,7 +367,7 @@ $(document).ready(() => {
 
   function exportJSON() {
     //Squashes the keymaps to the api payload format, might look into making this a function
-    var layers = myKeymap.exportLayers();
+    var layers = myKeymap.exportLayers({ compiler: false });
 
     //API payload format
     var data = {
@@ -403,7 +403,7 @@ $(document).ready(() => {
 
   function compileLayout() {
     disableCompileButton();
-    var layers = myKeymap.exportLayers();
+    var layers = myKeymap.exportLayers({ compiler: true });
     var data = {
       keyboard: $keyboard.val(),
       keymap: getKeymapName(),
@@ -788,8 +788,18 @@ $(document).ready(() => {
     return key;
   }
 
+  function stripANY(keycode) {
+    if (keycode.indexOf('ANY(') === 0) {
+      // strip ANY from keycodes, this is only for human debugging
+      keycode = keycode.slice(4, -1);
+    }
+    return keycode;
+  }
+
   function parseKeycode(keycode, stats) {
     var metadata;
+
+    keycode = stripANY(keycode);
 
     // Check if the keycode is a complex/combo keycode ie. contains ()
     if (keycode.includes('(')) {
@@ -1654,7 +1664,7 @@ $(document).ready(() => {
       instance.km[__layer][index].text = text;
     }
 
-    function exportLayers() {
+    function exportLayers({ compiler }) {
       return _.reduce(
         instance.km,
         function(layers, _layer, k) {
@@ -1674,7 +1684,9 @@ $(document).ready(() => {
                 keycode = keycode.replace('layer', key.layer);
               }
               if (key.code.indexOf('text') !== -1) {
-                keycode = key.text;
+                // add a special ANY marker to keycodes that were defined using ANY
+                // This will be stripped back off on import.
+                keycode = compiler ? key.text : `ANY(${key.text})`;
               }
               acc.push(keycode);
               return acc;


### PR DESCRIPTION
We recently had to deal with a bug caused by keycodes that had been
exported into the keymap by ANY being reimported back into configurator
but it wasn't clear where they had come from.

@skullydazed requested, when we export an ANY keycode, we should
explicitly mark it as such so we know where it came from. On import, we
can strip this back off as any keys have their own type inside
configurator.

This commit adds ANY() to exported ANY keycodes and removes it when we
import it again. This should give someone debugging a keymap better
information about where a keycode came from.