### PR TITLE
Change keymap name to avoid conflicting with default

### DIFF
--- a/keymaps/tada68_default.json
+++ b/keymaps/tada68_default.json
@@ -1,6 +1,6 @@
 {
   "keyboard": "tada68",
-  "keymap": "default",
+  "keymap": "default_ansi",
   "layout": "LAYOUT_ansi",
   "layers": [
     ["KC_ESC","KC_1","KC_2","KC_3","KC_4","KC_5","KC_6","KC_7","KC_8","KC_9","KC_0","KC_MINS","KC_EQL","KC_BSPC","KC_GRV",


### PR DESCRIPTION
Quick fix. Contributed keymaps can't have the same names as one already in the repo like default. 1 liner fix.