### PR TITLE
Fix Modifier keycode handling

### DIFF
--- a/src/components/colorways/modCodes.js
+++ b/src/components/colorways/modCodes.js
@@ -2,7 +2,7 @@ export default {
   /*
    * List of keycodes that considered mods
    */
-  modCodes: [
+  ... [
     'KC_F1',
     'KC_F2',
     'KC_F3',


### PR DESCRIPTION
The component that was supposed to handle the lookup table of modifier keycodes for the colorway system wasn't working.