### PR TITLE
added browser warn

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
     <noscript>
       <strong>We're sorry but configurator doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
+    <div id="browser-warn-container"></div>
     <div id="status-app"></div>
     <div class="hidden"></div>
     <div id="controller">

--- a/src/components/BrowserWarn.vue
+++ b/src/components/BrowserWarn.vue
@@ -1,5 +1,6 @@
 <template>
-  <div id="browser-warn" v-show="isNotSupported">
+  <div id="browser-warn" v-show="isNotSupported && !isDimissed">
+    <a class="dismiss" title="dismiss" v-on:click="dismiss">X</a>
     {{ $t('message.errors.unsupportedBrowser') }}
     <a href="https://www.google.com/intl/en_us/chrome/" target="_blank"
       >Google Chrome</a
@@ -14,6 +15,14 @@
 <script>
 export default {
   name: 'browser-warn-bar',
+  data() {
+    return { isDimissed: false };
+  },
+  methods: {
+    dismiss() {
+      this.isDimissed = true;
+    }
+  },
   computed: {
     isNotSupported() {
       const isChrome =
@@ -28,8 +37,8 @@ export default {
 
 <style>
 #browser-warn {
+  padding: 0 5px;
   z-index: 3001;
-  display: grid;
   position: fixed;
   top: 20px;
   left: 0;
@@ -40,5 +49,8 @@ export default {
 #browser-warn a {
   color: #e0e0e0;
   font-weight: bold;
+}
+a.dismiss {
+  cursor: pointer;
 }
 </style>

--- a/src/components/BrowserWarn.vue
+++ b/src/components/BrowserWarn.vue
@@ -1,0 +1,44 @@
+<template>
+  <div id="browser-warn" v-show="isNotSupported">
+    {{ $t('message.errors.unsupportedBrowser') }}
+    <a href="https://www.google.com/intl/en_us/chrome/" target="_blank"
+      >Google Chrome</a
+    >
+    /
+    <a href="https://www.mozilla.org/en-US/firefox/new/" target="_blank"
+      >Mozilla Firefox</a
+    >
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'browser-warn-bar',
+  computed: {
+    isNotSupported() {
+      const isChrome =
+        !!window.chrome &&
+        (!!window.chrome.webstore || !!window.chrome.runtime);
+      const isFirefox = typeof InstallTrigger !== 'undefined';
+      return !(isChrome || isFirefox);
+    }
+  }
+};
+</script>
+
+<style>
+#browser-warn {
+  z-index: 3001;
+  display: grid;
+  position: fixed;
+  top: 20px;
+  left: 0;
+  background: #d00;
+  color: #e0e0e0;
+  width: 100%;
+}
+#browser-warn a {
+  color: #e0e0e0;
+  font-weight: bold;
+}
+</style>

--- a/src/i18n/en/index.js
+++ b/src/i18n/en/index.js
@@ -103,7 +103,8 @@ export default {
           "Sorry, that doesn't appear to be a valid QMK keymap file.",
         kbfirmwareJSONUnsupported:
           "Sorry, QMK Configurator doesn't support importing kbfirmware JSON files.",
-        unknownJSON: "Sorry, this doesn't appear to be a QMK keymap file."
+        unknownJSON: "Sorry, this doesn't appear to be a QMK keymap file.",
+        unsupportedBrowser: "You're using a non supported browser. Please use"
       },
       statsTemplate:
         '\nLoaded {layers} layers and {count} keycodes. Defined {any} Any key keycodes\n'

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 import StatusBar from '@/components/StatusBar';
+import BrowserWarn from '@/components/BrowserWarn';
 import Veil from '@/components/Veil';
 import vSelect from 'vue-select';
 import 'vue-select/dist/vue-select.css';
@@ -74,3 +75,8 @@ new Vue({
 new Vue({
   render: h => h(StatusBar)
 }).$mount('#status-app');
+
+new Vue({
+  i18n,
+  render: h => h(BrowserWarn)
+}).$mount('#browser-warn-container');


### PR DESCRIPTION
fixes: https://github.com/qmk/qmk_configurator/issues/148

![2019-06-03 12_14_45-http___localhost_8080_#_1upkeyboards_1up60hse_LAYOUT_60_ansi - Internet Explorer](https://user-images.githubusercontent.com/6959636/58794970-caf64980-85f9-11e9-959c-2006bb70fc76.png)

Note: is that normal that all content of the repo is using `CRLF` instead of `LF` ?