### PR TITLE
Issue 157 - Keymap Name Input Handling

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -197,7 +197,7 @@ $(document).ready(() => {
         keyboards: [],
         layout: '',
         layouts: {},
-        keymapName: 'mine',
+        keymapName: '',
         compileDisabled: false,
         isPreview: false
       },
@@ -212,8 +212,14 @@ $(document).ready(() => {
          * @return {string} parsed filtered keymap name
          */
         keymapName: state => {
-          let name = state.keymapName.replace(/\s/g, '_').toLowerCase();
-          return name === '' ? 'mine' : name;
+          return state.keymapName.replace(/\s/g, '_').toLowerCase();
+        },
+        exportKeymapName: state => {
+          let exportName = state.keymapName.replace(/\s/g, '_').toLowerCase();
+          if (exportName === '') {
+            exportName = `${state.keyboard}_${state.layout}_mine`.toLowerCase();
+          }
+          return exportName;
         },
         compileDisabled: state => state.compileDisabled,
         isPreview: state => state.isPreview
@@ -278,7 +284,7 @@ $(document).ready(() => {
         disablePreview(state) {
           state.isPreview = false;
           state.keyboards = state.keyboards.filter(k => k !== PREVIEW_LABEL);
-          state.keymapName = 'mine';
+          state.keymapName = '';
         },
         setKeyboard(state, _keyboard) {
           state.keyboard = _keyboard;
@@ -357,7 +363,7 @@ $(document).ready(() => {
       </span>
       <span class="topctrl-2">
         <label id="keymap-name-label">Keymap Name:</label>
-        <input id="keymap-name" type="text" v-model="keymapName" placeholder="keymap name"/>
+        <input id="keymap-name" type="text" v-model="keymapName" placeholder="custom keymap name"/>
       </span>
       <span class="topctrl-3">
       <button id="load-default"
@@ -554,7 +560,7 @@ $(document).ready(() => {
       },
       data: () => {
         return {
-          keymapName: 'mine',
+          keymapName: '',
           width: 0
         };
       },
@@ -831,13 +837,13 @@ $(document).ready(() => {
     //API payload format
     var data = {
       keyboard: vueStore.getters['app/keyboard'],
-      keymap: vueStore.getters['app/keymapName'],
+      keymap: vueStore.getters['app/exportKeymapName'],
       layout: vueStore.getters['app/layout'],
       layers: layers
     };
 
     download(
-      `${vueStore.getters['app/keymapName']}.json`,
+      `${vueStore.getters['app/exportKeymapName']}.json`,
       JSON.stringify(data)
     );
   }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -555,7 +555,14 @@ $(document).ready(() => {
           store.commit('app/setKeymapName', newKeymapName);
         },
         compile() {
-          compileLayout(this.keyboard, this.realKeymapName, this.layout);
+          let keymapName = this.realKeymapName;
+          let _keymapName = store.getters['app/exportKeymapName'];
+          // TODO extract this name function to the store
+          keymapName =
+            keymapName === ''
+              ? _keymapName.slice(this.keyboard.length + 1, _keymapName.length)
+              : keymapName;
+          compileLayout(this.keyboard, keymapName, this.layout);
         }
       },
       data: () => {


### PR DESCRIPTION
With the new reactive data model, the keymap name handling was a little too strict. Relax it to allow empty keymap names and substitute in a appropriate keymap name only if it is blank.

 - add a exportKeymapName getter to 'app' store
 - special handling for the compile keymap handler which does it's own keymap name handling
 - default keymap name to empty string
 - when no keymap name is supplied use ${keyboard}_${layout}_mine as the default keymap name for 
   exports and downloaded firmware names

@mechmerlin please give us your Good Quality Wizarding seal of approval.