### PR TITLE
Whitelist the characters we allow in keymap names

### DIFF
--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -55,6 +55,8 @@ const getters = {
     if (exportName === '') {
       exportName = `${state.keyboard}_${state.layout}_mine`.toLowerCase();
     }
+    // issue #331 whitelist what we send to API for keymapName and save to disk
+    exportName = exportName.replace(/[^a-z0-9_-]/gi, '');
     return exportName;
   },
   compileDisabled: state => state.compileDisabled,


### PR DESCRIPTION
 - prevent people sending invalid keymap names to the API or saving to the disk

Issue #331 

All characters not in a-z0-9_ are removed from filenames saved to disk and sent to API. I do not prevent users from inputting them. I just ignore them.