### PR TITLE
Default Keymap Extravaganza

### DIFF
--- a/public/keymaps/1upkeyboards_1up60hte_default.json
+++ b/public/keymaps/1upkeyboards_1up60hte_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "1upkeyboards/1up60hte",
+  "keymap": "default_58b065c",
+  "commit": "58b065cfdaca29144fa7fd18d482223bc1ea7308",
+  "layout": "LAYOUT_tsangan",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_GRV",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "MO(1)",
+      "KC_LCTL", "KC_LALT", "KC_LGUI",                                             "KC_SPC",                                              "KC_RGUI", "KC_RALT", "KC_RCTL"
+    ],
+    [
+      "RESET",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_INS",  "KC_DEL",
+      "KC_CAPS", "BL_TOGG", "BL_DEC",  "BL_INC",  "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_SLCK", "KC_PAUS", "KC_UP",   "KC_TRNS", "KC_CLR",
+      "KC_TRNS", "KC_VOLD", "KC_VOLU", "KC_MUTE", "KC_MPLY", "KC_MPRV", "KC_MNXT", "RGB_VAD", "KC_HOME", "KC_PGUP", "KC_LEFT", "KC_RGHT", "KC_TRNS",
+      "KC_TRNS", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "KC_END",  "KC_PGDN", "KC_DOWN", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                             "KC_TRNS",                                             "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/1upkeyboards_1up60rgb_default.json
+++ b/public/keymaps/1upkeyboards_1up60rgb_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "1upkeyboards/1up60rgb",
+  "keymap": "default_0072fdd",
+  "commit": "0072fdd799ffe61bf64f12c23335da3adeb083e5",
+  "layout": "LAYOUT_all",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",  "KC_ENT",
+      "KC_LSFT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "KC_RGUI", "MO(1)",   "KC_RCTL"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/1upkeyboards_super16_default.json
+++ b/public/keymaps/1upkeyboards_super16_default.json
@@ -1,0 +1,14 @@
+{
+  "keyboard": "1upkeyboards/super16",
+  "keymap": "default_80d427a",
+  "commit": "80d427a2035afdc57b850381a36e4dd9d2c179ea",
+  "layout": "LAYOUT_ortho_4x4",
+  "layers": [
+    [
+      "KC_A",    "KC_1",    "KC_2",    "KC_4",
+      "KC_A",    "KC_1",    "KC_2",    "KC_4",
+      "KC_A",    "KC_1",    "KC_2",    "KC_4",
+      "KC_A",    "KC_1",    "KC_2",    "KC_4"
+    ]
+  ]
+}

--- a/public/keymaps/1upkeyboards_sweet16_default.json
+++ b/public/keymaps/1upkeyboards_sweet16_default.json
@@ -1,0 +1,14 @@
+{
+  "keyboard": "1upkeyboards/sweet16",
+  "keymap": "default_0072fdd",
+  "commit": "0072fdd799ffe61bf64f12c23335da3adeb083e5",
+  "layout": "LAYOUT_ortho_4x4",
+  "layers": [
+    [
+      "KC_7",    "KC_8",    "KC_9",    "KC_ASTR",
+      "KC_4",    "KC_5",    "KC_6",    "KC_SLSH",
+      "KC_1",    "KC_2",    "KC_3",    "KC_MINS",
+      "KC_0",    "KC_ENT",  "KC_DOT",  "KC_EQL"
+    ]
+  ]
+}

--- a/public/keymaps/30wer_default.json
+++ b/public/keymaps/30wer_default.json
@@ -1,0 +1,18 @@
+{
+  "keyboard": "30wer",
+  "keymap": "default_ef84bd9",
+  "commit": "ef84bd979979f092980dc68d513a906e084c8c57",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_BSPC",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+                 "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "LT(1,KC_SPC)"
+    ],
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_UP",   "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_RGHT", "KC_TRNS",
+                 "KC_LALT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_DOWN", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/40percentclub_gherkin_default.json
+++ b/public/keymaps/40percentclub_gherkin_default.json
@@ -1,0 +1,18 @@
+{
+  "keyboard": "40percentclub/gherkin",
+  "keymap": "default_b173c05",
+  "commit": "b173c05cc25e9394c6e50081c1af707443950104",
+  "layout": "LAYOUT_ortho_3x10",
+  "layers": [
+    [
+      "LT(1,KC_Q)", "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O", "KC_P",
+      "KC_A",       "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L", "KC_ESC",
+      "KC_Z",       "KC_X",    "KC_C",    "KC_V",    "KC_BSPC", "KC_SPC",  "KC_B",    "KC_N",    "KC_M", "KC_ENT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "BL_INC",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",   "KC_TRNS", "KC_TRNS", "BL_DEC"
+    ]
+  ]
+}

--- a/public/keymaps/40percentclub_mf68_default.json
+++ b/public/keymaps/40percentclub_mf68_default.json
@@ -1,0 +1,29 @@
+{
+  "keyboard": "40percentclub/mf68",
+  "keymap": "default_0786f22",
+  "commit": "0786f227d8563be3c9a31c0c4153a1b1cebcfc69",
+  "layout": "LAYOUT_68_ansi",
+  "layers": [
+    [
+      "KC_ESC",       "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",            "KC_INS",  "KC_PGUP",
+      "KC_TAB",       "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_DEL",  "KC_PGDN",
+      "LT(2,KC_GRV)", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_LSFT",      "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",                       "KC_RSFT",            "KC_UP",
+      "KC_LCTL",      "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "MO(1)",   "KC_RALT", "KC_RCTL",            "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_BSPC",            "KC_VOLU", "KC_HOME",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "BL_STEP", "KC_TRNS",            "KC_VOLD", "KC_END",
+      "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MUTE", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS",            "KC_MUTE",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_MPRV", "KC_MPLY", "KC_MNXT"
+    ],
+    [
+      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_BSPC",            "KC_VOLU", "KC_HOME",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_7",    "KC_8",    "KC_9",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_VOLD", "KC_END",
+      "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_4",    "KC_5",    "KC_6",    "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_0",    "KC_1",    "KC_2",    "KC_3",    "KC_TRNS",                       "KC_TRNS",            "KC_MUTE",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_MPRV", "KC_MPLY", "KC_MNXT"
+    ]
+  ]
+}

--- a/public/keymaps/acr60_default.json
+++ b/public/keymaps/acr60_default.json
@@ -1,0 +1,29 @@
+{
+  "keyboard": "acr60",
+  "keymap": "default_9e4ac6c",
+  "commit": "9e4ac6cf29e6b2ce950135c8f877c95f2d1f1d55",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_NO",   "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_LSFT", "KC_NO",   "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_NO",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",            "KC_SPC",  "KC_SPC",  "KC_SPC",                        "KC_RALT", "MO(2)",   "KC_NO",   "MO(1)",   "KC_RCTL"
+    ],
+    [
+      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "BL_DEC",  "BL_TOGG", "BL_INC",  "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/alf_dc60_default.json
+++ b/public/keymaps/alf_dc60_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "alf/dc60",
+  "keymap": "default_215375f",
+  "commit": "215375f37c2bd81f4a5f26c4c2d3b5fb32782168",
+  "layout": "LAYOUT_all",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_LSFT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "MO(1)",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",  "KC_SPC",  "KC_SPC",                        "KC_RALT", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_LSFT", "KC_TRNS", "KC_TRNS", "BL_DEC",  "BL_TOGG", "BL_INC",  "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/alf_x2_default.json
+++ b/public/keymaps/alf_x2_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "alf/x2",
+  "keymap": "default_",
+  "commit": "cd3518b802071a915ff11659a32bf0a124687ea3",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+                    "KC_VOLU", "KC_VOLD",
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_NO",   "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_LSFT", "KC_NO",   "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_NO",   "KC_RSFT", "KC_NO",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "MO(1)",   "KC_NO",   "KC_APP",  "KC_RCTL"
+      ],
+    [
+                    "KC_MNXT", "KC_MPRV",
+      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_UP",   "KC_TRNS", "RESET",
+      "KC_TRNS", "KC_VOLD", "KC_VOLU", "KC_MUTE", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_HOME", "KC_PGUP", "KC_LEFT", "KC_RGHT",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_END",  "KC_PGDN", "KC_DOWN", "KC_DOWN", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/alps64_default.json
+++ b/public/keymaps/alps64_default.json
@@ -1,0 +1,15 @@
+{
+  "keyboard": "alps64",
+  "keymap": "default_67adc29",
+  "commit": "67adc29aa35719eea2de43bacf9cd5e8b5dfd79e",
+  "layout": "LAYOUT_all",
+  "layers": [
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_NUHS", "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_ESC",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_APP",  "KC_RALT", "KC_RGUI", "KC_RCTL"
+    ]
+  ]
+}

--- a/public/keymaps/atreus62_default.json
+++ b/public/keymaps/atreus62_default.json
@@ -1,0 +1,29 @@
+{
+  "keyboard": "atreus62",
+  "keymap": "default_67adc29",
+  "commit": "67adc29aa35719eea2de43bacf9cd5e8b5dfd79e",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                          "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS",
+      "KC_BSLS", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                          "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_RBRC",
+      "KC_TAB",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                          "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",                          "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_LBRC",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_GRV",  "MO(1)",   "KC_BSPC", "KC_DEL",  "KC_ENT",  "KC_SPC",  "KC_EQL",  "KC_MINS", "KC_QUOT", "KC_ENT",  "KC_RGUI"
+    ],
+    [
+      "TO(0)",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",                         "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_F12",  "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS",
+      "TO(2)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "TO(0)",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RESET"
+    ]
+  ]
+}

