### PR TITLE
Add a beta-banner to config.qmk.fm

### DIFF
--- a/_layouts/qmk.html
+++ b/_layouts/qmk.html
@@ -28,6 +28,7 @@
   </head>
   <body>
     <div id="status-app"></div>
+    <div id="beta-banner"></div>
     <div class="wrapper">
       <header>
         <h1><a href="/"><img src="/qmk_icon_48.png" alt="QMK Logo" width="48" style="vertical-align: middle" /> {{ site.title | default: site.github.repository_name }}</a></h1>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1178,7 +1178,7 @@ input[type='number'] {
   overflow-y: hidden;
   transition-property: all;
   transition-duration: 1s;
-  transition-timing-function: cubic-bezier(0, 1, 0.5. 1);
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
 }
 
 .slideDown-enter, .slideDown-leave-to {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1160,3 +1160,27 @@ input[type='number'] {
 .topctrl-3 {
   grid-column: 3;
 }
+
+.beta {
+  position: absolute;
+  top: 10px;
+  background: #add8e6;
+  width: 100%;
+  color: purple;
+  left: 0;
+  height: 36px;
+  line-height: 100%;
+  text-align: center;
+}
+
+.slideDown-enter-active, .slideDown-leave-active {
+  max-height: 38px;
+  overflow-y: hidden;
+  transition-property: all;
+  transition-duration: 1s;
+  transition-timing-function: cubic-bezier(0, 1, 0.5. 1);
+}
+
+.slideDown-enter, .slideDown-leave-to {
+  max-height: 0;
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -69,6 +69,7 @@ $(document).ready(() => {
   );
 
   var vueStatus = checkStatus();
+  var beta = initBetaBanner();
 
   Vue.use(VueRouter);
   Vue.use(Vuex);
@@ -90,7 +91,8 @@ $(document).ready(() => {
   ignoreKeypressListener($('input[type=text]'));
   return {
     vueStatus,
-    vueInstance
+    vueInstance,
+    beta
   };
 
   ////////////////////////////////////////
@@ -1081,6 +1083,43 @@ $(document).ready(() => {
       mounted() {
         this.fetchKeyboards();
       }
+    });
+  }
+
+  function initBetaBanner() {
+    var betaBanner = Vue.component('beta-banner', {
+      template: `
+      <transition name="slideDown">
+      <div @click="hideMe" v-show="show" class="beta">
+        <p>Try out our new <a class="beta-link" href="https://yanfali.github.io/qmk_configurator" target="blank">beta Configurator</a> and let us know what you think.</p>
+        </div>
+        </transition>
+      `,
+      data: () => {
+        return {
+          show: false,
+          timer: undefined
+        };
+      },
+      methods: {
+        hideMe() {
+          this.show = false;
+        }
+      },
+      mounted() {
+        var instance = this;
+        this.timer = setTimeout(() => {
+          instance.show = true;
+          setTimeout(() => {
+            instance.show = false;
+          }, 57000);
+        }, 3000);
+      }
+    });
+    return new Vue({
+      el: '#beta-banner',
+      template: '<betaBanner />',
+      components: { betaBanner }
     });
   }
 


### PR DESCRIPTION
Promote the beta, so we can get more testing. Banner appears after 3 seconds and disappears after a total of 60 seconds. Can also be dismissed by a click.


![banner](https://user-images.githubusercontent.com/2275667/51812585-03120800-2267-11e9-926a-953c642b4816.gif)
