### PR TITLE
Remove ALTG keycode from Configurator

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -2221,12 +2221,6 @@ $(document).ready(() => {
         title: 'LCTL + LALT + LGUI'
       },
       {
-        name: 'ALTG',
-        code: 'ALTG(kc)',
-        type: 'container',
-        title: 'RCTL + RALT'
-      },
-      {
         name: 'SGUI',
         code: 'SCMD(kc)',
         type: 'container',


### PR DESCRIPTION
ALTG was removed from QMK Firmware in qmk/qmk_firmware#4338.

Reported by @vomindoraan