### PR TITLE
add MacOS JP key and rename JP Kana key

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -2068,7 +2068,7 @@ $(document).ready(() => {
 
       { name: '無変換', code: 'KC_MHEN', title: 'JIS Muhenkan', width: 1250 },
       { name: '変換', code: 'KC_HENK', title: 'JIS Henkan', width: 1250 },
-      { name: 'カタカナ ひらがな', code: 'KC_KANA', title: 'JIS Katakana/Hiragana', width: 1500  },
+      { name: 'カタカナ\nひらがな', code: 'KC_KANA', title: 'JIS Katakana/Hiragana', width: 1500  },
       { name: 'かな', code: 'KC_LANG1', title: 'JP Mac Kana', width: 1250 },
       { name: '英数', code: 'KC_LANG2', title: 'JP Mac Eisu', width: 1250 },
       { width: 250 },


### PR DESCRIPTION
There is no alternate key, so I add MacOS JP keys, Kana and Eisu.

And I change JIS Kana name to  "カタカナ\nひらがな(Katakana Hiragana)" from "かな(Kana)" because many keyboard has it as Katakana Hiragana. 

Reason of inserting "\n" is Japanese characters is not be line break by space.