### PR TITLE
Replace spaces & slashes in keyboard names with underscores before they can get trimmed

### DIFF
--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -47,7 +47,8 @@ const getters = {
   exportKeymapName: state => {
     let exportName = state.keymapName.replace(/[\s/]/g, '_').toLowerCase();
     if (exportName === '') {
-      exportName = `${state.keyboard}_${state.layout}_mine`.toLowerCase();
+      let keyboardName = state.keyboard.replace(/[\s/]/g, '_').toLowerCase();
+      exportName = `${keyboardName}_${state.layout}_mine`.toLowerCase();
     }
     // issue #331 whitelist what we send to API for keymapName and save to disk
     exportName = exportName.replace(/[^a-z0-9_-]/gi, '');


### PR DESCRIPTION
When compiling a keymap for a keyboard with slashes in the name, eg. `lazydesigners/dimple`, the `exportKeymapName` lambda replaces those slashes with nothing: `lazydesignersdimple_layout_mine`. This results in the slice done in `compile()` being calculated incorrectly, and the keymap gets called `ayout_mine`.

So, the keyboard name needs to be sanitized before `exportName` hits the whitelisting replace.