### PR TITLE
Issue #121 Fix for bad keycodes

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1316,19 +1316,19 @@ $(document).ready(() => {
       },
       {
         name: 'LCtl_T',
-        code: 'LCtl_T(kc)',
+        code: 'LCTL_T(kc)',
         type: 'container',
         title: 'Control when held, kc when tapped'
       },
       {
         name: 'LAlt_T',
-        code: 'LAlt_T(kc)',
+        code: 'LALT_T(kc)',
         type: 'container',
         title: 'Alt when held, kc when tapped'
       },
       {
         name: 'LGui_T',
-        code: 'LGui_T(kc)',
+        code: 'LGUI_T(kc)',
         type: 'container',
         title: 'Gui when held, kc when tapped'
       },
@@ -1340,19 +1340,19 @@ $(document).ready(() => {
       },
       {
         name: 'RCtl_T',
-        code: 'RCtl_T(kc)',
+        code: 'RCTL_T(kc)',
         type: 'container',
         title: 'Control when held, kc when tapped'
       },
       {
         name: 'RAlt_T',
-        code: 'RAlt_T(kc)',
+        code: 'RALT_T(kc)',
         type: 'container',
         title: 'Alt when held, kc when tapped'
       },
       {
         name: 'RGui_T',
-        code: 'RGui_T(kc)',
+        code: 'RGUI_T(kc)',
         type: 'container',
         title: 'Gui when held, kc when tapped'
       },


### PR DESCRIPTION
@Arrowmaster on discord discovered an issue with a group of our Mod key
combination keycodes. Looking at the keycodes list we had a few
incorrectly defined keycodes that were lower case instead of all caps.

This patch sets the back to the same as the defines on the API.

I tested this with the keymap file supplied by @Arrowmaster