### PR TITLE
Issue 329 Prevent invalid layer input

### DIFF
--- a/src/components/LayerKey.vue
+++ b/src/components/LayerKey.vue
@@ -15,6 +15,7 @@
     @dragenter.prevent="dragenter"
     >{{ displayName }}<div><input
       class="key-layer-input"
+      :class="errorClasses"
       type="number"
       :value="value"
       @focus="focus"
@@ -35,25 +36,43 @@ import BaseKey from './BaseKey';
 export default {
   name: 'layer-key',
   extends: BaseKey,
+  data() {
+    return {
+      error: false
+    };
+  },
   computed: {
     ...mapGetters('keymap', {
       curLayer: 'layer'
     }),
     value() {
       return this.meta.layer;
+    },
+    errorClasses() {
+      if (this.error) {
+        return 'input-error';
+      }
+      return '';
     }
   },
   methods: {
+    ...mapMutations('app', ['setHasErrors', 'setHasNoErrors']),
     ...mapMutations('keymap', ['setText']),
     ...mapActions('keymap', ['setKeycodeLayer']),
     input(e) {
       const toLayer = parseInt(e.target.value, 10);
       if (!isNaN(toLayer) && isNumber(toLayer)) {
+        this.error = toLayer < 0 || toLayer > 15;
         this.setKeycodeLayer({
           layer: this.curLayer,
           index: this.id,
           toLayer
         });
+      }
+      if (this.error) {
+        this.setHasErrors();
+      } else {
+        this.setHasNoErrors();
       }
     },
     blur() {
@@ -66,3 +85,9 @@ export default {
   }
 };
 </script>
+<style>
+.key-layer-input.input-error {
+  outline-color: red;
+  border-color: red;
+}
+</style>

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -262,6 +262,12 @@ const mutations = {
   },
   toggleSettingsPanel(state) {
     state.settingsPanelVisible = !state.settingsPanelVisible;
+  },
+  setHasErrors(state) {
+    mutations.disableCompile(state);
+  },
+  setHasNoErrors(state) {
+    mutations.enableCompile(state);
   }
 };
 


### PR DESCRIPTION
 - if a layer key is input with a range less than 0 or greater than 15
   - indicate visually the key is in error
   - prevent compilation

In screenshot, compile button is disabled and red indicator around bad input value

![Screen Shot 2019-05-04 at 19 19 53](https://user-images.githubusercontent.com/2275667/57187349-d68f0d00-6ea1-11e9-902c-52d19a1436eb.png)
