### PR TITLE
[tester] adjust loggin

### DIFF
--- a/src/components/VisualTesterKeymap.vue
+++ b/src/components/VisualTesterKeymap.vue
@@ -38,6 +38,7 @@
         ref="status"
         cols="120"
         rows="5"
+        spellcheck="false"
         v-model="status"
       />
     </div>
@@ -130,13 +131,18 @@ export default {
     getComponent() {
       return TesterKey;
     },
+    formatLog(keyEventStr, pos, evStr) {
+      return `${keyEventStr.padEnd(8, ' ')} - QMK: ${this.getQMKCode(
+        pos
+      ).padEnd(7, ' ')} ${evStr}`;
+    },
     keyup(ev) {
       const endTS = performance.now();
       const evStr = this.formatKeyEvent(ev, endTS);
       ev.preventDefault();
       ev.stopPropagation();
       const pos = this.codeToPosition[this.firefoxKeys(ev.code)];
-      this.writeToStatus(`KEY-UP ---- QMK: '${this.getQMKCode(pos)}' ${evStr}`);
+      this.writeToStatus(this.formatLog('KEY-UP', pos, evStr));
       if (!isUndefined(pos)) {
         this.setDetected(pos);
       }
@@ -150,7 +156,7 @@ export default {
       ev.stopPropagation();
       const pos = this.codeToPosition[this.firefoxKeys(ev.code)];
       this.writeToStatus(
-        `KEY-DOWN -- QMK: '${this.getQMKCode(pos)}' ${this.formatKeyEvent(ev)}`
+        this.formatLog('KEY-DOWN', pos, this.formatKeyEvent(ev))
       );
       this.lastKey = ev.key === ' ' ? ev.code : ev.key;
       this.lastCode = ev.code;
@@ -181,7 +187,10 @@ export default {
         msg.push(`in ${(endTS - this.timing[ev.code]).toFixed(3)}ms`);
       }
       msg.unshift(
-        `Event key: '${ev.key}', Code: ${ev.code}, keyCode: ${ev.keyCode}`
+        `Event key: ${ev.key.padEnd(10, ' ')} Code: ${ev.code.padEnd(
+          11,
+          ' '
+        )} KeyCode: ${ev.keyCode}`
       );
       return msg.join(' ');
     },

--- a/src/components/VisualTesterKeymap.vue
+++ b/src/components/VisualTesterKeymap.vue
@@ -32,15 +32,14 @@
           {{ displayKeyCode }}
         </div>
       </div>
-      <textarea
+      <div
         class="status-log"
         id="terminal"
         ref="status"
-        cols="120"
-        rows="5"
         spellcheck="false"
-        v-model="status"
-      />
+        style="width:869px;text-align:left;"
+        v-html="status"
+      ></div>
     </div>
     <p>
       {{ $t('message.tester.docs.paragraph') }}
@@ -132,9 +131,13 @@ export default {
       return TesterKey;
     },
     formatLog(keyEventStr, pos, evStr) {
-      return `${keyEventStr.padEnd(8, ' ')} - QMK: ${this.getQMKCode(
-        pos
-      ).padEnd(7, ' ')} ${evStr}`;
+      return `${keyEventStr.padEnd(
+        8,
+        ' '
+      )} - QMK: <span class="log-green">${this.getQMKCode(pos).padEnd(
+        7,
+        ' '
+      )}</span> ${evStr}`;
     },
     keyup(ev) {
       const endTS = performance.now();
@@ -187,10 +190,13 @@ export default {
         msg.push(`in ${(endTS - this.timing[ev.code]).toFixed(3)}ms`);
       }
       msg.unshift(
-        `Event key: ${ev.key.padEnd(10, ' ')} Code: ${ev.code.padEnd(
+        `Event key: <span class="log-green">${ev.key.padEnd(
+          10,
+          ' '
+        )}</span> Code: <span class="log-green">${ev.code.padEnd(
           11,
           ' '
-        )} KeyCode: ${ev.keyCode}`
+        )}</span> KeyCode: <span class="log-green">${ev.keyCode}</span>`
       );
       return msg.join(' ');
     },
@@ -232,6 +238,9 @@ export default {
 };
 </script>
 <style>
+span.log-green {
+  color: lightgreen;
+}
 .tester {
   margin-top: 35px;
   display: grid;

--- a/src/components/VisualTesterKeymap.vue
+++ b/src/components/VisualTesterKeymap.vue
@@ -14,30 +14,28 @@
       <h3 class="info-title">{{ $t('message.tester.keycodeStatus.label') }}</h3>
       <div class="letter-display">
         <div class="letter-key">
-          <label class="key-label"
-            >{{ $t('message.tester.letters.key.label') }}
-          </label>
+          <label class="key-label">{{
+            $t('message.tester.letters.key.label')
+          }}</label>
           {{ lastKey }}
         </div>
         <div class="letter-code">
-          <label class="code-label">
-            {{ $t('message.tester.letters.code.label') }}
-          </label>
+          <label class="code-label">{{
+            $t('message.tester.letters.code.label')
+          }}</label>
           {{ lastCode }}
         </div>
         <div class="letter-key-code" @click="togglehex">
-          <label class="keycode-label">
-            {{ $t('message.tester.letters.keycode.label') }}
-          </label>
+          <label class="keycode-label">{{
+            $t('message.tester.letters.keycode.label')
+          }}</label>
           {{ displayKeyCode }}
         </div>
       </div>
       <div
         class="status-log"
-        id="terminal"
         ref="status"
         spellcheck="false"
-        style="width:869px;text-align:left;"
         v-html="status"
       ></div>
     </div>
@@ -130,14 +128,15 @@ export default {
     getComponent() {
       return TesterKey;
     },
+    greenMarkup(text, padlen) {
+      return `<span class="log-green">${text.padEnd(padlen, ' ')}</span>`;
+    },
     formatLog(keyEventStr, pos, evStr) {
-      return `${keyEventStr.padEnd(
-        8,
-        ' '
-      )} - QMK: <span class="log-green">${this.getQMKCode(pos).padEnd(
-        7,
-        ' '
-      )}</span> ${evStr}`;
+      const qmkCode = this.getQMKCode(pos);
+      return `${keyEventStr.padEnd(8, ' ')} - QMK: ${this.greenMarkup(
+        qmkCode,
+        7
+      )} ${evStr}`;
     },
     keyup(ev) {
       const endTS = performance.now();
@@ -190,13 +189,10 @@ export default {
         msg.push(`in ${(endTS - this.timing[ev.code]).toFixed(3)}ms`);
       }
       msg.unshift(
-        `Event key: <span class="log-green">${ev.key.padEnd(
-          10,
-          ' '
-        )}</span> Code: <span class="log-green">${ev.code.padEnd(
-          11,
-          ' '
-        )}</span> KeyCode: <span class="log-green">${ev.keyCode}</span>`
+        `Event key: ${this.greenMarkup(ev.key, 10)} Code: ${this.greenMarkup(
+          ev.code,
+          11
+        )} KeyCode: ${ev.keyCode}`
       );
       return msg.join(' ');
     },
@@ -290,6 +286,24 @@ span.log-green {
 }
 .status-log {
   grid-row: info-bottom;
+  padding: 2px 5px;
+  width: 869px;
+  text-align: left;
+  background: #272822;
+  color: #f8f8f2;
+  border: 1px solid #000;
+  font-family: 'Roboto Mono', Monaco, Bitstream Vera Sans Mono, Lucida Console,
+    Terminal, Consolas, Liberation Mono, DejaVu Sans Mono, Courier New,
+    monospace;
+  white-space: pre-wrap;
+  overflow-y: scroll;
+  height: 200px;
+  font-size: 12px;
+  margin: 0px auto;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  display: block;
 }
 .key-label,
 .keycode-label,

--- a/src/components/VisualTesterKeymap.vue
+++ b/src/components/VisualTesterKeymap.vue
@@ -14,21 +14,21 @@
       <h3 class="info-title">{{ $t('message.tester.keycodeStatus.label') }}</h3>
       <div class="letter-display">
         <div class="letter-key">
-          <label class="key-label">{{
-            $t('message.tester.letters.key.label')
-          }}</label>
+          <label class="key-label">
+            {{ $t('message.tester.letters.key.label') }}
+          </label>
           {{ lastKey }}
         </div>
         <div class="letter-code">
-          <label class="code-label">{{
-            $t('message.tester.letters.code.label')
-          }}</label>
+          <label class="code-label">
+            {{ $t('message.tester.letters.code.label') }}
+          </label>
           {{ lastCode }}
         </div>
         <div class="letter-key-code" @click="togglehex">
-          <label class="keycode-label">{{
-            $t('message.tester.letters.keycode.label')
-          }}</label>
+          <label class="keycode-label">
+            {{ $t('message.tester.letters.keycode.label') }}
+          </label>
           {{ displayKeyCode }}
         </div>
       </div>
@@ -133,10 +133,12 @@ export default {
     },
     formatLog(keyEventStr, pos, evStr) {
       const qmkCode = this.getQMKCode(pos);
-      return `${keyEventStr.padEnd(8, ' ')} - QMK: ${this.greenMarkup(
-        qmkCode,
-        7
-      )} ${evStr}`;
+      return [
+        keyEventStr.padEnd(8, ' '),
+        '- QMK:',
+        this.greenMarkup(qmkCode, 7),
+        evStr
+      ].join(' ');
     },
     keyup(ev) {
       const endTS = performance.now();
@@ -189,10 +191,14 @@ export default {
         msg.push(`in ${(endTS - this.timing[ev.code]).toFixed(3)}ms`);
       }
       msg.unshift(
-        `Event key: ${this.greenMarkup(ev.key, 10)} Code: ${this.greenMarkup(
-          ev.code,
-          11
-        )} KeyCode: ${ev.keyCode}`
+        [
+          'Event key:',
+          this.greenMarkup(ev.key, 10),
+          'Code:',
+          this.greenMarkup(ev.code, 11),
+          'KeyCode:',
+          ev.keyCode
+        ].join(' ')
       );
       return msg.join(' ');
     },


### PR DESCRIPTION
I've adjusted the loggin in the console to make it more readable:
From this:
![2019-06-10 14_29_08-QMK Configurator](https://user-images.githubusercontent.com/6959636/59195555-9439a980-8b8c-11e9-8e26-44c1d647bda4.png)
to this:
![2019-06-10 14_51_44-QMK Configurator](https://user-images.githubusercontent.com/6959636/59196733-c13b8b80-8b8f-11e9-88e4-b472f70fe2ed.png)

Note: added `spellsheck=false` to avoid the browser to try to parse content and having red highlighting depends on the browser lang.