### PR TITLE
Issue #274 Fix loading readme on importing keymap

### DIFF
--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -250,8 +250,10 @@ export default {
               stats.count
             } keycodes. Defined ${stats.any} Any key keycodes\n`;
             store.commit('status/deferredMessage', msg);
-            store.commit('app/setKeymapName', data.keymap);
-            store.commit('keymap/setDirty');
+            store.dispatch('status/viewReadme', this.keyboard).then(() => {
+              store.commit('app/setKeymapName', data.keymap);
+              store.commit('keymap/setDirty');
+            });
           });
           disableOtherButtons();
         });

--- a/src/components/VisualKeymap.vue
+++ b/src/components/VisualKeymap.vue
@@ -65,8 +65,9 @@ export default {
         return [];
       }
       if (this.loadingKeymapPromise) {
-        this.loadingKeymapPromise();
+        const _promise = this.loadingKeymapPromise;
         this.setLoadingKeymapPromise(undefined);
+        _promise();
       }
       // Calculate Max with given layout
       // eslint-disable-next-line no-console

--- a/src/store/modules/status.js
+++ b/src/store/modules/status.js
@@ -22,6 +22,7 @@ const actions = {
       .get(backend_readme_url_template({ keyboard: _keyboard }))
       .then(result => {
         if (result.status === 200) {
+          commit('clear');
           commit('append', escape(result.data));
           commit('append', escape(state.deferredMessage));
           commit('deferredMessage', '');


### PR DESCRIPTION
Regression. Pre-vue upgrade the README would reload when importing a
keymap.json. This did not work anymore. Reported by @noroadsleft

 - change status/viewReadme to always clear status window
 - wait for viewReadme action to finish before setting keymapname and
 dirty flag
 - clean up loadingKeymapPromise slightly and cache it, remove it then
 execute the promise.

@noroadsleft @mechmerlin can you verify this is fixed please? Thanks