### PR TITLE
Issue #114 Info.json UI preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ secrets.tar
 .bundle/*
 vendor/*
 *.sw[po]
+node_modules

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -523,6 +523,7 @@ $(document).ready(() => {
       if (isPreviewMode) {
         $keyboard.find('option[value="'+PREVIEW_LABEL+'"]').remove();
         isPreviewMode = false;
+        setKeymapName('mine');
       }
     }
     disableOtherButtons();

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,6 +1,7 @@
 $(document).ready(() => {
   const PREVIEW_LABEL = 'Preview info.json';
   var layouts = {};
+  var isPreviewMode = false;
   //  var keymap = [];
   var layer = 0;
   var job_id = '';
@@ -120,12 +121,16 @@ $(document).ready(() => {
   keypressListener.register_many(generateKeypressCombos(keycodes));
   keypressListener.simple_combo('ctrl shift i', () => {
     // add a special bogus entry to the keyboard list for previews
-    $keyboard.append(
-      $('<option>', {
-        value: PREVIEW_LABEL,
-        text: PREVIEW_LABEL
-      })
-    );
+    if (!isPreviewMode) {
+      $keyboard.append(
+        $('<option>', {
+          value: PREVIEW_LABEL,
+          text: PREVIEW_LABEL
+        })
+      );
+      disableCompileButton();
+      isPreviewMode = true;
+    }
     $infoPreview.click();
   });
 
@@ -352,7 +357,7 @@ $(document).ready(() => {
       setSelectWidth($layout);
       layout = _.first(_.keys(data.layouts));
       $layout.val(layout);
-      switchKeyboardLayout();
+      switchKeyboardLayout(isPreviewMode);
 
       setKeymapName('info.json preview');
 
@@ -508,10 +513,18 @@ $(document).ready(() => {
     myKeymap.clearDirty();
   }
 
-  function switchKeyboardLayout() {
+  function switchKeyboardLayout(preview=false) {
     window.location.hash = '#/' + $keyboard.val() + '/' + $layout.val();
     $status.html(''); // clear the DOM not the value otherwise weird things happen
     myKeymap.clearDirty();
+    if (!preview) {
+      // only do these steps if we haven't been invoked from preview
+      enableCompileButton();
+      if (isPreviewMode) {
+        $keyboard.find('option[value="'+PREVIEW_LABEL+'"]').remove();
+        isPreviewMode = false;
+      }
+    }
     disableOtherButtons();
     // load_layouts($keyboard).val());
   }


### PR DESCRIPTION
Adds the ability to preview an info.json file, which is useful for
contributors who are working on creating new info.json files. Currently
we must go through a full review and commit cycle or set up a proxy/fake
API service to preview these files.

 - add hidden keybindings CTRL + SHIFT + I to access file dialog
 - add a Fake the keybord name so it is clear in UI what is happening
   and this also prevents compilation
 - add a new onload function dedicated to previewing these files
 - modify the load layout code to handle data coming from a non API
   source
 - extract functions
   - anon onload functions extracted to named function
 - clean up direct jquery DOM lookups and use existing aliases