### PR TITLE
Added bigseries and clueboard/66 to keyboard exclusion list

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -2365,8 +2365,10 @@ $(document).ready(() => {
   function getExclusionList() {
     return [
       'atom47',
+      'bigseries',
       'chibios_test',
       'christmas_tree',
+      'clueboard/66',
       'crkbd',
       'deltasplit75',
       'duck/eagle_viper',


### PR DESCRIPTION
Noticed a couple "keyboards" that seem to have been missed in the review stage for #198.

`bigseries` was a parent directory for the Big Series line of PCBs by Woodkeys, and `clueboard/66` was a parent directory for revs. 1-3 of the Clueboard 66%.

@yanfali @mechmerlin 