### PR TITLE
geckodriver support for selenium_setup script

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -2293,7 +2293,8 @@ $(document).ready(() => {
       'China is the world’s largest potato producer.',
       'Potatoes were the first vegetable grown in space.',
       'Potatoes are totally gluten-free.',
-      'One of the most basic Incan measurements of time was the time it took to cook a potato.'
+      'One of the most basic Incan measurements of time was the time it took to cook a potato.',
+      'If a potato is exposed to light while growing, it will turn green and become poisonous.'
     ];
     $('.random-potato').html(
       potatoFact[Math.floor(Math.random(Date.now()) * potatoFact.length)]

--- a/functional_tests/README.md
+++ b/functional_tests/README.md
@@ -19,16 +19,17 @@ Ideally these should be downloaded by a script when executed on a CI environment
 ## Setup
 
 1. Run the `selenium_setup.sh` script to install the following to `qmk_configurator/functional_tests/bin`  
-            Selenium Standalone Server 
-            Chrome Web Driver version 
+            Selenium Standalone Server  
+            Chrome Web Driver   
+            Geckodriver  
 
 ```
 foo@bar:~/qmk_configurator/functional_tests$ ./selenium_setup.sh
 ```
-At the time of this writing, `chromedriver` is at `2.40` and Selenium Standalone Server is at `3.13.0'
+At the time of this writing, `chromedriver` is at `2.40`, `geckodriver` is at `0.21.0` and Selenium Standalone Server is at `3.13.0`
 
 2. Download and install the Java SDK. 
-3. Run 'npm install'  from the the main qmk_configurator directory
+3. Run `npm install`  from the the main qmk_configurator directory
 ```console
 foo@bar:~/qmk_configurator$ npm install
 ```

--- a/functional_tests/selenium_setup.sh
+++ b/functional_tests/selenium_setup.sh
@@ -52,6 +52,27 @@ sudo chmod 0755 "$DEST_PATH"
 
 printf "Installed Chrome Web Driver for %s to %s.\\n" "${DRIVER}" "${DEST_PATH}"
 
+# Download geckodriver to temporary location
+TEMP_PATH=${PWD}"/tmp/geckodriver"
+mkdir "$TEMP_PATH" && pushd "$TEMP_PATH"
+wget $GKO_DRIVER -P "$TEMP_PATH"
+printf "geckodriver downloaded to %s.\\n" "${TEMP_PATH}"
+
+# gunzip/tar geckodriver to qmk_configurator/functional_tests/bin directory
+DEST_PATH=${PWD}"/bin"
+if [ "${OS}" == "Darwin" ]; then
+    DRIVER="macos"
+fi
+
+gunzip "${TEMP_PATH}"/geckodriver-v$GKO_DRIVER_VER-$DRIVER.tar.gz
+tar xvf "${TEMP_PATH}"/geckodriver-v$GKO_DRIVER_VER-$DRIVER.tar
+
+sudo mv -f ./geckodriver "$DEST_PATH"
+sudo chown root:root "$DEST_PATH"
+sudo chmod 0755 "$DEST_PATH"
+
+printf "Installed geckodriver for %s to %s.\\n" "${DRIVER}" "${DEST_PATH}"
+
 #Download and install Standalone Selenium Server
 SELENIUM_JAR_FILE=selenium-server-standalone-$SELENIUM_VERSION.jar
 wget http://selenium-release.storage.googleapis.com/$(echo "$SELENIUM_VERSION" | cut -d'.' -f-2)/$SELENIUM_JAR_FILE -P "$TEMP_PATH"

--- a/functional_tests/selenium_setup.sh
+++ b/functional_tests/selenium_setup.sh
@@ -14,6 +14,7 @@ OS="$(uname -s)"
 # Set Versions
 SELENIUM_VERSION="3.13.0"
 CHR_DRIVER_VER="2.40"
+GKO_DRIVER_VER="0.21.0"
 
 # Get Paths
 PWD="$(pwd)" # should be qmk_configurator/functional_tests
@@ -21,14 +22,17 @@ PWD="$(pwd)" # should be qmk_configurator/functional_tests
 # Determine which Chrome Web Driver to download based on system
 if [ "${OS}" == "Darwin" ]; then
     CHR_DRIVER="https://chromedriver.storage.googleapis.com/${CHR_DRIVER_VER}/chromedriver_mac64.zip"
+    GKO_DRIVER="https://github.com/mozilla/geckodriver/releases/download/v${GKO_DRIVER_VER}/geckodriver-v${GKO_DRIVER_VER}-macos.tar.gz"
     DRIVER="mac64"
 else
     VERSION="$(uname -m)"
     if [ "${VERSION}" == "x86_64:" ]; then
 	    CHR_DRIVER="https://chromedriver.storage.googleapis.com/${CHR_DRIVER_VER}/chromedriver_linux32.zip"
+        GKO_DRIVER="https://github.com/mozilla/geckodriver/releases/download/v${GKO_DRIVER_VER}/geckodriver-v${GKO_DRIVER_VER}-linux32.tar.gz"
         DRIVER="linux32"
     else
 	    CHR_DRIVER="https://chromedriver.storage.googleapis.com/${CHR_DRIVER_VER}/chromedriver_linux64.zip"
+        GKO_DRIVER="https://github.com/mozilla/geckodriver/releases/download/v${GKO_DRIVER_VER}/geckodriver-v${GKO_DRIVER_VER}-linux64.tar.gz"
         DRIVER="linux64"
     fi
 fi


### PR DESCRIPTION
- download the current "latest" geckodriver (0.21.0)
- gunzip and tar it to the appropriate locations
- update readme for formatting and new info
- add a random potato fact