### PR TITLE
BUG: keycode import was only partially working

### DIFF
--- a/src/jquery.js
+++ b/src/jquery.js
@@ -189,7 +189,7 @@ function parseKeycode(keycode, stats) {
         return newAnyKey(keycode);
       }
 
-      key = newKey(metadata, keycode, { contents: internalkeycode });
+      key = newKey(metadata, outerKeycode, { contents: internalkeycode });
       return key;
     }
 
@@ -200,7 +200,7 @@ function parseKeycode(keycode, stats) {
       stats.any += 1;
       return newAnyKey(keycode);
     }
-    key = newKey(metadata, keycode, { layer: internal });
+    key = newKey(metadata, outerKeycode, { layer: internal });
     return key;
   }
 


### PR DESCRIPTION
 - symptom, being unable to change any layer or (kc) style codes once
 they were set in the UI.
 - Use correct regenerated keycode, not the imported keycode, so
 export works correctly again

Longer description:

A coding error. When we import codes from a JSON file we parse them and
set their original KC_CODE to that configurator can export them
correctly again.

e.g. TG(3) would be internally referred to as TG(layer). When exported
it would save TG(3).

The bug was on import. The key was correctly parsed as an layer key, but
then it was incorrectly imported to be `TG(3)` instead of `TG(layer)`. This
caused the export to save the wrong data because the code could not be
correctly looked up, so it was treated like an ANY key.

This also affected any container keys, which would create a similarly
bogus key mapping.