### PR TITLE
Proof-of-concept to display unicode via the UC macro

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -220,7 +220,8 @@ export default {
       );
     },
     formatName(name) {
-      return name.length === 1 ? name.toUpperCase() : name;
+      let unicode = name.codePointAt(0) > 255;
+      return name.length === 1 && !unicode ? name.toUpperCase() : name;
     },
     remove() {
       this.setSelected(this.id);

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -264,6 +264,11 @@ function parseKeycode(keycode, stats) {
     let internal = splitcode[1];
     internal = internal.split(')')[0];
 
+    if (maincode === 'UC') {
+      metadata = {code: keycode, name: String.fromCodePoint(internal), title: `Unicode ${internal}`}
+      return newKey(metadata, keycode)
+    }
+
     //Check whether it is a layer switching code or combo keycode
     if (internal.includes('KC')) {
       // Layer Tap keycode


### PR DESCRIPTION
The current behavior displays an Any key with the text from the UC macro. This commit changes it to display the unicode character.

There are several issues:
- You can't compile a keyboard with UC directly from the configurator
- You can't add unicode characters from the configurator
- I changed it to not upper case the character if the code point is above 255 which is arbitrary and potentially confusing
- I only made that change in one place, there are two other places where we do toUpperCase when the key is a single character but I don't understand what code path engages them
- It might not work if the UC macro is within another macro

Again, this is a proof-of-concept. It seems like a simple enough change to merge but I don't want to add anything that would be confusing to future coders due to the half-assed nature of my code. Please let me know if there's anything I can do, other than adding full unicode support, which I don't think I'd be able to actually accomplish. 

@yanfali 