### PR TITLE
Add default keymaps for remaining Bathroom Epiphanies keyboards

### DIFF
--- a/public/keymaps/bpiphany_frosty_flake_default.json
+++ b/public/keymaps/bpiphany_frosty_flake_default.json
@@ -1,0 +1,16 @@
+{
+  "keyboard": "bpiphany/frosty_flake",
+  "keymap": "default_4446f86",
+  "commit": "4446f86bfd273512d473d33c46d99690db5fbc51",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_PSCR", "KC_SLCK", "KC_PAUS",
+      "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL", "KC_BSPC", "KC_INS", "KC_HOME", "KC_PGUP", "KC_NLCK", "KC_PSLS", "KC_PAST", "KC_PMNS",
+      "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_DEL", "KC_END", "KC_PGDN", "KC_P7", "KC_P8", "KC_P9", "KC_PPLS",
+      "KC_CAPS", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_ENT", "KC_P4", "KC_P5", "KC_P6",
+      "KC_LSFT", "KC_NUBS", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_RSFT", "KC_UP", "KC_P1", "KC_P2", "KC_P3", "KC_PENT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_SPC", "KC_RALT", "KC_RGUI", "KC_APP", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_P0", "KC_PDOT"
+    ]
+  ]
+}

--- a/public/keymaps/bpiphany_kitten_paw_default.json
+++ b/public/keymaps/bpiphany_kitten_paw_default.json
@@ -1,0 +1,16 @@
+{
+  "keyboard": "bpiphany/kitten_paw",
+  "keymap": "default_67adc29",
+  "commit": "67adc29aa35719eea2de43bacf9cd5e8b5dfd79e",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_PSCR", "KC_SLCK", "KC_PAUS",
+      "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL", "KC_BSPC", "KC_INS", "KC_HOME", "KC_PGUP", "KC_NLCK", "KC_PSLS", "KC_PAST", "KC_PMNS",
+      "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_DEL", "KC_END", "KC_PGDN", "KC_P7", "KC_P8", "KC_P9", "KC_PPLS",
+      "KC_CAPS", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_ENT", "KC_P4", "KC_P5", "KC_P6",
+      "KC_LSFT", "KC_NUBS", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_RSFT", "KC_UP", "KC_P1", "KC_P2", "KC_P3", "KC_PENT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_SPC", "KC_RALT", "KC_RGUI", "KC_APP", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_P0", "KC_PDOT"
+    ]
+  ]
+}

--- a/public/keymaps/bpiphany_pegasushoof_default.json
+++ b/public/keymaps/bpiphany_pegasushoof_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "bpiphany/pegasushoof",
+  "keymap": "default_039434c",
+  "commit": "039434caf96c77a8584f03ab2b27ed255e7adae5",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+	    "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",  "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7", "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_PSCR", "KC_SLCK", "KC_PAUS",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",   "KC_4",    "KC_5",    "KC_6",    "KC_7",  "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_INS",  "KC_HOME", "KC_PGUP",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",   "KC_R",    "KC_T",    "KC_Y",    "KC_U",  "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_DEL",  "KC_END",  "KC_PGDN",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",   "KC_F",    "KC_G",    "KC_H",    "KC_J",  "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",   "KC_C",    "KC_V",    "KC_B",    "KC_N",  "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_SPC", "KC_RALT", "KC_RGUI", "KC_MENU", "MO(1)", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_WAKE", "KC_PWR", "KC_SLEP",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_VOLU",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_VOLD",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MPLY",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",   "KC_TRNS", "KC_MPRV", "KC_MSTP", "KC_MNXT"
+    ]
+  ]
+}

--- a/public/keymaps/bpiphany_sixshooter_default.json
+++ b/public/keymaps/bpiphany_sixshooter_default.json
@@ -1,0 +1,16 @@
+{
+  "keyboard": "bpiphany/sixshooter",
+  "keymap": "defaultish_ffb75b7",
+  "commit": "ffb75b720fd0d4d28ed0ae99b66313c06df47183",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "MO(1)", "KC_VOLD", "KC_VOLU",
+      "KC_MPRV", "KC_MPLY", "KC_MNXT"
+    ],
+    [
+      "KC_TRNS", "KC_NO", "KC_NO",
+      "KC_NO",   "KC_NO",  "KC_NO"
+    ]
+  ]
+}

--- a/public/keymaps/bpiphany_tiger_lily_default.json
+++ b/public/keymaps/bpiphany_tiger_lily_default.json
@@ -1,0 +1,16 @@
+{
+  "keyboard": "bpiphany/tiger_lily",
+  "keymap": "default_5b4bcfa",
+  "commit": "5b4bcfa7f2530ad12ef801101933aba6ac46acb2",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_PSCR", "KC_SLCK", "KC_PAUS",
+      "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL", "KC_BSPC", "KC_INS", "KC_HOME", "KC_PGUP", "KC_NLCK", "KC_PSLS", "KC_PAST", "KC_PMNS",
+      "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_DEL", "KC_END", "KC_PGDN", "KC_P7", "KC_P8", "KC_P9", "KC_PPLS",
+      "KC_CAPS", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_ENT", "KC_P4", "KC_P5", "KC_P6",
+      "KC_LSFT", "KC_NUBS", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_RSFT", "KC_UP", "KC_P1", "KC_P2", "KC_P3", "KC_PENT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_SPC", "KC_RALT", "KC_RGUI", "KC_APP", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_P0", "KC_PDOT"
+    ]
+  ]
+}


### PR DESCRIPTION
## Description / Notes

All based on the current default keymaps in qmk/qmk_firmware.

Six Shooter uses custom keycodes in qmk_firmware to manage its LEDs, so those keys have been changed to `KC_NO`.
