### PR TITLE
add treadstone48 default keymap

### DIFF
--- a/public/keymaps/treadstone48_rev1_default.json
+++ b/public/keymaps/treadstone48_rev1_default.json
@@ -1,0 +1,22 @@
+{
+    "keyboard": "treadstone48",
+    "keymap": "treadstone48_default",
+    "layout": "LAYOUT_base",
+    "layers": [
+        [   "KC_ESC","KC_Q","KC_W","KC_E","KC_R","KC_T","KC_Y","KC_U","KC_I","KC_O","KC_P","KC_MINS",
+            "KC_TAB","KC_A","KC_S","KC_D","KC_F","KC_G","KC_H","KC_J","KC_K","KC_L","KC_SCLN","KC_ENT",
+            "KC_LSFT","KC_Z","KC_X","KC_C","KC_V","KC_B","KC_N","KC_M","KC_COMM","KC_DOT","KC_SLSH","KC_UP",
+            "KC_LCTL","KC_LGUI","KC_LALT","MO(1)","KC_BSPC","KC_SPC","MO(2)","KC_APP","KC_LEFT","KC_DOWN","KC_RGHT","KC_DEL"
+        ],
+        [   "KC_NO","KC_F1","KC_F2","KC_F3","KC_F4","KC_F5","KC_MINS","KC_EQL","KC_LBRC","KC_RBRC","KC_BSLS","KC_NO",
+            "KC_NO","KC_F6","KC_F7","KC_F8","KC_F9","KC_F10","KC_NO","KC_NO","KC_NO","KC_SCLN","KC_QUOT","KC_NO",
+            "KC_NO","KC_F11","KC_F12","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_COMM","KC_DOT","KC_SLSH","KC_PGUP",
+            "KC_NO","KC_NO","KC_NO","KC_TRNS","KC_DEL","KC_NO","KC_NO","KC_NO","KC_HOME","KC_PGDN","KC_END","KC_NO"
+        ],
+        [   "KC_NO","KC_1","KC_2","KC_3","KC_4","KC_5","KC_6","KC_7","KC_8","KC_9","KC_0","KC_NO",
+            "KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO",
+            "KC_NO","MAGIC_UNSWAP_LALT_LGUI","MAGIC_SWAP_LALT_LGUI","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO",
+            "KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO","KC_TRNS","KC_NO","KC_NO","KC_NO","KC_NO","KC_NO"
+        ]
+    ]
+}


### PR DESCRIPTION
I created and compiled from https://config.qmk.fm/, written to treadstone48, after that confirmed with behavior.

Best regards,