--- a/public/keymaps/atreus_default.json
+++ b/public/keymaps/atreus_default.json
@@ -1,0 +1,26 @@
+{
+  "keyboard": "atreus",
+  "keymap": "default_79acf1e",
+  "commit": "79acf1e6602a20a5d82bd70e4fc7b2b34ec2207a",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                          "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",
+      "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                          "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN",
+      "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",                          "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",
+      "KC_ESC",  "KC_TAB",  "KC_LGUI", "KC_LSFT", "KC_BSPC", "KC_LCTL", "KC_LALT", "KC_SPC",  "MO(1)",   "KC_MINS", "KC_QUOT", "KC_ENT"
+    ],
+    [
+      "KC_EXLM", "KC_AT",   "KC_UP",   "KC_LCBR", "KC_RCBR",                       "KC_PGUP", "KC_7",    "KC_8",    "KC_9",    "KC_ASTR",
+      "KC_HASH", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_DLR",                        "KC_PGDN", "KC_4",    "KC_5",    "KC_6",    "KC_PLUS",
+      "KC_LBRC", "KC_RBRC", "KC_LPRN", "KC_RPRN", "KC_AMPR",                       "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_BSLS",
+      "TG(2)",   "KC_INS",  "KC_LGUI", "KC_LSFT", "KC_BSPC", "KC_LCTL", "KC_LALT", "KC_SPC",  "KC_TRNS", "KC_DOT",  "KC_0",    "KC_EQL"
+    ],
+    [
+      "KC_INS",  "KC_HOME", "KC_UP",   "KC_END",  "KC_PGUP",                       "KC_UP",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",
+      "KC_DEL",  "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_PGDN",                       "KC_DOWN", "KC_F4",   "KC_F5",   "KC_F6",   "KC_F11",
+      "KC_NO",   "KC_VOLU", "KC_NO",   "KC_NO",   "RESET",                         "KC_NO",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F12",
+      "KC_NO",   "KC_VOLD", "KC_LGUI", "KC_LSFT", "KC_BSPC", "KC_LCTL", "KC_LALT", "KC_SPC",  "TO(0)",   "KC_PSCR", "KC_SLCK", "KC_PAUS"
+    ]
+  ]
+}

--- a/public/keymaps/cannonkeys_ortho60_default.json
+++ b/public/keymaps/cannonkeys_ortho60_default.json
@@ -1,0 +1,29 @@
+{
+  "keyboard": "cannonkeys/ortho60",
+  "keymap": "default_7186d15",
+  "commit": "7186d1581abbd97d7c76626ae83fc866e85d217c",
+  "layout": "LAYOUT_ortho_5x12",
+  "layers": [
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_TOGG", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(1)",   "KC_SPC",  "KC_SPC",  "MO(2)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",       "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "RGB_TOG", "RGB_MOD", "BL_INC",  "BL_DEC",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ]
+  ]
+}

--- a/public/keymaps/crkbd_rev1_default.json
+++ b/public/keymaps/crkbd_rev1_default.json
@@ -1,0 +1,32 @@
+{
+  "keyboard": "crkbd/rev1",
+  "keymap": "default_1904319",
+  "commit": "19043197459c5c8ed4a7039f1a4c1da180da45e1",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",           "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                          "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "LCTL_T(KC_TAB)",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                          "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT",          "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",                          "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+                                                 "LGUI_T(KC_LANG2)",  "MO(1)",   "KC_SPC",  "KC_ENT",  "MO(2)",   "LALT_T(KC_LANG1)"
+    ],
+    [
+      "KC_ESC",           "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                          "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "LCTL_T(KC_TAB)",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",                         "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_NO",
+      "KC_LSFT",          "KC_F11",  "KC_F12",  "KC_F13",  "KC_F14",  "KC_F15",                        "KC_F16",  "KC_F17",  "KC_F18",  "KC_F19",  "KC_F20",  "KC_NO",
+                                                  "LGUI_T(KC_LANG2)", "MO(1)",   "KC_SPC",  "KC_ENT",  "MO(2)",   "LALT_T(KC_LANG1)"
+    ],
+    [
+      "KC_ESC",           "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC",                       "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "LCTL_T(KC_TAB)",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_MINS", "KC_EQL",  "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_GRV",
+      "KC_LSFT",          "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_UNDS", "KC_PLUS", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TILD",
+                                                  "LGUI_T(KC_LANG2)", "MO(1)",   "KC_SPC",  "KC_ENT",  "MO(2)",   "LALT_T(KC_LANG1)"
+    ],
+    [
+      "RESET",            "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "RGB_TOG",          "RGB_HUI", "RGB_SAI", "RGB_VAI", "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "RGB_MOD",          "RGB_HUD", "RGB_SAD", "RGB_VAD", "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+                                                  "LGUI_T(KC_LANG2)", "MO(1)",   "KC_SPC",  "KC_ENT",  "MO(2)",   "LALT_T(KC_LANG1)"
+    ]
+  ]
+}

