### PR TITLE
Correct m0lly defaultish

### DIFF
--- a/keymaps/m0lly_default.json
+++ b/keymaps/m0lly_default.json
@@ -1,8 +1,8 @@
 {
    "keyboard":"m0lly",
    "keymap":"defaultish",
-   "layout":"LAYOUT",
+   "layout":"LAYOUT_all",
    "layers":[
-	  ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL", "KC_BSPC", "KC_NO", "KC_NLCK", "KC_PSLS", "KC_PAST", "KC_PMNS", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_P7", "KC_P8", "KC_P9", "KC_NO", "KC_CAPS", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_NO", "KC_ENT", "KC_P4", "KC_P5", "KC_P6", "KC_PPLS", "KC_LSFT", "KC_NO", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_RSFT", "KC_NO", "KC_P1", "KC_P2", "KC_P3", "KC_NO", "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_SPC", "KC_RALT", "KC_RWIN", "KC_APP", "KC_RCTL", "KC_P0", "KC_NO", "KC_PDOT", "KC_PENT"]
+	  ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL", "KC_BSPC", "KC_NO", "KC_NLCK", "KC_PSLS", "KC_PAST", "KC_PMNS", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_P7", "KC_P8", "KC_P9", "KC_NO", "KC_CAPS", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_NO", "KC_ENT", "KC_P4", "KC_P5", "KC_P6", "KC_PPLS", "KC_LSFT", "KC_NO", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_RSFT", "KC_NO", "KC_P1", "KC_P2", "KC_P3", "KC_NO", "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_SPC", "KC_RALT", "KC_RGUI", "KC_APP", "KC_RCTL", "KC_P0", "KC_NO", "KC_PDOT", "KC_PENT"]
    ]
 }


### PR DESCRIPTION
Upon merging code into QMK, LAYOUT macro had to be renamed to LAYOUT_all
to comply with conventions. Also corrected RWIN to RGUI.