### PR TITLE
Fix off-by-one errors in Potato Facts feature

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -81,8 +81,8 @@ export default {
   methods: {
     ...mapMutations('app', ['setShowSpinner', 'setSettingsPanel']),
     randomPotatoFact() {
-      const len = size(this.$t('message.potato')) - 1;
-      this.potatoFact = this.$t('message.potato.' + random(0, len));
+      const len = size(this.$t('message.potato'));
+      this.potatoFact = this.$t('message.potato.' + random(1, len));
     },
     dismiss() {
       this.setShowSpinner(false);


### PR DESCRIPTION
Fixes two off-by-one errors in the loading of the Potato Facts.

1. Function could attempt to load an index 0, which never existed because the Potato Fact indexes start from 1.
2. Function was setting the maximum index to one less than it should have been, causing the last Potato Fact to never be used.