--- a/public/keymaps/duck_lightsaver_default.json
+++ b/public/keymaps/duck_lightsaver_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "duck/lightsaver",
+  "keymap": "default_a63d477",
+  "commit": "a63d4774f5115b91703936183a39a4724b44b94d",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_PSCR", "KC_NLCK", "KC_INS",  "KC_HOME", "KC_PGUP", "KC_PSLS",
+      "KC_GRV",   "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",             "KC_BSPC", "KC_DEL",  "KC_END",  "KC_PGDN", "KC_PAST",
+      "KC_TAB",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC",            "KC_BSLS", "KC_P7",   "KC_P8",   "KC_P9",   "KC_PMNS",
+      "MO(1)",    "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",                       "KC_ENT",  "KC_P4",   "KC_P5",   "KC_P6",   "KC_PPLS",
+      "KC_LSFT",             "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",             "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_P1",   "KC_P2",   "KC_P3",   "KC_PENT",
+      "KC_LCTL",  "KC_LGUI", "KC_LALT",                                                        "KC_SPC",                        "KC_RALT", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_P0",   "KC_PDOT"
+    ],
+    [
+      "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PAUS", "KC_SLCK", "RGB_TOG", "RGB_MOD", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_CAPS", "BL_TOGG", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END",  "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",
+      "KC_TRNS",  "KC_TRNS", "KC_TRNS",                                                        "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/ergodash_mini_default.json
+++ b/public/keymaps/ergodash_mini_default.json
@@ -1,0 +1,32 @@
+{
+  "keyboard": "ergodash/mini",
+  "keymap": "default_e2d3c92",
+  "commit": "e2d3c92199d6cc42a39c5d8729dfff61d78dd7d1",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_MINS",                                  "KC_EQL",  "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSLS",
+      "KC_TAB",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_LBRC",                                  "KC_RBRC", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_SPC",                                   "KC_ENT",  "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "LALT(KC_GRV)",       "MO(1)",   "KC_SPC",  "KC_DEL",             "KC_BSPC", "KC_ENT",  "MO(2)",              "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_UNDS",                                  "KC_PLUS", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_PIPE",
+      "KC_TILD", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_LCBR",                                  "KC_RCBR", "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_COLN", "KC_DQUO",
+      "KC_LSFT", "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_SPC",                                   "KC_ENT",  "KC_N",    "KC_M",    "KC_LT",   "KC_GT",   "KC_QUES", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "LALT(KC_GRV)",       "MO(1)",   "KC_SPC",  "KC_DEL",             "KC_BSPC", "KC_ENT",  "MO(3)",              "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END"
+    ],
+    [
+      "KC_GRV",  "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_UNDS",                                  "KC_PLUS", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_PIPE",
+      "KC_TILD", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_LCBR",                                  "KC_RCBR", "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_COLN", "KC_DQUO",
+      "KC_LSFT", "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_SPC",                                   "KC_ENT",  "KC_N",    "KC_M",    "KC_LT",   "KC_GT",   "KC_QUES", "KC_RSFT",
+      "KC_LCTL", "KC_F11",  "KC_F12",  "LALT(KC_GRV)",       "MO(3)",   "KC_SPC",  "KC_DEL",             "KC_BSPC", "KC_ENT",  "MO(2)",              "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END"
+    ],
+    [
+      "KC_TRNS", "RESET",   "RGB_TOG", "RGB_MOD", "RGB_HUD", "RGB_HUI", "KC_TRNS",                                  "KC_TRNS", "RGB_SAD", "RGB_SAI", "RGB_VAD", "RGB_VAI", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "BL_TOGG", "BL_BRTG", "BL_INC",  "BL_DEC",  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/ergodash_rev2_default.json
+++ b/public/keymaps/ergodash_rev2_default.json
@@ -1,0 +1,36 @@
+{
+  "keyboard": "ergodash/rev2",
+  "keymap": "default_0072fdd",
+  "commit": "0072fdd799ffe61bf64f12c23335da3adeb083e5",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_LBRC",                       "KC_RBRC", "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_PSCR",
+      "KC_GRV",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_MINS",                       "KC_EQL",  "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSLS",
+      "KC_TAB",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_DEL",                        "KC_BSPC", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_SPC",                        "KC_ENT",  "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "LALT(KC_GRV)",       "MO(1)",   "KC_SPC",  "KC_SPC",  "KC_SPC",  "KC_ENT",  "MO(2)",              "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_F11",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_LCBR",                       "KC_RCBR", "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F12",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_UNDS",                       "KC_PLUS", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_PIPE",
+      "KC_TAB",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_DEL",                        "KC_BSPC", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_COLN", "KC_DQUO",
+      "KC_LSFT", "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_SPC",                        "KC_ENT",  "KC_N",    "KC_M",    "KC_LT",   "KC_GT",   "KC_QUES", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "LALT(KC_GRV)",       "KC_TRNS", "KC_SPC",  "KC_SPC",  "KC_SPC",  "KC_ENT",  "MO(3)",              "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END"
+    ],
+    [
+      "KC_F11",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_LCBR",                       "KC_RCBR", "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F12",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_UNDS",                       "KC_PLUS", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_PIPE",
+      "KC_TAB",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_DEL",                        "KC_BSPC", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_COLN", "KC_DQUO",
+      "KC_LSFT", "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_SPC",                        "KC_ENT",  "KC_N",    "KC_M",    "KC_LT",   "KC_GT",   "KC_QUES", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "LALT(KC_GRV)",       "MO(3)",   "KC_SPC",  "KC_SPC",  "KC_SPC",  "KC_ENT",  "KC_TRNS",            "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "RESET",   "RGB_TOG", "RGB_MOD", "RGB_HUD", "RGB_HUI", "KC_TRNS",                       "KC_TRNS", "RGB_SAD", "RGB_SAI", "RGB_VAD", "RGB_VAI", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "BL_TOGG", "BL_BRTG", "BL_INC",  "BL_DEC",  "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/ergotravel_rev1_default.json
+++ b/public/keymaps/ergotravel_rev1_default.json
@@ -1,0 +1,32 @@
+{
+  "keyboard": "ergotravel/rev1",
+  "keymap": "default_39b5958",
+  "commit": "39b5958ae8dbcf374ab68366838acb5cbd380d94",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",               "KC_Q",     "KC_W",     "KC_E",     "KC_R",     "KC_T",     "KC_MINS",             "KC_EQL",   "KC_Y",     "KC_U",     "KC_I",     "KC_O",     "KC_P",     "KC_BSPC",
+      "KC_TAB",               "KC_A",     "KC_S",     "KC_D",     "KC_F",     "KC_G",     "KC_LBRC",             "KC_RBRC",  "KC_H",     "KC_J",     "KC_K",     "KC_L",     "KC_SCLN",  "KC_QUOT",
+      "KC_LSFT",              "KC_Z",     "KC_X",     "KC_C",     "KC_V",     "KC_B",     "KC_SPC",              "KC_SPC",   "KC_N",     "KC_M",     "KC_COMM",  "KC_DOT",   "KC_SLSH",  "KC_ENT",
+      "KC_LCTL",              "KC_LGUI",  "KC_LALT",  "MO(3)",                "MO(1)",    "KC_SPC",              "KC_SPC",   "MO(2)",                "KC_LEFT",  "KC_UP",    "KC_DOWN",  "KC_RGHT"
+    ],
+    [
+      "KC_TILD",              "KC_EXLM",  "KC_AT",    "KC_HASH",  "KC_DLR",   "KC_PERC",  "KC_HOME",             "KC_PGUP",  "KC_CIRC",  "KC_AMPR",  "KC_ASTR",  "KC_LPRN",  "KC_RPRN",  "KC_DEL",
+      "KC_TRNS",              "KC_F1",    "KC_F2",    "KC_F3",    "KC_F4",    "KC_F5",    "KC_END",              "KC_PGDN",  "KC_F6",    "KC_UNDS",  "KC_PLUS",  "KC_LCBR",  "KC_RCBR",  "KC_BSLS",
+      "KC_TRNS",              "KC_F7",    "KC_F8",    "KC_F9",    "KC_F10",   "KC_F11",   "KC_BSPC",             "KC_BSPC",  "KC_F12",   "KC_TRNS",  "KC_TRNS",  "KC_MUTE",  "KC_TRNS",  "KC_PIPE",
+      "KC_TRNS",              "KC_TRNS",  "KC_TRNS",  "KC_TRNS",              "KC_TRNS",  "KC_BSPC",             "KC_BSPC",  "KC_TRNS",              "KC_MNXT",  "KC_VOLD",  "KC_VOLU",  "KC_MPLY"
+    ],
+    [
+      "KC_ESC",               "KC_1",     "KC_2",     "KC_3",     "KC_4",     "KC_5",     "KC_TRNS",             "KC_TRNS",  "KC_6",     "KC_7",     "KC_8",     "KC_9",     "KC_0",     "KC_DEL",
+      "KC_TRNS",              "KC_4",     "KC_5",     "KC_6",     "KC_PLUS",  "KC_TRNS",  "KC_TRNS",             "KC_TRNS",  "KC_TRNS",  "KC_MINS",  "KC_EQL",   "KC_LBRC",  "KC_RBRC",  "KC_TRNS",
+      "KC_ENT",               "KC_7",     "KC_8",     "KC_9",     "KC_MINS",  "KC_TRNS",  "KC_TRNS",             "KC_TRNS",  "KC_TRNS",  "KC_NUHS",  "KC_NUBS",  "KC_MUTE",  "KC_TRNS",  "KC_BSLS",
+      "KC_TRNS",              "KC_COMM",  "KC_0",     "KC_DOT",               "KC_TRNS",  "KC_BSPC",             "KC_BSPC",  "KC_TRNS",              "KC_MNXT",  "KC_VOLD",  "KC_VOLU",  "KC_MPLY"
+    ],
+    [
+      "LCTL(LSFT(KC_ESC))",   "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",             "KC_TRNS",  "KC_TRNS",  "RGB_MOD",  "RGB_VAI",  "RGB_SAI",  "RGB_HUI",  "LCTL(LALT(KC_DEL))",
+      "KC_TRNS",              "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",             "KC_TRNS",  "KC_TRNS",  "RGB_RMOD", "RGB_VAD",  "RGB_SAD",  "RGB_HUD",  "RGB_TOG",
+      "KC_TRNS",              "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",             "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "BL_STEP",
+      "KC_TRNS",              "KC_TRNS",  "KC_TRNS",  "KC_TRNS",              "KC_TRNS",  "KC_TRNS",             "KC_TRNS",  "KC_TRNS",              "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "RESET"
+    ]
+  ]
+}

--- a/public/keymaps/evil80_default.json
+++ b/public/keymaps/evil80_default.json
@@ -1,0 +1,32 @@
+{
+  "keyboard": "evil80",
+  "keymap": "default_77433b1",
+  "commit": "77433b1a3140411b8b8f1b0389827c38384fc5fe",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",             "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",      "KC_PSCR", "KC_SLCK", "KC_PAUS",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",     "KC_INS",  "KC_HOME", "KC_PGUP",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",     "KC_DEL",  "KC_END",  "KC_PGDN",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUHS", "KC_ENT",
+      "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "MO(2)",                  "KC_UP",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "KC_RGUI", "KC_APP",  "KC_RCTL",     "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_ESC",             "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",      "KC_PSCR", "KC_SLCK", "KC_PAUS",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",     "KC_INS",  "KC_HOME", "KC_PGUP",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",     "KC_DEL",  "KC_END",  "KC_PGDN",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUHS", "KC_ENT",
+      "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "MO(2)",                  "KC_UP",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_NO",   "KC_RALT", "KC_RGUI", "KC_RCTL",     "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_TRNS",            "BL_ON",   "BL_OFF",  "BL_STEP", "BL_BRTG", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",     "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",     "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",     "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",     "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/fc980c_default.json
+++ b/public/keymaps/fc980c_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "fc980c",
+  "keymap": "default_67adc29",
+  "commit": "67adc29aa35719eea2de43bacf9cd5e8b5dfd79e",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",  "KC_INS",  "KC_PGUP", "KC_PGDN",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_NLCK", "KC_PSLS", "KC_PAST", "KC_PMNS",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_P7",   "KC_P8",   "KC_P9",   "KC_PPLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",  "KC_P4",   "KC_P5",   "KC_P6",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_P1",   "KC_P2",   "KC_P3",   "KC_PENT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                        "KC_RALT", "KC_RCTL", "MO(1)",   "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_P0",   "KC_PDOT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_HOME", "KC_END",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PGUP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                       "KC_TRNS", "KC_APP",  "KC_TRNS", "KC_HOME", "KC_PGDN", "KC_END",  "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/hhkb_default.json
+++ b/public/keymaps/hhkb_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "hhkb",
+  "keymap": "default_67adc29",
+  "commit": "67adc29aa35719eea2de43bacf9cd5e8b5dfd79e",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_GRV",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "MO(1)",
+                            "KC_LALT", "KC_LGUI",                       "KC_SPC",                                   "KC_RGUI", "KC_RALT"
+    ],
+    [
+      "KC_PWR",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_INS",  "KC_DEL",
+      "KC_CAPS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_UP",   "KC_TRNS", "KC_BSPC",
+      "KC_TRNS", "KC_VOLD", "KC_VOLU", "KC_MUTE", "KC_TRNS", "KC_TRNS", "KC_PAST", "KC_PSLS", "KC_HOME", "KC_PGUP", "KC_LEFT", "KC_RGHT",            "KC_PENT",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PPLS", "KC_PMNS", "KC_END",  "KC_PGDN", "KC_DOWN", "KC_TRNS", "KC_TRNS",
+                            "KC_TRNS", "KC_TRNS",                       "KC_TRNS",                                  "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/hotdox_default.json
+++ b/public/keymaps/hotdox_default.json
@@ -1,0 +1,65 @@
+{
+  "keyboard": "hotdox",
+  "keymap": "default_3e7a2c4",
+  "commit": "3e7a2c49a6e81ba51a8079494bb99f61942e3d7f",
+  "layout": "LAYOUT_ergodox",
+  "layers": [
+    [
+      "KC_EQL",       "KC_1",           "KC_2",          "KC_3",    "KC_4",    "KC_5",            "KC_LEFT",
+      "KC_DEL",       "KC_Q",           "KC_W",          "KC_E",    "KC_R",    "KC_T",            "TG(1)",
+      "KC_BSPC",      "KC_A",           "KC_S",          "KC_D",    "KC_F",    "KC_G",
+      "KC_LSFT",      "LCTL_T(KC_Z)",   "KC_X",          "KC_C",    "KC_V",    "KC_B",            "ALL_T(KC_NO)",
+      "LT(1,KC_GRV)", "KC_QUOT",        "LALT(KC_LSFT)", "KC_LEFT", "KC_RGHT",
+                                                                               "LALT_T(KC_APP)",  "KC_LGUI",
+                                                                                                  "KC_HOME",
+                                                                    "KC_SPC",  "KC_BSPC",         "KC_END",
+
+      "KC_RGHT",      "KC_6",           "KC_7",          "KC_8",    "KC_9",    "KC_0",            "KC_MINS",
+      "TG(1)",        "KC_Y",           "KC_U",          "KC_I",    "KC_O",    "KC_P",            "KC_BSLS",
+                      "KC_H",           "KC_J",          "KC_K",    "KC_L",    "LT(2,KC_SCLN)",   "LGUI_T(KC_QUOT)",
+      "MEH_T(KC_NO)", "KC_N",           "KC_M",          "KC_COMM", "KC_DOT",  "LCTL_T(KC_SLSH)", "KC_RSFT",
+                                        "KC_UP",         "KC_DOWN", "KC_LBRC", "KC_RBRC",         "MO(1)",
+      "KC_LALT",      "LCTL_T(KC_ESC)",
+      "KC_PGUP",
+      "KC_PGDN",      "KC_TAB",         "KC_ENT"
+    ],
+    [
+      "KC_NO",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_TRNS",
+      "KC_TRNS", "KC_EXLM", "KC_AT",   "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS",
+      "KC_TRNS", "KC_HASH", "KC_DLR",  "KC_LPRN", "KC_RPRN", "KC_GRV",
+      "KC_TRNS", "KC_PERC", "KC_CIRC", "KC_LBRC", "KC_RBRC", "KC_TILD", "KC_TRNS",
+      "EEP_RST", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+                                                             "RGB_MOD", "KC_TRNS",
+                                                                        "KC_TRNS",
+                                                  "RGB_VAD", "RGB_VAI", "KC_TRNS",
+
+      "KC_TRNS", "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",
+      "KC_TRNS", "KC_UP",   "KC_7",    "KC_8",    "KC_9",    "KC_ASTR", "KC_F12",
+                 "KC_DOWN", "KC_4",    "KC_5",    "KC_6",    "KC_PLUS", "KC_TRNS",
+      "KC_TRNS", "KC_AMPR", "KC_1",    "KC_2",    "KC_3",    "KC_BSLS", "KC_TRNS",
+                            "KC_TRNS", "KC_DOT",  "KC_0",    "KC_EQL",  "KC_TRNS",
+      "RGB_TOG", "RGB_M_P",
+      "KC_TRNS",
+      "KC_TRNS", "RGB_HUD", "RGB_HUI"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MS_U", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_MS_L", "KC_MS_D", "KC_MS_R", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_BTN1", "KC_BTN2",
+                                                             "KC_TRNS", "KC_TRNS",
+                                                                        "KC_TRNS",
+                                                  "KC_TRNS", "KC_TRNS", "KC_TRNS",
+
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+                 "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MPLY",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MPRV", "KC_MNXT", "KC_TRNS", "KC_TRNS",
+                            "KC_VOLU", "KC_VOLD", "KC_MUTE", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_WBAK"
+    ]
+  ]
+}

--- a/public/keymaps/idobo_default.json
+++ b/public/keymaps/idobo_default.json
@@ -1,0 +1,15 @@
+{
+  "keyboard": "idobo",
+  "keymap": "default_d6184be",
+  "commit": "d6184be67a56429a284c2d0fa5f990368a580735",
+  "layout": "LAYOUT_ortho_5x15",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_GRV",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC", "KC_DEL",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",  "KC_ENT",  "KC_PGUP",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_RSFT", "KC_UP",   "KC_PGDN",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_SPC",  "KC_SPC",  "KC_SPC",  "KC_SPC",  "KC_SPC",  "KC_SPC",  "KC_RALT", "KC_RCTL", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ]
+  ]
+}

--- a/public/keymaps/jc65_v32u4_default.json
+++ b/public/keymaps/jc65_v32u4_default.json
@@ -1,0 +1,15 @@
+{
+  "keyboard": "jc65/v32u4",
+  "keymap": "default_ac05cdd",
+  "commit": "ac05cdd1f8ebda53b6dac959843b7dd7b7602f0c",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_BSPC", "KC_INS",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_DEL",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",             "KC_PGUP",
+      "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",            "KC_UP",   "KC_PGDN",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",  "KC_SPC",  "KC_SPC",                        "KC_RALT", "KC_RGUI", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ]
+  ]
+}

