### PR TITLE
Updated Keyboard Exclusion List: 2019-05-13 part 2

### DIFF
--- a/src/jquery.js
+++ b/src/jquery.js
@@ -309,12 +309,13 @@ function getExclusionList() {
     'ps2avrGB',
     'qwertyydox',
     'redox',
+    'rgbkb/sol',
+    'rgbkb/zen',
+    'rgbkb/zygomorph',
     'sentraq/s60_x',
-    'sol',
     'treadstone48',
     'vitamins_included',
     'yosino58',
-    'zen',
     'zinc'
   ].reduce((acc, k) => {
     acc[k] = true;


### PR DESCRIPTION
Now featuring the RGBKB Edition of the Keyboard Exclusion list.

Figures I would deliberately leave these changes off of the last PR, knowing the keyboards were going to move, only to discover the PR that moved them had already been merged without me noticing. :frowning_face: 