### PR TITLE
Capture KC_APP properly

### DIFF
--- a/src/jquery.js
+++ b/src/jquery.js
@@ -46,7 +46,7 @@ function generateKeypressCombos(_keycodes) {
 }
 
 const keyLUT = {
-  'ContextMenu': 'KC_APP'
+  ContextMenu: 'KC_APP'
 };
 
 const mods = {
@@ -65,7 +65,7 @@ function generateKeypressHandler(keycode) {
       let _meta = meta;
 
       // handle special cases eg. ContextMenu
-      const special = keyLUT(ev.key);
+      const special = keyLUT[ev.key];
       if (!isUndefined(special)) {
         _meta = store.getters['keycodes/lookupKeycode'](special);
       } else {

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -65,6 +65,11 @@ function generateKeypressHandler(keycode) {
         case 'KC_LGUI':
         case 'KC_LALT':
         case 'KC_LCTL':
+          // Keypress reports this keycode as Left GUI because they (sometimes) have the same event keyCode
+          if (ev.key === 'ContextMenu') {
+            _meta = store.getters['keycodes/lookupKeycode']('KC_APP');
+            break;
+          }
           if (ev.location === ev.DOM_KEY_LOCATION_RIGHT) {
             _meta = store.getters['keycodes/lookupKeycode'](mods[meta.code]);
           }


### PR DESCRIPTION
In Chrome and Safari on macOS, `ev.keyCode` for the left OS and context menu key is the same, and Keypress.js favours the former, so we need a second opinion from `ev.key`.

I *think* this is the right place to put this...

Side note: On Safari, the context menu key is actually not even recognised and [results in `KC_BSLS`](https://github.com/dmauro/Keypress/blob/df626c49f3208386a735d0bb1bd38b7aafbc1b02/keypress.coffee#L806):

```coffeescript
_keycode_dictionary = 
    0   : "\\"          # Firefox reports this keyCode when shift is held
    8   : "backspace"
    9   : "tab"
```

The Configurator should probably throw away any key events where `e.key === 'Unidentified'`.