### PR TITLE
Initial Porting work to Vue 2

### DIFF
--- a/_layouts/qmk.html
+++ b/_layouts/qmk.html
@@ -18,17 +18,14 @@
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.5/lodash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/keypress/2.1.5/keypress.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.3/vue.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.js"></script>
     <script src="{{ '/assets/js/script.js?v=' | append: site.github.build_revision | relative_url }}"></script>
 
     <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
   </head>
   <body>
-    <div class="backend-status">
-      <div class="bes-title">Server Status:</div>
-      <div class="bes-status">Checking</div>
-      <div class="bes-version">API Version: <span class="version-num">0.1</div>
-      <div class="bes-jobs">...</div>
-    </div>
+    <div id="status-app"></div>
     <div class="wrapper">
       <header>
         <h1><a href="/"><img src="/qmk_icon_48.png" alt="QMK Logo" width="48" style="vertical-align: middle" /> {{ site.title | default: site.github.repository_name }}</a></h1>

--- a/_layouts/qmk.html
+++ b/_layouts/qmk.html
@@ -18,7 +18,9 @@
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.5/lodash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/keypress/2.1.5/keypress.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.3/vue.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.3/vue.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vuex/3.0.1/vuex.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/3.0.1/vue-router.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.js"></script>
     <script src="{{ '/assets/js/script.js?v=' | append: site.github.build_revision | relative_url }}"></script>
 

--- a/assets/.eslintrc.json
+++ b/assets/.eslintrc.json
@@ -9,6 +9,7 @@
     "$": true,
     "_": true,
     "Vue": true,
+    "Vuex": true,
     "axios": true
   },
   "rules": {

--- a/assets/.eslintrc.json
+++ b/assets/.eslintrc.json
@@ -7,7 +7,9 @@
   },
   "globals": {
     "$": true,
-    "_": true
+    "_": true,
+    "Vue": true,
+    "axios": true
   },
   "rules": {
     "block-scoped-var": 2,

--- a/assets/.eslintrc.json
+++ b/assets/.eslintrc.json
@@ -10,6 +10,7 @@
     "_": true,
     "Vue": true,
     "Vuex": true,
+    "VueRouter": true,
     "axios": true
   },
   "rules": {

--- a/assets/.eslintrc.json
+++ b/assets/.eslintrc.json
@@ -25,6 +25,7 @@
     "eqeqeq": [2, "allow-null"],
     "semi-style": ["error", "last"],
     "guard-for-in": 2,
+    "valid-jsdoc": 2,
     "new-cap": [2, { "capIsNewExceptions": ["Deferred"] }],
     "no-bitwise": 2,
     "no-caller": 2,

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -32,12 +32,12 @@ $(document).ready(() => {
   var $keyboard = $('#keyboard');
   var $layout = $('#layout');
   var $layer = $('.layer');
-  //  var $compile = $('#compile');
+
   var $fwFile = $('#fwFile');
   var $source = $('#source');
   var $export = $('#export');
   var $import = $('#import');
-  //  var $loadDefault = $('#load-default');
+
   var $fileImport = $('#fileImport');
   var $infoPreview = $('#infoPreview');
   var $status = $('#status');
@@ -62,8 +62,6 @@ $(document).ready(() => {
   $('#keycodes').click(assignKeycodeToSelectedKey);
 
   $layer.click(changeLayer);
-
-  //  $compile.click(compileLayout);
 
   $fwFile.click(downloadFirmwareFile);
 
@@ -99,7 +97,6 @@ $(document).ready(() => {
   var keypressListener = new window.keypress.Listener();
   keypressListener.register_many(generateKeypressCombos(keycodes));
   keypressListener.simple_combo('ctrl shift i', () => {
-    // add a special bogus entry to the keyboard list for previews
     if (!vueStore.getters['app/isPreview']) {
       vueStore.commit('app/enablePreview');
       disableCompileButton();

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -164,6 +164,11 @@ $(document).ready(() => {
     if (_.includes(keys, 'KEYMAP')) {
       return 'KEYMAP';
     }
+    // avoid keymaps ending with _kc unless we have no other choice
+    var nextBest = keys.filter((key) => !key.endsWith('_kc'));
+    if (nextBest.length > 0) {
+      return _.first(nextBest);
+    }
     return _.first(keys);
   }
 

--- a/index.html
+++ b/index.html
@@ -7,23 +7,8 @@ layout: qmk
     <option id="templateOption"></option>
 </select>
 <div id="controller">
-  <div id="controller-top">
-    <div class="topctrl">
-      <span class="topctrl-1">
-      <label style="display: inline-block; width: 75px;" >Keyboard:</label>
-      <select id="keyboard" onChange="setSelectWidth(this);"></select>
-      </span>
-      <span class="topctrl-2">
-        <label id="keymap-name-label">Keymap Name:</label>
-        <input id="keymap-name" type="text" value="mine" />
-      </span>
-      <span class="topctrl-3">
-      <button id="load-default" title="Load default keymap from QMK Firmware">Load Default</button>
-      <button id="compile" title="Compile keymap">Compile</button>
-      </span>
-    </div>
-    <label style="display: inline-block; width: 75px;">Layout:</label>
-    <select id="layout" onChange="setSelectWidth(this);"></select>
+  <div id="controller-app">
+    <router-view></router-view>
   </div>
   <textarea id="status" readonly></textarea>
   <div id="controller-bottom" class="botctrl">


### PR DESCRIPTION
This is the first part of a planned series of PRs to port Configurator over to Vue 2.

### Why are we doing this?

As the state of the application increases, relying on state management through global variables is only going to get more difficult. We also have other goals that while possible, are made more difficult because jQuery code can become brittle during refactoring due to their being no single responsibility pattern enforcement.

These include:

 - i18n support
 - integrating more pages into the application like converter

### Why Vue?

Of the choices out there, react, angular, and ember, vue is the least disruptive and easiest to integrate into existing code. Vue strikes a gentle balance between opinionated and flexible. This has advantages when on-boarding new developers, because there are existing docs and patterns which the framework has already decided.

Other advantages:

 - good documentation
 - community developed and maintained authoritative implementations of useful components like routing and state management
 - no build process is required to begin development

### About this port

It ports responsibility for core parts of the configurator app from jquery over to vue.

This includes:
 - routing (vue-router)
 - state management (vuex)
 - introduces 2 new components
    - the status bar component used to display API status
    - the top control section of the app which contains drop downs for keyboard and layout
 - integrates the existing jQuery components into the vuex state management for interop

Testing has been performed by @mechmerlin and @noroadsleft and they feel this is now ready for deployment to production.

TODO:
  - port jquery components to vue, including:
    - status panel
    - bottom controls
  - visual keymap
  - visual keycodes