### PR TITLE
Updated Keyboard Exclusion List: 2019-03-14

### DIFF
--- a/src/jquery.js
+++ b/src/jquery.js
@@ -215,6 +215,7 @@ function getExclusionList() {
     '40percentclub/i75',
     'atom47',
     'bigseries',
+    'cannonkeys/satisfaction75',
     'chibios_test',
     'christmas_tree',
     'converter/palm_usb',


### PR DESCRIPTION
New entry:

- cannonkeys/satisfaction75 (defaults to cannonkeys/satisfaction75/rev1)