### PR TITLE
Add default for Romac

### DIFF
--- a/public/keymaps/romac_default.json
+++ b/public/keymaps/romac_default.json
@@ -1,6 +1,7 @@
 {
   "keyboard":"romac",
-  "keymap":"default",
+  "keymap":"default_803ba23",
+  "commit": "803ba239febeca4bddc080d3d33630b3ab8087b8",
   "layout":"LAYOUT",
   "layers":[
       ["KC_7", "KC_8", "KC_9",

--- a/public/keymaps/romac_default.json
+++ b/public/keymaps/romac_default.json
@@ -1,0 +1,15 @@
+{
+  "keyboard":"romac",
+  "keymap":"default",
+  "layout":"LAYOUT",
+  "layers":[
+      ["KC_7", "KC_8", "KC_9",
+        "KC_4", "KC_5", "KC_6",
+        "KC_1", "KC_2", "KC_3",
+        "MO(1)", "KC_0", "KC_ENT"],
+      ["KC_TRNS", "KC_HOME", "KC_PGUP",
+        "KC_TRNS", "KC_END", "KC_PGDN",
+        "KC_TRNS", "KC_TRNS", "KC_TRNS",
+        "KC_TRNS", "KC_TRNS", "KC_DOT"]
+  ]
+}


### PR DESCRIPTION
Add default to match default keymap in QMK for new Romac macro board.