### PR TITLE
Issue #64 Default name for empty keymap names

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -299,9 +299,11 @@ $(document).ready(() => {
   }
 
   function getKeymapName() {
-    return $('#keymap-name')
+    var keymapName = $('#keymap-name')
       .val()
       .replace(/\s/g, '_');
+    // use a default name if it is blank
+    return keymapName === '' ? 'mine' : keymapName;
   }
 
   function setKeymapName(name) {


### PR DESCRIPTION
 - if empty string is used for a keymap name, revert it to default on
   export to avoid it being named json.txt