### PR TITLE
Yanfali issue 103 qmk tooblbox install link

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -628,7 +628,6 @@ a img {
 #export,
 #import,
 #load-default {
-  float: right;
   line-height: 120%;
   margin: 0px 4px 0px 0px;
   border-radius: 3px;
@@ -639,20 +638,12 @@ a img {
   cursor: pointer;
 }
 
-#compile,
-#hex {
+#compile {
   margin-right: 0px;
 }
 
-#source,
-#toolbox,
-#export,
-#import {
-  float: left;
-}
-
-#fileImport {
-  visibility: hidden;
+#fileImport, #infoPreview {
+  display: none;
 }
 
 #compile:disabled,
@@ -718,6 +709,28 @@ button {
   -webkit-box-sizing: border-box;
   overflow: hidden;
   line-height: 100%;
+}
+
+.botctrl {
+  display: grid;
+  grid-template: auto auto / 80% 20%;
+  grid-row-gap: 5px;
+}
+
+.botctrl-1-1 {
+  grid-row: 1;
+  grid-column: 1;
+  justify-self: start;
+}
+.botctrl-1-2 {
+  grid-row: 1;
+  grid-column: 2;
+  justify-self: end;
+}
+.botctrl-2 {
+  grid-row: 2;
+  grid-column: span 2;
+  justify-self: start;
 }
 
 #layers {
@@ -1131,4 +1144,19 @@ input[type='number'] {
 
 .bes-jobs {
   justify-self: end;
+}
+
+.topctrl {
+  display: grid;
+  grid-template: auto / 45% 35% 20%;
+}
+
+.topctrl-1 {
+  grid-column: 1;
+}
+.topctrl-2 {
+  grid-column: 2;
+}
+.topctrl-3 {
+  grid-column: 3;
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -892,9 +892,9 @@ $(document).ready(() => {
   }
 
   function setSelectWidth(s) {
-    var sel = $(s);
-    $('#templateOption').text(sel.val());
-    sel.width($('#template').width() * 1.03);
+    var $sel = $(s);
+    $('#templateOption').text($sel.val());
+    $sel.width($('#template').width() * 1.03);
   }
 
   function reset_keymap() {

--- a/index.html
+++ b/index.html
@@ -10,19 +10,20 @@ layout: qmk
   <div id="controller-top">
     <div class="topctrl">
       <span class="topctrl-1">
-      <label style="display: inline-block; width: 90px;" >Keyboard:</label>
+      <label style="display: inline-block; width: 75px;" >Keyboard:</label>
       <select id="keyboard" onChange="setSelectWidth(this);"></select>
       </span>
       <span class="topctrl-2">
-      <label>Layout:</label>
-      <select id="layout" onChange="setSelectWidth(this);"></select>
+        <label id="keymap-name-label">Keymap Name:</label>
+        <input id="keymap-name" type="text" value="mine" />
       </span>
       <span class="topctrl-3">
-      <button id="compile" title="Compile keymap">Compile</button>
       <button id="load-default" title="Load default keymap from QMK Firmware">Load Default</button>
+      <button id="compile" title="Compile keymap">Compile</button>
       </span>
     </div>
-    <label id="keymap-name-label">Keymap Name: <input id="keymap-name" type="text" value="mine" /></label>
+    <label style="display: inline-block; width: 75px;">Layout:</label>
+    <select id="layout" onChange="setSelectWidth(this);"></select>
   </div>
   <textarea id="status" readonly></textarea>
   <div id="controller-bottom" class="botctrl">

--- a/index.html
+++ b/index.html
@@ -8,20 +8,38 @@ layout: qmk
 </select>
 <div id="controller">
   <div id="controller-top">
-    <label>Keyboard: <select id="keyboard" onChange=" setSelectWidth(this);"></select></label>
-    <label>Layout: <select id="layout" onChange=" setSelectWidth(this);"></select></label>
+    <div class="topctrl">
+      <span class="topctrl-1">
+      <label style="display: inline-block; width: 90px;" >Keyboard:</label>
+      <select id="keyboard" onChange="setSelectWidth(this);"></select>
+      </span>
+      <span class="topctrl-2">
+      <label>Layout:</label>
+      <select id="layout" onChange="setSelectWidth(this);"></select>
+      </span>
+      <span class="topctrl-3">
+      <button id="compile" title="Compile keymap">Compile</button>
+      <button id="load-default" title="Load default keymap from QMK Firmware">Load Default</button>
+      </span>
+    </div>
     <label id="keymap-name-label">Keymap Name: <input id="keymap-name" type="text" value="mine" /></label>
-    <button id="compile" title="Compile keymap">Compile</button>
-    <button id="load-default" title="Load default keymap from QMK Firmware">Load Default</button>
   </div>
   <textarea id="status" readonly></textarea>
-  <div id="controller-bottom">
-    <button id="hex" title="Download .hex file for flashing" disabled>Download .hex</button>
-    <button id="toolbox" title="Load firmware file in QMK Toolbox" disabled>Open in QMK Toolbox</button>
-    <button id="source" title="Download QMK Firmware code" disabled>Download Source</button>
-    <button id="export" title="Export QMK Keymap JSON file">Export Keymap</button>
-    <button id="import" title="Import QMK Keymap JSON file">Import Keymap</button>
-    <input id="fileImport" type="file" accept="application/json" />
+  <div id="controller-bottom" class="botctrl">
+    <div class="botctrl-1-1">
+      <button id="toolbox" title="Load firmware file in QMK Toolbox" disabled>Open in QMK Toolbox</button>
+      <button id="source" title="Download QMK Firmware code" disabled>Download Source</button>
+      <button id="export" title="Export QMK Keymap JSON file">Export Keymap</button>
+      <button id="import" title="Import QMK Keymap JSON file">Import Keymap</button>
+      <input id="fileImport" type="file" accept="application/json" />
+      <input id="infoPreview" type="file" accept="application/json" />
+    </div>
+    <div class="botctrl-1-2">
+      <button id="hex" title="Download .hex file for flashing" disabled>Download .hex</button>
+    </div>
+    <div class="botctrl-2">
+      <a class="hint" href="https://github.com/qmk/qmk_toolbox/releases">Download QMK Toolbox</a>
+    </div>
   </div>
 </div>
 <div class="split-content">


### PR DESCRIPTION
 - add a toolbox install link to the UI underneath QMK toolbox button
 - update control layouts to use grid so we have more control without
   using floats.

### New Layout

![screen shot 2018-05-19 at 16 00 24](https://user-images.githubusercontent.com/2275667/40273873-c4dad522-5b7d-11e8-94d2-16a238900b76.png)

 1. move layout drop down below keyboard
 1. use grid to format controls
 1. add a Download QMK Toolbox link