### PR TITLE
Added instructions for gh-pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This project is very much a work in progress. To begin contributing, please refe
 
 [Issues](https://github.com/qmk/qmk_configurator/issues)  
 [Development Environment Setup](https://github.com/qmk/qmk_configurator/blob/master/assets/js/development.md)  
-[Deploying an instance of the Configurator](https://github.com/qmk/qmk_configurator/blob/master/assets/js/gh-pages_setup.md)  
+[Deploying an instance of the Configurator to GitHub Pages](https://github.com/qmk/qmk_configurator/blob/master/assets/js/gh-pages_setup.md)  

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ The QMK Configurator allows simple keymap creation and saving via .json keymap f
 This project is very much a work in progress. To begin contributing, please refer to the following:
 
 [Issues](https://github.com/qmk/qmk_configurator/issues)  
-[Development Environment Setup](https://github.com/qmk/qmk_configurator/blob/master/assets/js/development.md)   
-
+[Development Environment Setup](https://github.com/qmk/qmk_configurator/blob/master/assets/js/development.md)  
+[Deploying an instance of the Configurator](https://github.com/qmk/qmk_configurator/blob/master/assets/js/gh-pages_setup.md)  

--- a/assets/js/gh-pages_setup.md
+++ b/assets/js/gh-pages_setup.md
@@ -1,0 +1,46 @@
+# How to set up a GitHub instance of the QMK Configurator
+
+This document will walk you through deploying an instance of the QMK Configurator via your own repository.
+
+## 1. Fork the qmk/qmk_configurator repository
+
+Go to [qmk/qmk_configurator](https://github.com/qmk/qmk_configurator), and click the `fork` button at top right.
+
+## 2. Create a gh-pages branch
+
+In your git CLI, enter:
+
+    git branch gh-pages
+
+This will create a copy of the `gh-pages` branch that is already on the QMK repo.
+
+## 3. Remove the CNAME directory
+
+Remove the `CNAME` directory, which is only for the production version of the Configurator.
+
+    rm CNAME
+
+## 4. Edit the _config.yml file
+
+In the root directory, open the `_config.yml` file in a text editor, and edit it as appropriate:
+
+    title: QMK Configurator
+    email: <github_email>     # the email attached to your GitHub account
+    show_downloads: true
+    description: QMK for potatoes - an open source configurator for QMK Firmware (only the AVR boards right now)
+    baseurl: "/qmk_configurator"     # DO NOT CHANGE THIS LINE!
+    # Replace <github_username> on the following three lines with your GitHub username
+    url: "http://<github_username>.qmk.fm"
+    github_username: <github_username>
+    repository: <github_username>/qmk_configurator
+    theme: jekyll-theme-minimal
+
+## 5. Deploy your instance
+
+When you're done editing, save the file, commit it to your branch, and push your changes to your GitHub repo.
+
+    git add .
+    git commit -m "initial setup"
+    git push
+
+Once you've pushed your changes, your instance should be live in about 30 seconds at `https://<github_username>.qmk.fm/qmk_configurator`.

--- a/assets/js/gh-pages_setup.md
+++ b/assets/js/gh-pages_setup.md
@@ -14,9 +14,9 @@ In your git CLI, enter:
 
 This will create a copy of the `gh-pages` branch that is already on the QMK repo.
 
-## 3. Remove the CNAME directory
+## 3. Remove the CNAME file
 
-Remove the `CNAME` directory, which is only for the production version of the Configurator.
+Remove the `CNAME` file, which is only for the production version of the Configurator.
 
     rm CNAME
 

--- a/assets/js/gh-pages_setup.md
+++ b/assets/js/gh-pages_setup.md
@@ -10,7 +10,7 @@ Go to [qmk/qmk_configurator](https://github.com/qmk/qmk_configurator), and click
 
 In your git CLI, enter:
 
-    git branch gh-pages
+    git checkout gh-pages
 
 This will create a copy of the `gh-pages` branch that is already on the QMK repo.
 
@@ -30,7 +30,7 @@ In the root directory, open the `_config.yml` file in a text editor, and edit it
     description: QMK for potatoes - an open source configurator for QMK Firmware (only the AVR boards right now)
     baseurl: "/qmk_configurator"     # DO NOT CHANGE THIS LINE!
     # Replace <github_username> on the following three lines with your GitHub username
-    url: "http://<github_username>.qmk.fm"
+    url: "http://<github_username>.github.io"
     github_username: <github_username>
     repository: <github_username>/qmk_configurator
     theme: jekyll-theme-minimal
@@ -43,4 +43,4 @@ When you're done editing, save the file, commit it to your branch, and push your
     git commit -m "initial setup"
     git push
 
-Once you've pushed your changes, your instance should be live in about 30 seconds at `https://<github_username>.qmk.fm/qmk_configurator`.
+Once you've pushed your changes, your instance should be live in about 30 seconds at `https://<github_username>.github.io/qmk_configurator`.


### PR DESCRIPTION
re: #90 

Adds a document detailing how to deploy an instance of the Configurator via GitHub Pages, with a link to it on the main readme.

@mechmerlin can maybe lay off @yanfali now. :laughing: 
