### PR TITLE
Port Status Panel to Vue

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -678,7 +678,7 @@ button {
   font-size: 12px;
 }
 
-#status {
+#terminal {
   padding: 2px 5px;
   background: #272822;
   color: #f8f8f2;

--- a/assets/js/README.md
+++ b/assets/js/README.md
@@ -23,6 +23,19 @@ The current functions for the configurator are:
  1. Compiling those keymaps into firmware files. Currently, only .hex files are supported
  1. Downloading Hex Files or Source code generated
 
+Vue 2 Integration
+=================
+
+We're currently in the process of porting many of the UI elements into Vue 2. Currently this is a WIP in progress, but up until now this includes:
+
+ 1. application state (vuex)
+ 1. routing (vue-router)
+ 1. top control panel (vue component)
+ 1. backend status bar (vue component)
+ 1. vue status panel (vue component)
+
+This is a non-optimized implementation, that is allowing co-existence with existing jquery components with no build process. At some future date, once the port is complete we may introduce more build process. This document is therefore in a state of flux and is mostly true except for the noted exceptions in the above list.
+
 Code Style
 ==========
 
@@ -40,6 +53,7 @@ External Dependencies
  - jQuery UI components for drag and drop.
  - keypress.js for keyboard bindings
  - lodash.js for general collections and utility functions
+ - vue 2, vuex, vue-router, axios
 
 
 Startup

--- a/assets/js/development.md
+++ b/assets/js/development.md
@@ -15,7 +15,7 @@ The [QMK Configurator](https://config.qmk.fm/) leverages the Jekyll static site 
 
         cd qmk_configurator
 
- 1. If you have never run serve before you may have to install the ruby dependencies for this project.    
+ 1. If you have never run serve before you may have to install the ruby dependencies for this project.
     From the CLI, run `bundle install`. You'll get a warning if the next command doesn't work.
  1. From the CLI, run `bundle exec jekyll serve`
 
@@ -36,12 +36,9 @@ Configuration file: none
   Server running... press ctrl-c to stop.
  ```
 
-On OSX, it will open a browser pointing to localhost port 4000. If it does not, open up a browser and paste http://127.0.0.1:4000 into the search bar. 
+On OSX, it will open a browser pointing to localhost port 4000. If it does not, open up a browser and paste http://127.0.0.1:4000 into the search bar.
 
-You are now able to do development. 
+You are now able to do development.
 
 You will have to reload between changes as `jekyll` in it's default configuration doesn't support live reloading. If someone wants to contribute that please do.
 
-## Development using gh-pages
-
-TBD

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -326,6 +326,10 @@ $(document).ready(() => {
     };
   }
 
+  /**
+   * initStatusStore
+   * @return {object} a new instance of a status store
+   */
   function initStatusStore() {
     return {
       namespaced: true,

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -186,11 +186,11 @@ $(document).ready(() => {
   }
 
   /**
-   * newStore
-   * @return {object} initialized Vuex store instance
+   * initAppStore - creates a new store for the app namespace
+   * @return {object} initialized app store
    */
-  function newStore() {
-    var appStore = {
+  function initAppStore() {
+    return {
       namespaced: true,
       state: {
         keyboard: '',
@@ -327,10 +327,40 @@ $(document).ready(() => {
         }
       }
     };
+  }
 
+  function initStatusStore() {
+    return {
+      namespaced: true,
+      state: {
+        message: '',
+      },
+      getters: {},
+      actions: {
+        scrollToEnd() {
+          // signal scroll buffer to lastest message
+        }
+      },
+      mutations: {
+        clear(state) {
+          state.message = '';
+        },
+        append(state, message) {
+          state.message += message;
+        }
+      }
+    };
+  }
+
+  /**
+   * newStore
+   * @return {object} initialized Vuex store instance
+   */
+  function newStore() {
     return new Vuex.Store({
       modules: {
-        app: appStore
+        app: initAppStore(),
+        status: initStatusStore()
       },
       strict: true
     });

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@ layout: qmk
   <div id="controller-app">
     <router-view></router-view>
   </div>
-  <textarea id="status" readonly></textarea>
   <div id="controller-bottom" class="botctrl">
     <div class="botctrl-1-1">
       <button id="toolbox" title="Load firmware file in QMK Toolbox" disabled>Open in QMK Toolbox</button>


### PR DESCRIPTION
Part of 2 of a series.

Port the status panel to vue, now we have the base in place from the previous patch set.

 - moves responsibility for textarea to vue component statusPanelComponent
 - adds a status state machine to the vuex store
 - updates all previous callers of $status to use new store 'status'
 - removes old code