### PR TITLE
add tada68 default ANSI layout

### DIFF
--- a/keymaps/tada68_default.json
+++ b/keymaps/tada68_default.json
@@ -1,0 +1,17 @@
+{
+  "keyboard": "tada68",
+  "keymap": "default",
+  "layout": "LAYOUT_ansi",
+  "layers": [
+    ["KC_ESC","KC_1","KC_2","KC_3","KC_4","KC_5","KC_6","KC_7","KC_8","KC_9","KC_0","KC_MINS","KC_EQL","KC_BSPC","KC_GRV",
+"KC_TAB","KC_Q","KC_W","KC_E","KC_R","KC_T","KC_Y","KC_U","KC_I","KC_O","KC_P","KC_LBRC","KC_RBRC","KC_BSLS","KC_DEL",
+"KC_CAPS","KC_A","KC_S","KC_D","KC_F","KC_G","KC_H","KC_J","KC_K","KC_L","KC_SCLN","KC_QUOT","KC_ENT","KC_PGUP",
+"KC_LSFT","KC_Z","KC_X","KC_C","KC_V","KC_B","KC_N","KC_M","KC_COMM","KC_DOT","KC_SLSH","KC_RSFT","KC_UP","KC_PGDN",
+"KC_LCTL","KC_LGUI","KC_LALT","KC_SPC","KC_RALT","MO(1)","KC_RCTL","KC_LEFT","KC_DOWN","KC_RGHT"],
+    ["KC_TRNS","KC_F1","KC_F2","KC_F3","KC_F4","KC_F5","KC_F6","KC_F7","KC_F8","KC_F9","KC_F10","KC_F11","KC_F12","KC_DEL","KC_INS",
+"KC_TRNS","KC_TRNS","KC_UP","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_HOME",
+"KC_TRNS","KC_LEFT","KC_DOWN","KC_RGHT","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_END",
+"KC_TRNS","KC_TRNS","KC_TRNS","BL_DEC","BL_TOGG","BL_INC","KC_TRNS","KC_VOLD","KC_VOLU","KC_MUTE","KC_TRNS","KC_BTN1","KC_MS_U","KC_BTN2",
+"KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_MS_L","KC_MS_D","KC_MS_RIGHT"]
+  ]
+}


### PR DESCRIPTION
Default layout same as https://github.com/qmk/qmk_firmware/tree/master/keyboards/tada68/keymaps/default

Though the mouse keycodes do not render properly on the editor.
And I'm getting some compile errors after changing the Keymap name due to "Keymap name collision!"