### PR TITLE
Make 1U keymaps great again

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -201,6 +201,10 @@ export default {
       );
     },
     formatName(name) {
+      if (this.u < 1.75) {
+        name = name.replace(' ', '\n');
+        name = name.replace('_', '_\n');
+      }
       return name.length === 1 ? name.toUpperCase() : name;
     },
     remove() {

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -201,10 +201,6 @@ export default {
       );
     },
     formatName(name) {
-      if (this.u < 1.75) {
-        name = name.replace(' ', '\n');
-        name = name.replace('_', '_\n');
-      }
       return name.length === 1 ? name.toUpperCase() : name;
     },
     remove() {

--- a/src/components/PrintKey.vue
+++ b/src/components/PrintKey.vue
@@ -29,15 +29,28 @@ export default {
       }
       if (this.meta.type === 'layer-container') {
         return this.formatName(
-          `${this.meta.name.toUpperCase()},\n ${this.meta.contents.name}`
+          `${this.meta.name.toUpperCase()},\n ${this.breakLines(
+            this.meta.contents.name
+          )}`
         );
       }
       if (this.meta.type === 'container') {
         return this.formatName(
-          `${this.meta.name.toUpperCase()}(\n${this.meta.contents.name})`
+          `${this.meta.name.toUpperCase()}(\n${this.breakLines(
+            this.meta.contents.name
+          )})`
         );
       }
-      return this.formatName(this.meta.name);
+      return this.formatName(this.breakLines(this.meta.name));
+    }
+  },
+  methods: {
+    breakLines(name) {
+      if (this.u < 1.75) {
+        name = name.replace(' ', '\n');
+        name = name.replace('_', '_\n');
+      }
+      return name;
     }
   }
 };


### PR DESCRIPTION
Improves readability of keycodes in 1.25U and smaller keys on ergo and ortholinear.

 - force line breaks for legends with breaks

![Screen Shot 2019-05-21 at 22 50 38](https://user-images.githubusercontent.com/2275667/58150244-e2592e00-7c1a-11e9-9d54-94f4273be1aa.png)

 - force line breaks for raw keycodes

![Screen Shot 2019-05-21 at 22 50 46](https://user-images.githubusercontent.com/2275667/58150306-15032680-7c1b-11e9-9f91-9f1d3773c092.png)