--- a/public/keymaps/kbdfans_kbd19x_default.json
+++ b/public/keymaps/kbdfans_kbd19x_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "kbdfans/kbd19x",
+  "keymap": "default_b49dbf9",
+  "commit": "b49dbf9b19264e7558253a34ca737dcd301487b1",
+  "layout": "LAYOUT_ansi",
+  "layers": [
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "BL_STEP",            "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_PGDN",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",            "KC_NLCK", "KC_PSLS", "KC_PAST", "KC_PMNS",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_P7",   "KC_P8",   "KC_P9",   "KC_PPLS",
+      "KC_CAPS",            "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",             "KC_P4",   "KC_P5",   "KC_P6",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",      "KC_RSFT",    "KC_UP",      "KC_P1",   "KC_P2",   "KC_P3",   "KC_PENT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                        "KC_RALT", "MO(1)",   "KC_RCTL",         "KC_LEFT", "KC_DOWN", "KC_RGHT",    "KC_P0",   "KC_PDOT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RGB_TOG",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",              "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS",    "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS",         "KC_TRNS", "KC_TRNS", "KC_TRNS",    "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/kbdfans_kbd67_hotswap_default.json
+++ b/public/keymaps/kbdfans_kbd67_hotswap_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "kbdfans/kbd67/hotswap",
+  "keymap": "default_b49dbf9",
+  "commit": "b49dbf9b19264e7558253a34ca737dcd301487b1",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_DEL",  "KC_HOME",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",            "KC_PGUP",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",             "KC_PGDN",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",                       "KC_UP",   "KC_END",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",                                   "KC_RALT", "MO(1)",                         "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS",                                  "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/kbdfans_kbd67_rev1_default.json
+++ b/public/keymaps/kbdfans_kbd67_rev1_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "kbdfans/kbd67/rev1",
+  "keymap": "default_f9f04ff",
+  "commit": "f9f04ff2a4318798a79e6ec242ae773fdb80b069",
+  "layout": "LAYOUT_65_ansi",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_HOME",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_PGUP",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",  "KC_PGDN",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",            "KC_UP",   "KC_END",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",                                   "KC_RALT", "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",  "KC_INS",
+      "KC_CAPS", "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_HOME", "KC_PGUP", "KC_LEFT", "KC_RGHT",            "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_END",  "KC_PGDN", "KC_DOWN", "KC_TRNS",            "KC_PGUP", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_HOME", "KC_PGDN", "KC_END"
+    ]
+  ]
+}

