### PR TITLE
Color Contrast Updates for Nested Keycodes

### DIFF
--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -238,15 +238,19 @@
 .gmk-merlin-key {
   background: $color-gmk-abs-CP;
   color: $color-gmk-abs-TU1;
-  input {
-    background: lighten($color-gmk-abs-CP, 40%);
+  input, .key-contents {
+    background: lighten($color-gmk-abs-CP, 10%);
+    color: darken($color-gmk-abs-TU1, 5%);
+    border-color: mix($color-gmk-abs-CP, darken($color-gmk-abs-TU1, 5%));
   }
 }
 .gmk-merlin-mod {
   background: $color-gmk-abs-TU1;
   color: $color-gmk-abs-N6;
-  input {
-    background: lighten($color-gmk-abs-TU1, 40%);
+  input, .key-contents {
+    background: darken($color-gmk-abs-TU1, 10%);
+    color: $color-gmk-abs-N6;
+    border-color: mix($color-gmk-abs-TU1, $color-gmk-abs-N6);
   }
 }
 .gmk-merlin-accent {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -87,16 +87,19 @@
 .sa-jukebox-key {
   background: $color-sp-abs-TM;
   color: $color-sp-abs-RN;
-  input {
-    background: lighten($color-sp-abs-TM, 40%);
-    color: $color-sp-abs-RN;
+  input, .key-contents {
+    background: lighten($color-sp-abs-TM, 10%);
+    color: darken($color-sp-abs-RN, 10%);
+    border-color: mix($color-sp-abs-TM, darken($color-sp-abs-RN, 10%));
   }
 }
 .sa-jukebox-mod {
   background: $color-sp-abs-VCO;
   color: $color-sp-abs-RN;
-  input {
-    background: lighten($color-sp-abs-VCO, 40%);
+  input, .key-contents {
+    background: lighten($color-sp-abs-VCO, 12%);
+    color: darken($color-sp-abs-RN, 10%);
+    border-color: mix($color-sp-abs-VCO, darken($color-sp-abs-RN, 10%));
   }
 }
 .sa-jukebox-accent {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -182,16 +182,20 @@
 .dsa-galaxy-class-key {
   background: $color-sp-pbt-BFE;
   color: $color-sp-pbt-BLACK;
-  input {
-    background: lighten($color-sp-pbt-BFE, 40%);
+  input, .key-contents {
+    background: lighten($color-sp-pbt-BFE, 10%);
+    color: $color-sp-pbt-BLACK;
+    border-color: mix($color-sp-pbt-BFE, $color-sp-pbt-BLACK);
   }
 }
 .dsa-galaxy-class-mod {
   // yellow
   background: $color-pantone-141C;
   color: $color-sp-pbt-BLACK;
-  input {
-    background: lighten($color-pantone-141C, 40%);
+  input, .key-contents {
+    background: lighten($color-pantone-141C, 10%);
+    color: $color-sp-pbt-BLACK;
+    border-color: mix(lighten($color-pantone-141C, 10%), $color-sp-pbt-BLACK);
   }
 }
 .dsa-galaxy-class-purple {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -484,13 +484,10 @@
 .gmk-space-cadet-key {
   background: $color-sp-abs-GD;
   color: $color-gmk-abs-CP;
-  input {
-    background: lighten($color-sp-abs-GD, 40%);
-    color: darken($color-gmk-abs-CP, 60%);
-  }
-  .key-contents {
-    background: lighten($color-sp-abs-GD, 40%);
-    color: darken($color-gmk-abs-CP, 60%);
+  input, .key-contents {
+    background: darken($color-sp-abs-GD, 10%);
+    color: lighten($color-gmk-abs-CP, 10%);
+    border-color: mix($color-sp-abs-GD, lighten($color-gmk-abs-CP, 10%));
   }
 }
 
@@ -498,8 +495,9 @@
   background: $color-sp-abs-BFP;
   color: $color-gmk-abs-CP;
   input, .key-contents {
-    background: lighten($color-sp-abs-BFP, 10%);
-    color: $color-gmk-abs-CP;
+    background: darken($color-sp-abs-BFP, 10%);
+    color: lighten($color-gmk-abs-CP, 10%);
+    border-color: mix($color-sp-abs-BFP, lighten($color-gmk-abs-CP, 10%));
   }
 }
 

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -85,15 +85,19 @@
 .sa-oblivion-hagoromo-key {
   background: $color-sp-abs-WFK;
   color: $color-sp-abs-GD;
-  input {
-    background: lighten($color-sp-abs-WFK, 40%);
+  input, .key-contents {
+    background: lighten($color-sp-abs-WFK, 10%);
+    color: darken($color-sp-abs-GD, 10%);
+    border-color: mix($color-sp-abs-WFK, darken($color-sp-abs-GD, 10%));
   }
 }
 .sa-oblivion-hagoromo-mod {
   background: $color-sp-abs-GD;
   color: $color-sp-abs-GAL;
-  input {
-    background: lighten($color-sp-abs-GD, 40%);
+  input, .key-contents {
+    background: darken($color-sp-abs-GD, 10%);
+    color: lighten($color-sp-abs-GAL, 17%);
+    border-color: mix($color-sp-abs-GD, lighten($color-sp-abs-GAL, 17%));
   }
 }
 .sa-oblivion-hagoromo-kb {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -328,15 +328,18 @@
   background: $color-gmk-abs-CP;
   color: #363434;
   input, .key-contents {
-    background: lighten($color-gmk-abs-CP, 40%);
+    background: lighten($color-gmk-abs-CP, 10%);
+    color: #363434;
+    border-color: mix($color-gmk-abs-CP, #363434);
   }
 }
 .gmk-olivia-mod {
   background: #363434;
   color: #e8c4b8;
   input, .key-contents {
-    color: lighten(#e8c4b8, 20%);
-    background: lighten(#363434, 40%);
+    color: #e8c4b8;
+    background: darken(#363434, 10%);
+    border-color: mix(#363434, #e8c4b8);
   }
 }
 .gmk-olivia-accent {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -281,15 +281,19 @@
 .gmk-dolch-key {
   background: $color-gmk-abs-CC;
   color: $color-gmk-abs-WS1;
-  input {
-    background: lighten($color-gmk-abs-CC, 40%);
+  input, .key-contents {
+    background: darken($color-gmk-abs-CC, 10%);
+    color: $color-gmk-abs-WS1;
+    border-color: mix($color-gmk-abs-CC, $color-gmk-abs-WS1);
   }
 }
 .gmk-dolch-mod {
   background: $color-gmk-abs-N9;
   color: $color-gmk-abs-WS1;
-  input {
-    background: lighten($color-gmk-abs-N9, 40%);
+  input, .key-contents {
+    background: darken($color-gmk-abs-N9, 10%);
+    color: $color-gmk-abs-WS1;
+    border-color: mix($color-gmk-abs-N9, $color-gmk-abs-WS1);
   }
 }
 .gmk-dolch-kb {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -353,15 +353,20 @@
 .gmk-ta-royal-alpha-key {
   background: $color-gmk-abs-3K;
   color: $color-gmk-abs-N7;
-  input {
-    background: lighten($color-gmk-abs-3K, 40%);
+  input, .key-contents {
+    background: lighten($color-gmk-abs-3K, 10%);
+    color: darken($color-gmk-abs-N7, 10%);
+    border-color: mix($color-gmk-abs-3K, darken($color-gmk-abs-N7, 10%));
+
   }
 }
 .gmk-ta-royal-alpha-mod {
   background: $color-gmk-abs-AE;
   color: $color-gmk-abs-CP;
-  input {
-    background: lighten($color-gmk-abs-AE, 40%);
+  input, .key-contents {
+    background: darken($color-gmk-abs-AE, 17%);
+    color: lighten($color-gmk-abs-CP, 10%);
+    border-color: mix($color-gmk-abs-AE, lighten($color-gmk-abs-CP, 10%));
   }
 }
 .gmk-ta-royal-alpha-kb {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -3,15 +3,19 @@
 .sa-danger-zone-key {
   background: $color-sp-abs-BFU;
   color: $color-sp-abs-YY;
-  input {
-    background: lighten($color-sp-abs-BFU, 40%);
+  input, .key-contents {
+    background: darken($color-sp-abs-BFU, 10%);
+    color: $color-sp-abs-YY;
+    border-color: mix($color-sp-abs-BFU, $color-sp-abs-YY);
   }
 }
 .sa-danger-zone-mod {
   background: $color-sp-abs-GSM;
   color: $color-sp-abs-YY;
-  input {
-    background: lighten($color-sp-abs-GSM, 40%);
+  input, .key-contents {
+    background: darken($color-sp-abs-GSM, 10%);
+    color: $color-sp-abs-YY;
+    border-color: mix($color-sp-abs-GSM, $color-sp-abs-YY);
   }
 }
 .sa-danger-zone-kb {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -366,8 +366,9 @@
   background: $color-gmk-abs-WS1;
   color: $color-gmk-abs-CR;
   input, .key-contents {
-    background: $color-gmk-abs-WS1;
+    background: lighten($color-gmk-abs-WS1, 10%);
     color: $color-gmk-abs-CR;
+    border-color: mix($color-gmk-abs-WS1, $color-gmk-abs-CR);
   }
 }
 .gmk-metaverse-mod {
@@ -375,7 +376,9 @@
   color: $color-gmk-abs-WS1;
   input, .key-contents {
     color: $color-gmk-abs-WS1;
-    background: lighten($color-gmk-abs-CR, 40%);
+    background: lighten($color-gmk-abs-CR, 10%);
+    color: $color-gmk-abs-WS1;
+    border-color: mix($color-gmk-abs-CR, $color-gmk-abs-WS1);
   }
 }
 .gmk-metaverse-accent {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -385,15 +385,19 @@
 .gmk-jamon-key {
   background: #84172c;
   color: #ece4d0;
-  input {
-    background: lighten(#84172c, 40%);
+  input, .key-contents {
+    background: darken(#84172c, 10%);
+    color: #ece4d0;
+    border-color: mix(#84172c, #ece4d0);
   }
 }
 .gmk-jamon-mod {
   background: #ac2c32;
   color: #ece4d0;
-  input {
-    background: lighten(#ac2c32, 40%);
+  input, .key-contents {
+    background: darken(#ac2c32, 10%);
+    color: #ece4d0;
+    border-color: mix(darken(#ac2c32, 10%), #ece4d0);
   }
 }
 .gmk-jamon-accent {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -459,15 +459,19 @@
 .gmk-serika-key {
   background: #ece4d0;
   color: #333732;
-  input {
-    background: lighten(#ece4d0, 40%);
+  input, .key-contents {
+    background: lighten(#ece4d0, 10%);
+    color: #333732;
+    border-color: mix(#ece4d0, #333732);
   }
 }
 .gmk-serika-mod {
   background: #ffcd00;
   color: #333732;
-  input {
-    background: lighten(#ffcd00, 40%);
+  input, .key-contents {
+    background: lighten(#ffcd00, 10%);
+    color: #333732;
+    border-color: mix(#ffcd00, #333732);
   }
 }
 .gmk-serika-accent {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -43,15 +43,19 @@
 .sa-modern-selectric-key {
   background: $color-sp-abs-NN;
   color: $color-sp-abs-WFK;
-  input {
-    background: lighten($color-sp-abs-NN, 40%);
+  input, .key-contents {
+    background: lighten($color-sp-abs-NN, 10%);
+    color: $color-sp-abs-WFK;
+    border-color: mix($color-sp-abs-NN, $color-sp-abs-WFK);
   }
 }
 .sa-modern-selectric-mod {
   background: $color-sp-abs-BDH;
   color: $color-sp-abs-WFK;
-  input {
-    background: lighten($color-sp-abs-BDH, 40%);
+  input, .key-contents {
+    background: darken($color-sp-abs-BDH, 10%);
+    color: $color-sp-abs-WFK;
+    border-color: mix($color-sp-abs-BDH, $color-sp-abs-WFK);
   }
 }
 .sa-modern-selectric-kb {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -307,14 +307,18 @@
   background: $color-gmk-abs-CP;
   color: $color-gmk-abs-V4;
   input, .key-contents {
-    background: lighten($color-gmk-abs-CP, 40%);
+    background: lighten($color-gmk-abs-CP, 10%);
+    color: darken($color-gmk-abs-V4, 5%);
+    border-color: mix($color-gmk-abs-CP, darken($color-gmk-abs-V4, 5%));
   }
 }
 .gmk-olivetti-mod {
   background: $color-gmk-abs-U9;
   color: $color-gmk-abs-V4;
   input, .key-contents {
-    background: lighten($color-gmk-abs-U9, 40%);
+    background: lighten($color-gmk-abs-U9, 10%);
+    color: darken($color-gmk-abs-V4, 15%);
+    border-color: mix($color-gmk-abs-U9, darken($color-gmk-abs-V4, 15%));
   }
 }
 .gmk-olivetti-kb {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -64,15 +64,19 @@
 .sa-nantucket-selectric-key {
   background: $color-sp-abs-WV;
   color: $color-sp-abs-BBI;
-  input {
-    background: lighten($color-sp-abs-WV, 40%);
+  input, .key-contents {
+    background: lighten($color-sp-abs-WV, 10%);
+    color: $color-sp-abs-BBI;
+    border-color: mix($color-sp-abs-WV, $color-sp-abs-BBI);
   }
 }
 .sa-nantucket-selectric-mod {
   background: $color-sp-abs-BBI;
   color: $color-sp-abs-YCF;
-  input {
-    background: lighten($color-sp-abs-BBI, 40%);
+  input, .key-contents {
+    background: darken($color-sp-abs-BBI, 10%);
+    color: $color-sp-abs-YCF;
+    border-color: mix($color-sp-abs-BBI, $color-sp-abs-YCF);
   }
 }
 .sa-nantucket-selectric-kb {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -20,15 +20,19 @@
 .sa-carbon-key {
   background: $color-sp-abs-WBO;
   color: $color-sp-abs-GQM;
-  input {
-    background: lighten($color-sp-abs-WBO, 40%);
+  input, .key-contents {
+    background: lighten($color-sp-abs-WBO, 10%);
+    color: $color-sp-abs-GQM;
+    border-color: mix($color-sp-abs-WBO, $color-sp-abs-GQM);
   }
 }
 .sa-carbon-mod {
   background: $color-sp-abs-GQM;
   color: $color-sp-abs-OBC;
-  input {
-    background: lighten($color-sp-abs-GQM, 40%);
+  input, .key-contents {
+    background: darken($color-sp-abs-GQM, 12%);
+    color: lighten($color-sp-abs-OBC, 19%);
+    border-color: mix($color-sp-abs-GQM, lighten($color-sp-abs-OBC, 19%));
   }
 }
 

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -135,16 +135,20 @@
 .sa-vilebloom-key {
   background: $color-pantone-7699C;
   color: $color-sp-abs-WFK;
-  input {
-    background: lighten($color-pantone-7699C, 40%);
+  input, .key-contents {
+    background: darken($color-pantone-7699C, 10%);
+    color: $color-sp-abs-WFK;
+    border-color: mix($color-pantone-7699C, $color-sp-abs-WFK);
   }
 }
 
 .sa-vilebloom-mod {
   background: $color-pantone-7699C;
   color: $color-sp-abs-WFK;
-  input {
-    background: lighten($color-pantone-7699C, 40%);
+  input, .key-contents {
+    background: darken($color-pantone-7699C, 10%);
+    color: $color-sp-abs-WFK;
+    border-color: mix($color-pantone-7699C, $color-sp-abs-WFK);
   }
 }
 

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -422,15 +422,19 @@
 .gmk-nautilus-key {
   background: $color-pantone-534C;
   color: $color-gmk-abs-TU2;
-  input {
-    background: lighten($color-pantone-534C, 40%);
+  input, .key-contents {
+    background: darken($color-pantone-534C, 10%);
+    color: lighten($color-gmk-abs-TU2, 5%);
+    border-color: mix($color-pantone-534C, lighten($color-gmk-abs-TU2, 5%));
   }
 }
 .gmk-nautilus-mod {
   background: $color-pantone-533C;
   color: $color-gmk-abs-N6;
-  input {
-    background: lighten($color-pantone-533C, 40%);
+  input, .key-contents {
+    background: darken($color-pantone-533C, 10%);
+    color: $color-gmk-abs-N6;
+    border-color: mix($color-pantone-533C, $color-gmk-abs-N6);
   }
 }
 .gmk-nautilus-accent {

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -267,16 +267,18 @@
   background: $color-gmk-abs-CR;
   color: $color-gmk-abs-WS1;
   input, .key-contents {
-    color: $color-gmk-abs-CR;
-    background: lighten($color-gmk-abs-CR, 60%);
+    background: lighten($color-gmk-abs-CR, 10%);
+    color: $color-gmk-abs-WS1;
+    border-color: mix($color-gmk-abs-CR, $color-gmk-abs-WS1);
   }
 }
 .gmk-wob-mod {
   background: $color-gmk-abs-CR;
   color: $color-gmk-abs-WS1;
   input, .key-contents {
-    color: $color-gmk-abs-CR;
-    background: lighten($color-gmk-abs-CR, 40%);
+    background: lighten($color-gmk-abs-CR, 10%);
+    color: $color-gmk-abs-WS1;
+    border-color: mix($color-gmk-abs-CR, $color-gmk-abs-WS1);
   }
 }
 .gmk-wob-kb {


### PR DESCRIPTION
## Description / Notes

Following up on the work of #272, which is in reference to Issue #271.

Generally, the changes went as follows:

Start with key and legend colors identical to that of the "base" key (alpha or mod), then color shift via either the `lighten` or `darken` functions in Sass, until reaching a [WCAG 2.0](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.0&showtechniques=143#qr-visual-audio-contrast-contrast) contrast rating of 7.0 or higher (calculated using [this web tool](https://contrast-ratio.com/)). Generally, light-on-dark keysets got darker input fields, and dark-on-light sets got lighter input fields.

The goal here was to ensure high readability, while also maintaining/improving the visual appeal.


**TL;DR: Read good + look good = is good.**

Sample Image (SA Jukebox and GMK Dolch shown; before on left, after on right):

![image](https://user-images.githubusercontent.com/18669334/54497957-25ff8680-48be-11e9-9df0-a7ca899b359d.png)
