### PR TITLE
Fix Preonic default JSON files

### DIFF
--- a/public/keymaps/preonic_rev1_default.json
+++ b/public/keymaps/preonic_rev1_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard":"preonic/rev1",
   "keymap":"defaultish",
-  "layout":"LAYOUT_ortho_5x12",
+  "layout":"LAYOUT_preonic_grid",
   "layers":[
     ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
     ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_F", "KC_P", "KC_G", "KC_J", "KC_L", "KC_U", "KC_Y", "KC_SCLN", "KC_DEL", "KC_ESC", "KC_A", "KC_R", "KC_S", "KC_T", "KC_D", "KC_H", "KC_N", "KC_E", "KC_I", "KC_O", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_K", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],

--- a/public/keymaps/preonic_rev1_default.json
+++ b/public/keymaps/preonic_rev1_default.json
@@ -1,6 +1,7 @@
 {
   "keyboard":"preonic/rev1",
-  "keymap":"defaultish",
+  "keymap":"defaultish_80e7337",
+  "commit":"80e733798a808ba1cf0d5371360c152fbb933717",
   "layout":"LAYOUT_preonic_grid",
   "layers":[
     ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],

--- a/public/keymaps/preonic_rev2_default.json
+++ b/public/keymaps/preonic_rev2_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard":"preonic/rev2",
   "keymap":"defaultish",
-  "layout":"LAYOUT_ortho_5x12",
+  "layout":"LAYOUT_preonic_grid",
   "layers":[
     ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
     ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_F", "KC_P", "KC_G", "KC_J", "KC_L", "KC_U", "KC_Y", "KC_SCLN", "KC_DEL", "KC_ESC", "KC_A", "KC_R", "KC_S", "KC_T", "KC_D", "KC_H", "KC_N", "KC_E", "KC_I", "KC_O", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_K", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],

--- a/public/keymaps/preonic_rev2_default.json
+++ b/public/keymaps/preonic_rev2_default.json
@@ -1,6 +1,7 @@
 {
   "keyboard":"preonic/rev2",
-  "keymap":"defaultish",
+  "keymap":"defaultish_80e7337",
+  "commit":"80e733798a808ba1cf0d5371360c152fbb933717",
   "layout":"LAYOUT_preonic_grid",
   "layers":[
     ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],

--- a/public/keymaps/preonic_rev3_default.json
+++ b/public/keymaps/preonic_rev3_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard":"preonic/rev3",
   "keymap":"defaultish",
-  "layout":"LAYOUT_ortho_5x12",
+  "layout":"LAYOUT_preonic_grid",
   "layers":[
     ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
     ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_F", "KC_P", "KC_G", "KC_J", "KC_L", "KC_U", "KC_Y", "KC_SCLN", "KC_DEL", "KC_ESC", "KC_A", "KC_R", "KC_S", "KC_T", "KC_D", "KC_H", "KC_N", "KC_E", "KC_I", "KC_O", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_K", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],

--- a/public/keymaps/preonic_rev3_default.json
+++ b/public/keymaps/preonic_rev3_default.json
@@ -1,6 +1,7 @@
 {
   "keyboard":"preonic/rev3",
-  "keymap":"defaultish",
+  "keymap":"defaultish_80e7337",
+  "commit":"80e733798a808ba1cf0d5371360c152fbb933717",
   "layout":"LAYOUT_preonic_grid",
   "layers":[
     ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],


### PR DESCRIPTION
## Commit Log

### Redirect Preonic default keymaps to use LAYOUT_preonic_grid (f9bc8b7)

API doesn't see the LAYOUT_ortho_5x12 alias anymore.

### Add commit keys for version tracking. (be3fe3f)

Keymap JSONs for Preonic are current to:

&nbsp; &nbsp; https://github.com/qmk/qmk_firmware/blob/80e733798a808ba1cf0d5371360c152fbb933717/keyboards/preonic/keymaps/default/keymap.c

This is the most-recent revision as of 2019-02-11 13:49 -0800.