--- a/public/keymaps/kbdfans_kbd6x_default.json
+++ b/public/keymaps/kbdfans_kbd6x_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "kbdfans/kbd6x",
+  "keymap": "default_b49dbf9",
+  "commit": "b49dbf9b19264e7558253a34ca737dcd301487b1",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_DEL",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "MO(1)",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",                        "KC_RALT", "KC_RGUI", "KC_RCTL"
+    ],
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "BL_DEC",  "BL_TOGG", "BL_INC",  "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/kbdfans_kbd75_rev1_default.json
+++ b/public/keymaps/kbdfans_kbd75_rev1_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "kbdfans/kbd75/rev1",
+  "keymap": "default_b49dbf9",
+  "commit": "b49dbf9b19264e7558253a34ca737dcd301487b1",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_PSCR", "MO(1)",   "KC_DEL",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_DEL",  "KC_BSPC", "KC_HOME",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_PGUP",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",                       "KC_ENT",  "KC_PGDN",
+      "KC_LSFT", "MO(1)",   "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",            "KC_UP",   "KC_END",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",  "KC_SPC",  "KC_SPC",                        "KC_RALT", "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",   "KC_TRNS",
+      "KC_TRNS", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "BL_DEC",  "BL_TOGG", "BL_INC",  "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/kbdfans_kbd75_rev2_default.json
+++ b/public/keymaps/kbdfans_kbd75_rev2_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "kbdfans/kbd75/rev1",
+  "keymap": "default_rev2_b49dbf9",
+  "commit": "b49dbf9b19264e7558253a34ca737dcd301487b1",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_PSCR", "MO(1)",   "KC_DEL",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_DEL",  "KC_BSPC", "KC_HOME",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_PGUP",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",                       "KC_ENT",  "KC_PGDN",
+      "KC_LSFT", "MO(1)",   "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",            "KC_UP",   "KC_END",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",  "KC_SPC",  "KC_SPC",                        "KC_RALT", "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",   "KC_TRNS",
+      "KC_TRNS", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "BL_DEC",  "BL_TOGG", "BL_INC",  "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/keebio_bdn9_default.json
+++ b/public/keymaps/keebio_bdn9_default.json
@@ -1,0 +1,18 @@
+{
+  "keyboard": "keebio/bdn9",
+  "keymap": "default_b2ee290",
+  "commit": "b2ee290c9f506e42dd9c4577c8147646c405aeb0",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_MUTE", "KC_HOME", "KC_MPLY",
+      "MO(1)",   "KC_UP",   "RGB_MOD",
+      "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "RESET",   "BL_STEP", "KC_STOP",
+      "KC_TRNS", "KC_HOME", "RGB_MOD",
+      "KC_MPRV", "KC_END",  "KC_MNXT"
+    ]
+  ]
+}

