### PR TITLE
Setup for Google Analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw*
+ga-production.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - 10
 before_script:
+  - git clone --single-branch --branch config https://github.com/qmk/qmk_configurator config
+  - cp config/ga-production.js src/
   - yarn install
   - yarn build
 script: bash ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,6 +16,7 @@ git remote add origin https://github.com/${TRAVIS_REPO_SLUG}
 git pull origin config
 
 rm -rf .git
+mv ga-production.js src/
 git init
 
 # inside this git repo we'll pretend to be a new user

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "keypress.js": "^2.1.5",
     "lodash": "^4.17.11",
     "vue": "^2.5.17",
+    "vue-analytics": "^5.16.4",
     "vue-router": "^3.0.1",
     "vue-select": "^2.6.0",
     "vuex": "^3.0.1"

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -290,6 +290,12 @@ export default {
       this.$store.commit('app/setKeymapName', newKeymapName);
     },
     compile() {
+      this.$ga.event({
+        eventCategory: 'apicall',
+        eventAction: 'compilation',
+        eventLabel: 'keyboard',
+        eventValue: this.keyboard
+      });
       let keymapName = this.realKeymapName;
       let _keymapName = this.$store.getters['app/exportKeymapName'];
       // TODO extract this name function to the store

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -293,8 +293,7 @@ export default {
       this.$ga.event({
         eventCategory: 'apicall',
         eventAction: 'compilation',
-        eventLabel: 'keyboard',
-        eventValue: this.keyboard
+        eventLabel: this.keyboard
       });
       let keymapName = this.realKeymapName;
       let _keymapName = this.$store.getters['app/exportKeymapName'];

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -263,6 +263,11 @@ export default {
      * @return {object} promise when it has been done or error
      */
     updateKeyboard(newKeyboard) {
+      this.$ga.event({
+        eventCategory: 'apicall',
+        eventAction: 'changeKeyboard',
+        eventLabel: newKeyboard
+      });
       return this.$store
         .dispatch('app/changeKeyboard', newKeyboard)
         .then(this.postUpdateKeyboard);

--- a/src/ga-development.js
+++ b/src/ga-development.js
@@ -1,0 +1,3 @@
+export default {
+  id: ''
+};

--- a/src/ga-development.js
+++ b/src/ga-development.js
@@ -1,3 +1,3 @@
 export default {
-  id: ''
+  id: 'UA-XXX-X'
 };

--- a/src/ga.js
+++ b/src/ga.js
@@ -4,10 +4,14 @@ import config from './ga-development';
 
 export default {
   init() {
-    if (process.env.NODE_ENV === 'production') {
-      Vue.use(VueAnalytics, {
-        id: config.id
-      });
-    }
+    Vue.use(VueAnalytics, {
+      id: config.id,
+      autoTracking: {
+        screenview: true
+      },
+      debug: {
+        sendHitTask: process.env.NODE_ENV === 'production'
+      }
+    });
   }
 };

--- a/src/ga.js
+++ b/src/ga.js
@@ -1,0 +1,13 @@
+import Vue from 'vue';
+import VueAnalytics from 'vue-analytics';
+import config from './ga-development';
+
+export default {
+  init() {
+    if (process.env.NODE_ENV === 'production') {
+      Vue.use(VueAnalytics, {
+        id: config.id
+      });
+    }
+  }
+};

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,9 @@ import store from './store';
 import StatusBar from '@/components/StatusBar';
 import Veil from '@/components/Veil';
 import vSelect from 'vue-select';
+import ga from './ga';
+
+ga.init();
 
 Vue.component('Veil', Veil);
 Vue.component('v-select', vSelect);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -15,6 +15,11 @@ export default {
   components: {
     Main,
     Keycodes
+  },
+  methods: {
+    track() {
+      this.$ga.page('/');
+    }
   }
 };
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -11,7 +11,7 @@ import Main from '@/components/Main';
 import Keycodes from '@/components/Keycodes';
 
 export default {
-  name: 'home',
+  name: 'configurator',
   components: {
     Main,
     Keycodes

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,12 @@
+const webpack = require('webpack');
 module.exports = {
-  publicPath: process.env.NODE_ENV === 'production' ? '.' : '/'
+  publicPath: process.env.NODE_ENV === 'production' ? '.' : '/',
+  configureWebpack: config => {
+    config.plugins.push(
+      new webpack.NormalModuleReplacementPlugin(
+        /\.\/ga-development/,
+        './ga-production'
+      )
+    );
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10490,6 +10490,11 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+vue-analytics@^5.16.4:
+  version "5.16.4"
+  resolved "https://registry.yarnpkg.com/vue-analytics/-/vue-analytics-5.16.4.tgz#7f9e197cbc64afac96884a05214b17efaf8e9d09"
+  integrity sha512-M67cUqpPeyk2rftrvlx2uU+BQ/C4E8SkF2Ct9LizOYUoTccZtCCJwhMJfQ3XL8xep6p3K8KYz58FzRWvx5zlPw==
+
 vue-eslint-parser@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"


### PR DESCRIPTION
Adds capability to use Google Analytics to configurator. Requires a `ga-production.js` file which contains your id. During development it does not try to execute this code. This file is not checked in by default to avoid everyone using the same google analytics id and stepping over the data.

```
export default {
  id: 'UA-IDGOESHERE'
};
```