### PR TITLE
Move QMK toolbox link out of lower control box

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -713,7 +713,7 @@ button {
 
 .botctrl {
   display: grid;
-  grid-template: auto auto / 80% 20%;
+  grid-template: auto / 80% 20%;
   grid-row-gap: 5px;
 }
 

--- a/index.html
+++ b/index.html
@@ -38,10 +38,8 @@ layout: qmk
     <div class="botctrl-1-2">
       <button id="hex" title="Download .hex file for flashing" disabled>Download .hex</button>
     </div>
-    <div class="botctrl-2">
-      <a class="hint" href="https://github.com/qmk/qmk_toolbox/releases">Download QMK Toolbox</a>
-    </div>
   </div>
+  <a class="hint" href="https://github.com/qmk/qmk_toolbox/releases">Download QMK Toolbox</a>
 </div>
 <div class="split-content">
   <div class="left-side">


### PR DESCRIPTION
@jackhumbert recommended moving the anchor out of the control box, and
it does look better.