### PR TITLE
Fix naming to avoid errors on API

### DIFF
--- a/keymaps/fourier_rev1_default.json
+++ b/keymaps/fourier_rev1_default.json
@@ -1,6 +1,6 @@
 {
     "keyboard":"fourier",
-    "keymap":"default",
+    "keymap":"ckeys_workshop",
     "layout":"LAYOUT",
     "layers":[
         ["KC_ESC","KC_Q","KC_W","KC_E","KC_R","KC_T","KC_Y","KC_U","KC_I","KC_O","KC_P","KC_BSPC","KC_DEL","KC_TAB","KC_A","KC_S","KC_D","KC_F","KC_G","KC_H","KC_J","KC_J","KC_K","KC_SCLN","KC_ENT","KC_LSFT","KC_Z","KC_X","KC_C","KC_V","KC_B","KC_N","KC_M","KC_COMM","KC_DOT","KC_UP","KC_SLSH","KC_LCTL","KC_LALT","KC_LGUI","KC_NO","MO(1)","KC_SPC","KC_CAPS","KC_LEFT","KC_DOWN","KC_RGHT"],


### PR DESCRIPTION
Default causes it to conflict with the default keymap. Fix this before workshop.