### PR TITLE
Be more through about checking NaN

### DIFF
--- a/src/components/LayerKey.vue
+++ b/src/components/LayerKey.vue
@@ -29,6 +29,7 @@
 </template>
 <script>
 import isNumber from 'lodash/isNumber';
+import isNaN from 'lodash/isNaN';
 import { mapGetters, mapMutations, mapActions } from 'vuex';
 import BaseKey from './BaseKey';
 export default {
@@ -47,7 +48,7 @@ export default {
     ...mapActions('keymap', ['setKeycodeLayer']),
     input(e) {
       const toLayer = parseInt(e.target.value, 10);
-      if (isNumber(toLayer)) {
+      if (!isNaN(toLayer) && isNumber(toLayer)) {
         this.setKeycodeLayer({
           layer: this.curLayer,
           index: this.id,


### PR DESCRIPTION
 - NaN is considered a number, we don't want to pass NaN to datamodel so
 check for it and ignore it when parsing input from LayerKey

Thanks to guestavius for reporting on discord.

@noroadsleft @mechmerlin 