### PR TITLE
Remove clueboard/66 from keyboard exclusion list

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -2368,7 +2368,6 @@ $(document).ready(() => {
       'bigseries',
       'chibios_test',
       'christmas_tree',
-      'clueboard/66',
       'converter/usb_usb',
       'crkbd',
       'deltasplit75',


### PR DESCRIPTION
@skullydazed wants this handled via qmk_firmware. Reverting this change.
