### PR TITLE
Tweak the CSS grid for ControllerTop.vue

### DIFF
--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -320,7 +320,7 @@ export default {
 <style>
 .topctrl {
   display: grid;
-  grid-template: auto / 400px 360px auto;
+  grid-template: auto / 440px 400px auto;
   grid-row-gap: 0px;
 }
 #controller-top {

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -320,7 +320,7 @@ export default {
 <style>
 .topctrl {
   display: grid;
-  grid-template: auto / 440px 400px auto;
+  grid-template: auto / 400px 360px auto;
   grid-row-gap: 0px;
 }
 #controller-top {

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -364,4 +364,7 @@ export default {
   padding-right: 5px;
   min-width: 90px;
 }
+#keyboard {
+  max-width: 18rem;
+}
 </style>


### PR DESCRIPTION
`cannonkeys/satisfaction75/prototype` was added to QMK Firmware, and now the Configurator's UI rendering in Firefox is wonky because the Keyboard select element is so wide.

Added 40px of width to the left and middle columns of the grid.

![ui_tweak_before](https://user-images.githubusercontent.com/18669334/54183745-203f1680-4462-11e9-8401-17b4c32c31d3.png)
![ui_tweak_after](https://user-images.githubusercontent.com/18669334/54183749-2208da00-4462-11e9-9e1f-71e1f64a8b12.png)
