### PR TITLE
 tweak styling

### DIFF
--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -3,35 +3,42 @@
     <div ref="console">
       <controllerTop /><statusPanel /><controllerBottom />
     </div>
-    <a
-      class="hint"
-      target="_blank"
-      href="https://github.com/qmk/qmk_toolbox/releases"
-    >
-      Download QMK Toolbox
-    </a>
+    <div class="hint">
+      <a target="_blank" href="https://github.com/qmk/qmk_toolbox/releases">
+        Get QMK Toolbox
+      </a>
+    </div>
     <div class="split-content">
       <div class="left-side"><layerControl /></div>
       <div class="right-side">
         <p>
-          <label title="Ctrl + Alt + N to cycle next colorway">
+          <label
+            class="keymap--label"
+            title="Ctrl + Alt + N to cycle next colorway"
+          >
             <font-awesome-icon
               v-if="continuousInput"
               icon="keyboard"
               fixed-width
             />
             Keymap:
-            <select id="colorway-select" v-model="curIndex">
-              <option
-                class="option"
-                v-for="(name, index) in displayColorways"
-                :key="index"
-                :value="index"
-              >
-                {{ name }}
-              </option>
-            </select>
           </label>
+          &nbsp;
+          <!-- maintain spacing for paragraph -->
+          <select
+            class="keymap--keyset"
+            id="colorway-select"
+            v-model="curIndex"
+          >
+            <option
+              class="option"
+              v-for="(name, index) in displayColorways"
+              :key="index"
+              :value="index"
+            >
+              {{ name }}
+            </option>
+          </select>
         </p>
         <visualKeymap :profile="false" />
       </div>
@@ -101,8 +108,7 @@ export default {
 }
 .hint {
   display: grid;
-  justify-content: start;
-  align-content: start;
+  justify-content: end;
 }
 #colorway-select {
   font-family: 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -119,5 +125,11 @@ export default {
   border-radius: 9px;
   color: #ffa500;
   cursor: pointer;
+}
+.keymap--label {
+  float: left;
+}
+.keymap--keyset {
+  float: right;
 }
 </style>


### PR DESCRIPTION
Folks were complaining that the keyset next to the keymap label was confusing. Position them in different corners of the div to avoid this confusion. It will still occur for very smol boards but I'm not going to sweat that. Also move the QMK toolbox link closer to the download firmware button where it is more relevant, and make it's click zone smaller.

![Screen Shot 2019-04-21 at 10 52 37](https://user-images.githubusercontent.com/2275667/56473709-c9930800-6423-11e9-814c-aa6a2009dcbc.png)

 - float keymap label left
 - float keset dropdown right
 - move QMK Toolbox link closer to download firmware button
 - make just text clickable, not entire area.