### PR TITLE
Patch RGBKB default keymaps

### DIFF
--- a/public/keymaps/rgbkb_sol_rev1_default.json
+++ b/public/keymaps/rgbkb_sol_rev1_default.json
@@ -1,6 +1,6 @@
 {
   "keyboard": "rgbkb/sol/rev1",
-  "keymap": "default",
+  "keymap": "default_4cdb86c",
   "commit": "4cdb86c730528c8ca5ff90f5b9b01c395d31fc0e",
   "layout": "LAYOUT",
   "layers": [

--- a/public/keymaps/rgbkb_zen_rev1_default.json
+++ b/public/keymaps/rgbkb_zen_rev1_default.json
@@ -1,6 +1,6 @@
 {
   "keyboard": "rgbkb/zen/rev1",
-  "keymap": "default",
+  "keymap": "default_4cdb86c",
   "commit": "4cdb86c730528c8ca5ff90f5b9b01c395d31fc0e",
   "layout": "LAYOUT",
   "layers": [

--- a/public/keymaps/rgbkb_zen_rev2_default.json
+++ b/public/keymaps/rgbkb_zen_rev2_default.json
@@ -1,6 +1,6 @@
 {
   "keyboard": "rgbkb/zen/rev2",
-  "keymap": "default",
+  "keymap": "default_4cdb86c",
   "commit": "4cdb86c730528c8ca5ff90f5b9b01c395d31fc0e",
   "layout": "LAYOUT",
   "layers": [

--- a/public/keymaps/rgbkb_zygomorph_rev1_default.json
+++ b/public/keymaps/rgbkb_zygomorph_rev1_default.json
@@ -1,6 +1,6 @@
 {
   "keyboard": "rgbkb/zygomorph/rev1",
-  "keymap": "default",
+  "keymap": "default_4cdb86c",
   "commit": "4cdb86c730528c8ca5ff90f5b9b01c395d31fc0e",
   "layout": "LAYOUT_ortho_5x12",
   "layers": [


### PR DESCRIPTION
Updated the keymap names to prevent name collision errors.

@XScorpion2, you can't actually use `default` as the value for `keymap`, because the API can see the `keymap.c` files that are in qmk_firmware, even though Configurator itself can't do anything with them. In fact, the value for `keymap` cannot match *any* `keymap.c` that exists in qmk_firmware, for the same reason. The API tries to make a `keyboards/{keyboard}/keymaps/{keymap}/keymap.c` file when the compile job completes, but if one already exists the operation fails.

I append a partial commit hash to the `keymap` value to prevent this. (What you append actually doesn't matter so long as the corresponding file doesn't already exist in qmk_firmware.)

```
* Sending rgbkb/zen/rev2:default with LAYOUT
* Received job_id: c0f57610-44da-43f0-968d-106cd5483d43
* Queueing . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
* Running . . . . . . . .
* Finished:
Keymap name collision! qmk_firmware/keyboards/rgbkb/zen/rev2/keymaps/default already exists!
```