--- a/public/keymaps/keebio_nyquist_rev1_default.json
+++ b/public/keymaps/keebio_nyquist_rev1_default.json
@@ -1,0 +1,50 @@
+{
+  "keyboard": "keebio/nyquist/rev1",
+  "keymap": "default_b2ee290",
+  "commit": "b2ee290c9f506e42dd9c4577c8147646c405aeb0",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",       "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_TRNS", "RESET",   "RGB_TOG", "RGB_MOD", "RGB_HUD", "RGB_HUI", "RGB_SAD", "RGB_SAI", "RGB_VAD", "RGB_VAI", "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "TO(0)",   "TO(1)",   "TO(2)",   "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/keebio_nyquist_rev2_default.json
+++ b/public/keymaps/keebio_nyquist_rev2_default.json
@@ -1,0 +1,50 @@
+{
+  "keyboard": "keebio/nyquist/rev2",
+  "keymap": "default_b2ee290",
+  "commit": "b2ee290c9f506e42dd9c4577c8147646c405aeb0",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",       "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_TRNS", "RESET",   "RGB_TOG", "RGB_MOD", "RGB_HUD", "RGB_HUI", "RGB_SAD", "RGB_SAI", "RGB_VAD", "RGB_VAI", "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "TO(0)",   "TO(1)",   "TO(2)",   "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/keebio_nyquist_rev3_default.json
+++ b/public/keymaps/keebio_nyquist_rev3_default.json
@@ -1,0 +1,50 @@
+{
+  "keyboard": "keebio/nyquist/rev3",
+  "keymap": "default_b2ee290",
+  "commit": "b2ee290c9f506e42dd9c4577c8147646c405aeb0",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",       "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_TRNS", "RESET",   "RGB_TOG", "RGB_MOD", "RGB_HUD", "RGB_HUI", "RGB_SAD", "RGB_SAI", "RGB_VAD", "RGB_VAI", "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "TO(0)",   "TO(1)",   "TO(2)",   "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/keebio_quefrency_rev1_default.json
+++ b/public/keymaps/keebio_quefrency_rev1_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "keebio/quefrency/rev1",
+  "keymap": "default_b2ee290",
+  "commit": "b2ee290c9f506e42dd9c4577c8147646c405aeb0",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_GESC",  "KC_1",     "KC_2",     "KC_3",     "KC_4",     "KC_5",     "KC_6",     "KC_7",     "KC_8",     "KC_9",     "KC_0",     "KC_MINS",  "KC_EQL",   "KC_DEL",   "KC_BSPC",
+      "KC_TAB",   "KC_Q",     "KC_W",     "KC_E",     "KC_R",     "KC_T",     "KC_Y",     "KC_U",     "KC_I",     "KC_O",     "KC_P",     "KC_LBRC",  "KC_RBRC",  "KC_BSLS",
+      "KC_CAPS",  "KC_A",     "KC_S",     "KC_D",     "KC_F",     "KC_G",     "KC_H",     "KC_J",     "KC_K",     "KC_L",     "KC_SCLN",  "KC_QUOT",  "KC_ENT",
+      "KC_LSFT",  "KC_Z",     "KC_X",     "KC_C",     "KC_V",     "KC_B",     "KC_N",     "KC_M",     "KC_COMM",  "KC_DOT",   "KC_SLSH",  "KC_RSFT",  "KC_UP",
+      "KC_LCTL",  "KC_LALT",  "KC_LGUI",  "MO(1)",    "KC_SPC",   "MO(1)",    "KC_BSPC",  "KC_RALT",  "KC_RCTL",  "KC_LEFT",  "KC_DOWN",  "KC_RGHT"
+    ],
+    [
+      "KC_GESC",  "KC_F1",    "KC_F2",    "KC_F3",    "KC_F4",    "KC_F5",    "KC_F6",    "KC_F7",    "KC_F8",    "KC_F9",    "KC_F10",   "KC_F11",   "KC_F12",   "KC_DEL",   "KC_BSPC",
+      "RGB_TOG",  "RGB_MOD",  "KC_TRNS",  "KC_UP",    "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",
+      "KC_TRNS",  "KC_TRNS",  "KC_LEFT",  "KC_DOWN",  "KC_RGHT",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",
+      "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",
+      "KC_TILD",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/keebio_viterbi_rev1_default.json
+++ b/public/keymaps/keebio_viterbi_rev1_default.json
@@ -1,0 +1,36 @@
+{
+  "keyboard": "keebio/viterbi/rev1",
+  "keymap": "default_b2ee290",
+  "commit": "b2ee290c9f506e42dd9c4577c8147646c405aeb0",
+  "layout": "LAYOUT_ortho_5x14",
+  "layers": [
+    [
+      "KC_INS",  "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "KC_DEL",
+      "KC_MINS", "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC",
+      "KC_EQL",  "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_PGUP", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_HOME", "KC_END",
+      "KC_PGDN", "MO(3)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(1)",   "KC_SPC",  "KC_SPC",  "MO(2)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_BSLS"
+    ],
+    [
+      "KC_TRNS", "KC_TILD", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_UNDS", "KC_TRNS", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_LCBR", "KC_RCBR",
+      "KC_PLUS", "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS", "KC_PLUS", "KC_LCBR", "KC_RCBR", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(3)",   "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY", "KC_MUTE"
+    ],
+    [
+      "KC_TRNS", "KC_TILD", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_UNDS", "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_LCBR", "KC_RCBR",
+      "KC_PLUS", "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(3)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY", "KC_MUTE"
+    ],
+    [
+      "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "RESET",   "RGB_TOG", "RGB_MOD", "RGB_HUD", "RGB_HUI", "RGB_SAD", "RGB_SAI", "RGB_VAD", "RGB_VAI", "KC_TRNS", "KC_DEL",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "TO(0)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/keebio_viterbi_rev2_default.json
+++ b/public/keymaps/keebio_viterbi_rev2_default.json
@@ -1,0 +1,36 @@
+{
+  "keyboard": "keebio/viterbi/rev2",
+  "keymap": "default_b2ee290",
+  "commit": "b2ee290c9f506e42dd9c4577c8147646c405aeb0",
+  "layout": "LAYOUT_ortho_5x14",
+  "layers": [
+    [
+      "KC_INS",  "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "KC_DEL",
+      "KC_MINS", "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC",
+      "KC_EQL",  "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_PGUP", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_HOME", "KC_END",
+      "KC_PGDN", "MO(3)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(1)",   "KC_SPC",  "KC_SPC",  "MO(2)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_BSLS"
+    ],
+    [
+      "KC_TRNS", "KC_TILD", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_UNDS", "KC_TRNS", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_LCBR", "KC_RCBR",
+      "KC_PLUS", "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS", "KC_PLUS", "KC_LCBR", "KC_RCBR", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(3)",   "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY", "KC_MUTE"
+    ],
+    [
+      "KC_TRNS", "KC_TILD", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_UNDS", "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_LCBR", "KC_RCBR",
+      "KC_PLUS", "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(3)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY", "KC_MUTE"
+    ],
+    [
+      "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "RESET",   "RGB_TOG", "RGB_MOD", "RGB_HUD", "RGB_HUI", "RGB_SAD", "RGB_SAI", "RGB_VAD", "RGB_VAI", "KC_TRNS", "KC_DEL",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "TO(0)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/kinesis_stapelberg_default.json
+++ b/public/keymaps/kinesis_stapelberg_default.json
@@ -1,0 +1,29 @@
+{
+  "keyboard": "kinesis/stapelberg",
+  "keymap": "default_67adc29",
+  "commit": "67adc29aa35719eea2de43bacf9cd5e8b5dfd79e",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",
+      "KC_EQL",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",
+                 "KC_GRV",  "KC_INS",  "KC_LEFT", "KC_RGHT",
+                                                             "KC_LCTL", "KC_LALT",
+                                                                          "KC_HOME",
+                                                    "KC_BSPC", "KC_DEL",  "KC_END",
+
+      "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_FN0",  "KC_1",
+                                       "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS",
+                                       "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSLS",
+                                       "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+                                       "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+                                                  "KC_UP",   "KC_DOWN", "KC_LBRC", "KC_RBRC",
+                            "KC_RGUI", "KC_RCTL",
+                            "KC_PGUP",
+                            "KC_PGDN", "KC_ENT",  "KC_SPC"
+    ]
+  ]
+}

--- a/public/keymaps/lets_split_rev1_default.json
+++ b/public/keymaps/lets_split_rev1_default.json
@@ -1,0 +1,44 @@
+{
+  "keyboard": "lets_split/rev1",
+  "keymap": "default_161afe2",
+  "commit": "161afe2e54e14b210b30539bd8a100471bcdf2c3",
+  "layout": "LAYOUT_ortho_4x12",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",       "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_TRNS", "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "TO(0)",   "TO(1)",   "TO(2)",   "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/lets_split_rev2_default.json
+++ b/public/keymaps/lets_split_rev2_default.json
@@ -1,0 +1,44 @@
+{
+  "keyboard": "lets_split/rev2",
+  "keymap": "default_161afe2",
+  "commit": "161afe2e54e14b210b30539bd8a100471bcdf2c3",
+  "layout": "LAYOUT_ortho_4x12",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",       "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_TRNS", "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "TO(0)",   "TO(1)",   "TO(2)",   "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/lily58_rev1_default.json
+++ b/public/keymaps/lily58_rev1_default.json
@@ -1,0 +1,36 @@
+{
+  "keyboard": "lily58/rev1",
+  "keymap": "defaultish_28e182b",
+  "commit": "28e182bc8a2976562e0d76a1332527e0a4be81ea",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                          "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_GRV",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                          "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_MINS",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                          "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_LBRC", "KC_RBRC", "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+                                       "KC_LALT", "KC_LGUI", "MO(1)",   "KC_SPC",  "KC_ENT",  "MO(2)",   "KC_BSPC", "KC_RGUI"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",                         "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_GRV",  "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC",                       "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_TILD",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_NO",   "KC_UNDS", "KC_PLUS", "KC_LCBR", "KC_RCBR", "KC_PIPE",
+                                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                          "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_TRNS",
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",                         "KC_NO",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_NO",
+      "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS", "KC_PLUS", "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+                                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                         "KC_NO",   "KC_NO",   "RGB_TOG", "RGB_HUI", "RGB_SAI", "RGB_VAI",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RGB_MOD", "RGB_HUD", "RGB_SAD", "RGB_VAD",
+                                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/melody96_default.json
+++ b/public/keymaps/melody96_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "melody96",
+  "keymap": "default_118e948",
+  "commit": "118e948e355b784b22f94378b5f85285e6dd4634",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_PSCR", "KC_HOME", "KC_END",  "KC_PGUP", "KC_PGDN", "KC_DEL",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_BSPC", "KC_NLCK", "KC_PSLS", "KC_PAST", "KC_PMNS",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_P7",   "KC_P8",   "KC_P9",   "KC_PMNS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",                        "KC_P4",   "KC_P5",   "KC_P6",   "KC_PPLS",
+      "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",            "KC_UP",   "KC_P1",   "KC_P2",   "KC_P3",   "KC_PENT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "MO(1)",   "MO(1)",   "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_P0",   "KC_PDOT", "KC_PENT"
+    ],
+    [
+      "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "RGB_TOG", "KC_TRNS", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "BL_TOGG", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "BL_DEC",  "BL_TOGG", "BL_INC",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/niu_mini_default.json
+++ b/public/keymaps/niu_mini_default.json
@@ -1,0 +1,26 @@
+{
+  "keyboard": "niu_mini",
+  "keymap": "default_e2d3c92",
+  "commit": "e2d3c92199d6cc42a39c5d8729dfff61d78dd7d1",
+  "layout": "LAYOUT_planck_mit",
+  "layers": [
+    [
+      "KC_ESC",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_TAB",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_UP",   "KC_ENT",
+      "KC_LCTL", "KC_LGUI", "KC_CAPS", "KC_LALT", "MO(1)",        "KC_SPC",        "MO(2)",   "KC_SLSH", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_TRNS",
+      "KC_TRNS", "KC_VOLD", "KC_VOLU", "KC_MUTE", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS",       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_TRNS",
+      "KC_TRNS", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "KC_TRNS", "KC_TRNS", "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "BL_TOGG", "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS",       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/plaid_default.json
+++ b/public/keymaps/plaid_default.json
@@ -1,0 +1,50 @@
+{
+  "keyboard": "plaid",
+  "keymap": "defaultis_2f3dbb1",
+  "commit": "2f3dbb1253839fad1bb2e20db8ef7b88c5fd331a",
+  "layout": "LAYOUT_plaid_grid",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "KC_LCTL", "KC_RALT", "KC_LALT", "KC_LGUI", "MO(4)",   "KC_SPC",  "KC_SPC",  "MO(5)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "KC_LCTL", "KC_RALT", "KC_LALT", "KC_LGUI", "MO(4)",   "KC_SPC",  "KC_SPC",  "MO(5)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "KC_LCTL", "KC_RALT", "KC_LALT", "KC_LGUI", "MO(4)",   "KC_SPC",  "KC_SPC",  "MO(5)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",       "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",
+      "KC_NO",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC",
+      "KC_NO",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "TO(0)",   "KC_NO",   "KC_NO",   "KC_C",    "KC_V",    "KC_NO",   "KC_NO",   "KC_N",    "KC_M",    "KC_NO",   "KC_NO",   "KC_NO"
+    ],
+    [
+      "KC_TRNS", "RESET",   "DEBUG",   "RGB_TOG", "RGB_MOD", "RGB_HUI",              "RGB_HUD",            "RGB_SAI", "RGB_SAD",  "RGB_VAI", "RGB_VAD", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "MAGIC_UNSWAP_ALT_GUI", "MAGIC_SWAP_ALT_GUI", "TO(0)",   "TO(1)",    "TO(2)",   "TO(5)",   "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",                "MI_OFF",             "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",              "KC_TRNS",            "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/sentraq_s60_x_default_default.json
+++ b/public/keymaps/sentraq_s60_x_default_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "sentraq/s60_x/default",
+  "keymap": "default_e2d3c92",
+  "commit": "e2d3c92199d6cc42a39c5d8729dfff61d78dd7d1",
+  "layout": "LAYOUT_60_ansi",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "MO(1)",   "KC_APP",  "KC_RCTL"
+    ],
+    [
+      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PGUP", "KC_PGDN", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_TRNS",
+      "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/sentraq_s60_x_rgb_default.json
+++ b/public/keymaps/sentraq_s60_x_rgb_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "sentraq/s60_x/rgb",
+  "keymap": "default_e2d3c92",
+  "commit": "e2d3c92199d6cc42a39c5d8729dfff61d78dd7d1",
+  "layout": "LAYOUT_60_ansi",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "MO(1)",   "KC_APP",  "KC_RCTL"
+    ],
+    [
+      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PGUP", "KC_PGDN", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_TRNS",
+      "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/sentraq_s65_x_default.json
+++ b/public/keymaps/sentraq_s65_x_default.json
@@ -1,0 +1,36 @@
+{
+  "keyboard": "sentraq/s65_x",
+  "keymap": "default_9b232a7",
+  "commit": "9b232a7f885e320061aae994713acd31297eac5c",
+  "layout": "LAYOUT_65_ansi",
+  "layers": [
+    [
+      "KC_GESC",       "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_DEL",
+      "KC_TAB",        "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_END",
+      "LT(2,KC_CAPS)", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",  "KC_PGUP",
+      "KC_LSFT",                  "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_PGDN",
+      "KC_LCTL",       "KC_LGUI", "KC_LALT",                       "KC_SPC",                                   "KC_RALT", "MO(2)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_TRNS",       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",       "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",       "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",       "AG_SWAP", "AG_NORM",                       "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_GRV",        "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",       "TG(1)",   "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PGUP", "KC_PGDN", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",       "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",                  "TG(3)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_HOME", "KC_END",  "KC_TRNS", "KC_TRNS", "KC_VOLU", "KC_TRNS",
+      "KC_TRNS",       "KC_TRNS", "KC_TRNS",                       "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MUTE", "KC_VOLD", "KC_MPLY"
+    ],
+    [
+      "KC_TRNS",       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",       "BL_TOGG", "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",       "RGB_TOG", "RGB_MOD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",                  "KC_TRNS", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",       "KC_TRNS", "KC_TRNS",                       "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/thevankeyboards_minivan_default.json
+++ b/public/keymaps/thevankeyboards_minivan_default.json
@@ -1,0 +1,44 @@
+{
+  "keyboard": "thevankeyboards/minivan",
+  "keymap": "default_e2d3c92",
+  "commit": "e2d3c92199d6cc42a39c5d8729dfff61d78dd7d1",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "MO(3)",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "MO(3)",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "MO(4)",
+      "KC_LCTL", "MO(4)",   "KC_LGUI",                       "KC_ENT",  "KC_SPC",                        "KC_RALT", "KC_ESC",  "TG(5)"
+    ],
+    [
+      "KC_TAB",  "KC_SLSH", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "MO(3)",   "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "MO(3)",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "MO(4)",
+      "KC_LCTL", "MO(4)",   "KC_LGUI",                       "KC_ENT",  "KC_SPC",                        "KC_RALT", "KC_ESC",  "TG(5)"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "MO(3)",   "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "MO(3)",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "MO(4)",
+      "KC_LCTL", "MO(4)",   "KC_LGUI",                       "KC_ENT",  "KC_SPC",                        "KC_RALT", "KC_ESC",  "TG(5)"
+    ],
+    [
+      "KC_GRV",  "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_TRNS", "KC_BSLS", "KC_QUOT", "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_DOWN", "KC_UP",   "KC_LEFT", "KC_RGHT", "KC_TRNS",
+      "KC_TRNS", "KC_ESC",  "KC_TRNS", "KC_PSCR", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MSTP", "KC_MPLY", "KC_MPRV", "KC_MNXT", "KC_RSFT",
+      "KC_TRNS", "KC_LGUI", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_TRNS", "DF(0)",   "DF(1)",   "DF(2)",   "KC_TRNS", "KC_TRNS",       "KC_TRNS",       "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_TRNS",
+      "KC_ESC",  "KC_PIPE", "KC_DQUO", "KC_UNDS", "KC_PLUS", "LSFT(KC_LBRC)", "LSFT(KC_RBRC)", "KC_4",    "KC_5",    "KC_6",    "KC_VOLU", "KC_ENT",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",       "KC_0",          "KC_1",    "KC_2",    "KC_3",    "KC_VOLD", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS",       "KC_TRNS",                             "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_TRNS",
+      "KC_ESC",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_TRNS",
+      "KC_LSFT", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS",
+      "KC_TRNS", "KC_LSFT", "KC_B",                          "KC_SPC",  "KC_C",                          "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/tokyo60_default.json
+++ b/public/keymaps/tokyo60_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "tokyo60",
+  "keymap": "default_83df694",
+  "commit": "83df69488d1357ab2556180b30dc6cb4611218ad",
+  "layout": "LAYOUT_60_hhkb",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_GRV",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "MO(1)",
+                 "KC_LALT", "KC_LGUI",                       "KC_SPC",                                   "KC_RGUI", "KC_RALT"
+    ],
+    [
+      "KC_PWR",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_INS",  "KC_DEL",
+      "KC_CAPS", "RGB_TOG", "RGB_MOD", "RGB_RMOD","BL_TOGG", "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_UP",   "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_VOLD", "KC_VOLU", "KC_MUTE", "KC_EJCT", "KC_TRNS", "KC_PAST", "KC_PSLS", "KC_HOME", "KC_PGUP", "KC_LEFT", "KC_RGHT", "KC_PENT",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PPLS", "KC_PMNS", "KC_END",  "KC_PGDN", "KC_DOWN", "KC_TRNS", "KC_TRNS",
+                 "KC_TRNS", "KC_TRNS",                       "KC_TRNS",                                  "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/xd60_rev3_default.json
+++ b/public/keymaps/xd60_rev3_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "xd60/rev3",
+  "keymap": "default_0072fdd",
+  "commit": "0072fdd799ffe61bf64f12c23335da3adeb083e5",
+  "layout": "LAYOUT_all",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_GRV",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC",            "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NO",              "KC_ENT",
+      "KC_LSFT", "KC_NO",   "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_DEL",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RGUI", "MO(1)",   "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "RESET",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_F13",  "KC_F14",
+      "KC_NO",   "KC_WH_U", "KC_UP",   "KC_WH_D", "KC_BSPC", "KC_HOME", "KC_CALC", "KC_NO",   "KC_INS",  "KC_NO",   "KC_PSCR", "KC_SLCK", "KC_PAUS",            "KC_DEL",
+      "KC_NO",   "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_DEL",  "KC_END",  "KC_PGDN", "KC_NO",   "KC_NO",   "KC_NO",   "KC_HOME", "KC_PGUP", "KC_NO",              "KC_ENT",
+      "KC_LSFT", "KC_NO",   "KC_NO",   "KC_APP",  "BL_STEP", "KC_NO",   "KC_NO",   "KC_VOLD", "KC_VOLU", "KC_MUTE", "KC_END",  "KC_PGDN", "KC_RSFT", "KC_PGUP", "KC_INS",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RGUI", "MO(1)",   "KC_HOME", "KC_PGDN", "KC_END"
+    ]
+  ]
+}

--- a/public/keymaps/xd75_default.json
+++ b/public/keymaps/xd75_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "xd75",
+  "keymap": "default_e30c993",
+  "commit": "e30c993d75b2edd78c185a5d5f33f2fe10635eb5",
+  "layout": "LAYOUT_ortho_5x15",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_MINS", "KC_GRV",  "KC_EQL",  "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_LBRC", "KC_BSLS", "KC_RBRC", "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_QUOT",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_HOME", "KC_DEL",  "KC_PGUP", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_ENT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_END",  "KC_UP",   "KC_PGDN", "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "MO(1)",   "KC_SPC",  "KC_SPC",  "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_SPC",  "KC_SPC",  "MO(1)",   "KC_RALT", "KC_RGUI", "KC_RCTL"
+    ],
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_NLCK", "KC_SLSH", "KC_ASTR", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_MSEL", "KC_CALC", "KC_MYCM", "KC_MAIL", "RGB_HUD", "RGB_HUI", "KC_P7",   "KC_P8",   "KC_P9",   "KC_MINS", "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_SLCK", "KC_PAUS",
+      "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MSTP", "RGB_SAD", "RGB_SAI", "KC_P4",   "KC_P5",   "KC_P6",   "KC_PLUS", "KC_TRNS", "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_VOLD", "KC_MUTE", "KC_VOLU", "KC_APP",  "RGB_VAD", "RGB_VAI", "KC_P1",   "KC_P2",   "KC_P3",   "KC_PENT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "RGB_TOG", "MO(1)",   "RGB_RMOD","RGB_MOD", "KC_P0",   "KC_TRNS", "KC_PDOT", "KC_PENT", "KC_PENT", "MO(1)",   "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/yd68_default.json
+++ b/public/keymaps/yd68_default.json
@@ -1,0 +1,15 @@
+{
+  "keyboard": "yd68",
+  "keymap": "default_92d95ba",
+  "commit": "92d95ba1e1223538f8c16fe2d17a23fa0dd67725",
+  "layout": "LAYOUT_ansi",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_HOME",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_END",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",  "KC_PGUP",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_PGDN",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                        "KC_RALT", "KC_RGUI", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ]
+  ]
+}

--- a/public/keymaps/zlant_default.json
+++ b/public/keymaps/zlant_default.json
@@ -1,0 +1,20 @@
+{
+  "keyboard": "zlant",
+  "keymap": "default_17d3750",
+  "commit": "17d3750f13b720b5f57c0c8127b177fe41fafe26",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_ESC",  "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "RGB_HUI", "RGB_HUD", "KC_LGUI", "KC_LALT", "KC_LSFT", "KC_SPC",  "KC_SPC",  "MO(1)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_TRNS",
+      "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_PGUP", "KC_HOME", "KC_TRNS", "KC_TRNS",
+      "RGB_VAI", "RGB_VAD", "RESET",   "KC_PSCR", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PGDN", "KC_END",  "KC_TRNS", "KC_DEL"
+    ]
+  ]
+}


### PR DESCRIPTION
## Notes

All of these were tested and compile without errors.

The default keymap for the KBDfans KBD75 rev2 uses the KBD75 rev1 as its keyboard because Configurator doesn't handle source file inclusion quite the same way as compiling from source.

The resulting .hex file is compatible with both revs. 1 and 2 for the KBD75.
