### PR TITLE
Updated Keyboard Exclusion List: 2018-12-12 patch 1

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -2460,7 +2460,7 @@ $(document).ready(() => {
       'chibios_test',
       'christmas_tree',
       'converter/palm_usb',
-      'converter/sun_usb ',
+      'converter/sun_usb',
       'converter/usb_usb',
       'crkbd',
       'deltasplit75',


### PR DESCRIPTION
Mistyped the exclusion rule for converter/sun_usb.