### PR TITLE
Initial implementation of code for electron App

### DIFF
--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -98,19 +98,21 @@
         class="fixed-size"
         id="fwFile"
         @click="autoFlashFirmware"
-        title="Automaticly Flash compiled Firmware to MCU"
+        :title="$t('message.flashFirmware.title')"
         v-bind:disabled="disableDownloadBinary"
       >
-        <font-awesome-icon icon="download" size="lg" fixed-width />Auto-Flash
+        <font-awesome-icon icon="download" size="lg" fixed-width />
+        {{ $t('message.flashFirmware.label') }}
       </button>
       <button
         class="fixed-size"
         id="fwFile"
         @click="flashFirmware"
-        title="Flash User Selected file to MCU"
+        :title="$t('message.flashFile.title')"
         v-bind:disabled="disableFlashFile"
       >
-        <font-awesome-icon icon="download" size="lg" fixed-width />Custom-Flash
+        <font-awesome-icon icon="download" size="lg" fixed-width />
+        {{ $t('message.flashFile.label') }}
       </button>
     </div>
     <div v-else class="botctrl-1-2">
@@ -120,7 +122,8 @@
         :title="$t('message.downloadFirmware.title')"
         v-bind:disabled="disableDownloadBinary"
       >
-        <font-awesome-icon icon="download" size="lg" fixed-width />{{ $t('message.downloadFirmware.label') }}
+        <font-awesome-icon icon="download" size="lg" fixed-width />
+        {{ $t('message.downloadFirmware.label') }}
       </button>
     </div>
     <div v-if="downloadElementEnabled">

--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -166,7 +166,7 @@ export default {
       'author',
       'notes'
     ]),
-    ...mapGetters(['exportKeymapName']),
+    ...mapGetters(['exportKeymapName', 'firmwareFile']),
     disableDownloadKeymap() {
       return !this.enableDownloads && this.keymapSourceURL !== '';
     },
@@ -286,8 +286,8 @@ export default {
       window.Bridge.autoFlash = true;
       window.Bridge.flashURL(
         first(this.firmwareBinaryURL),
-        this.$store.getters['app/keyboard'],
-        this.$store.getters['app/firmwareFile']
+        this.keyboard,
+        this.firmwareFile
       );
     },
     downloadSource() {

--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -94,26 +94,8 @@
       />
     </div>
     <div v-if="electron" class="botctrl-1-2">
-      <button
-        class="fixed-size"
-        id="fwFile"
-        @click="autoFlashFirmware"
-        :title="$t('message.flashFirmware.title')"
-        v-bind:disabled="disableDownloadBinary"
-      >
-        <font-awesome-icon icon="download" size="lg" fixed-width />
-        {{ $t('message.flashFirmware.label') }}
-      </button>
-      <button
-        class="fixed-size"
-        id="fwFile"
-        @click="flashFirmware"
-        :title="$t('message.flashFile.title')"
-        v-bind:disabled="disableFlashFile"
-      >
-        <font-awesome-icon icon="download" size="lg" fixed-width />
-        {{ $t('message.flashFile.label') }}
-      </button>
+      <ElectronBottomControls :disableDownloadBinary="disableDownloadBinary">
+      </ElectronBottomControls>
     </div>
     <div v-else class="botctrl-1-2">
       <button
@@ -152,8 +134,12 @@ import {
   disableOtherButtons,
   getPreferredLayout
 } from '@/jquery';
+
+import ElectronBottomControls from './ElectronBottomControls';
+
 export default {
   name: 'bottom-controller',
+  components: { ElectronBottomControls },
   computed: {
     ...mapState([
       'keyboard',
@@ -180,17 +166,7 @@ export default {
         this.firmwareBinaryURL === ''
       );
     },
-    disableFlashFile() {
-      return !window.Bridge.enableFlashing;
-    },
-    disableFlashSource() {
-      return (
-        !window.Bridge.enableFlashing ||
-        isUndefined(this.firmwareBinaryURL) ||
-        this.firmwareBinaryURL === ''
-      );
-    },
-    electron: function() {
+    electron() {
       return window.electron;
     }
   },
@@ -277,18 +253,6 @@ export default {
         this.$refs.downloadElement.click();
         this.downloadElementEnabled = false;
       });
-    },
-    flashFirmware() {
-      window.Bridge.autoFlash = false;
-      window.Bridge.flashFile();
-    },
-    autoFlashFirmware() {
-      window.Bridge.autoFlash = true;
-      window.Bridge.flashURL(
-        first(this.firmwareBinaryURL),
-        this.keyboard,
-        this.firmwareFile
-      );
     },
     downloadSource() {
       this.urlEncodedData = first(this.firmwareSourceURL);

--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -93,15 +93,33 @@
         @change="infoPreviewChanged"
       />
     </div>
-    <div class="botctrl-1-2">
+    <div v-if="electron" class="botctrl-1-2">
+      <button
+       class="fixed-size"
+        id="fwFile"
+        @click="autoFlashFirmware"
+        title="Automaticly Flash Firmware to MCU"
+        v-bind:disabled="disableDownloadBinary"
+      >
+        <font-awesome-icon icon="download" size="lg" fixed-width/>Auto-Flash
+      </button>
+      <button
+        id="fwFile"
+        @click="flashFirmware"
+        title="Flash Firmware to MCU"
+        v-bind:disabled="disableDownloadBinary"
+      >
+        <font-awesome-icon icon="download" size="lg" fixed-width/>Flash
+      </button>
+    </div>
+    <div v-else class="botctrl-1-2">
       <button
         id="fwFile"
         @click="downloadFirmware"
         :title="$t('message.downloadFirmware.title')"
         v-bind:disabled="disableDownloadBinary"
       >
-        <font-awesome-icon icon="download" size="lg" fixed-width />
-        {{ $t('message.downloadFirmware.label') }}
+        <font-awesome-icon icon="download" size="lg" fixed-width/>{{ $t('message.downloadFirmware.label') }}
       </button>
     </div>
     <div v-if="downloadElementEnabled">
@@ -157,6 +175,9 @@ export default {
         isUndefined(this.firmwareBinaryURL) ||
         this.firmwareBinaryURL === ''
       );
+    },
+    electron: function() {
+      return window.electron;
     }
   },
   watch: {
@@ -242,6 +263,22 @@ export default {
         this.$refs.downloadElement.click();
         this.downloadElementEnabled = false;
       });
+    },
+    flashFirmware() {
+      window.Bridge.autoFlash = false;
+      window.Bridge.flashURL(
+        first(this.firmwareBinaryURL),
+        this.$store.getters['app/keyboard'],
+        this.$store.getters['app/firmwareFile']
+      );
+    },
+    autoFlashFirmware() {
+      window.Bridge.autoFlash = true;
+      window.Bridge.flashURL(
+        first(this.firmwareBinaryURL),
+        this.$store.getters['app/keyboard'],
+        this.$store.getters['app/firmwareFile']
+      );
     },
     downloadSource() {
       this.urlEncodedData = first(this.firmwareSourceURL);

--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -95,21 +95,22 @@
     </div>
     <div v-if="electron" class="botctrl-1-2">
       <button
-       class="fixed-size"
+        class="fixed-size"
         id="fwFile"
         @click="autoFlashFirmware"
-        title="Automaticly Flash Firmware to MCU"
+        title="Automaticly Flash compiled Firmware to MCU"
         v-bind:disabled="disableDownloadBinary"
       >
-        <font-awesome-icon icon="download" size="lg" fixed-width/>Auto-Flash
+        <font-awesome-icon icon="download" size="lg" fixed-width />Auto-Flash
       </button>
       <button
+        class="fixed-size"
         id="fwFile"
         @click="flashFirmware"
-        title="Flash Firmware to MCU"
-        v-bind:disabled="disableDownloadBinary"
+        title="Flash User Selected file to MCU"
+        v-bind:disabled="disableFlashFile"
       >
-        <font-awesome-icon icon="download" size="lg" fixed-width/>Flash
+        <font-awesome-icon icon="download" size="lg" fixed-width />Custom-Flash
       </button>
     </div>
     <div v-else class="botctrl-1-2">
@@ -119,7 +120,7 @@
         :title="$t('message.downloadFirmware.title')"
         v-bind:disabled="disableDownloadBinary"
       >
-        <font-awesome-icon icon="download" size="lg" fixed-width/>{{ $t('message.downloadFirmware.label') }}
+        <font-awesome-icon icon="download" size="lg" fixed-width />{{ $t('message.downloadFirmware.label') }}
       </button>
     </div>
     <div v-if="downloadElementEnabled">
@@ -172,6 +173,16 @@ export default {
     disableDownloadBinary() {
       return (
         !this.enableDownloads ||
+        isUndefined(this.firmwareBinaryURL) ||
+        this.firmwareBinaryURL === ''
+      );
+    },
+    disableFlashFile() {
+      return !window.Bridge.enableFlashing;
+    },
+    disableFlashSource() {
+      return (
+        !window.Bridge.enableFlashing ||
         isUndefined(this.firmwareBinaryURL) ||
         this.firmwareBinaryURL === ''
       );
@@ -266,11 +277,7 @@ export default {
     },
     flashFirmware() {
       window.Bridge.autoFlash = false;
-      window.Bridge.flashURL(
-        first(this.firmwareBinaryURL),
-        this.$store.getters['app/keyboard'],
-        this.$store.getters['app/firmwareFile']
-      );
+      window.Bridge.flashFile();
     },
     autoFlashFirmware() {
       window.Bridge.autoFlash = true;

--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -93,7 +93,7 @@
         @change="infoPreviewChanged"
       />
     </div>
-    <div v-if="electron" class="botctrl-1-2">
+    <div v-if="this.electron" class="botctrl-1-2">
       <ElectronBottomControls :disableDownloadBinary="disableDownloadBinary">
       </ElectronBottomControls>
     </div>
@@ -152,7 +152,7 @@ export default {
       'author',
       'notes'
     ]),
-    ...mapGetters(['exportKeymapName', 'firmwareFile']),
+    ...mapGetters(['exportKeymapName', 'firmwareFile', 'electron']),
     disableDownloadKeymap() {
       return !this.enableDownloads && this.keymapSourceURL !== '';
     },
@@ -166,9 +166,6 @@ export default {
         this.firmwareBinaryURL === ''
       );
     },
-    electron() {
-      return window.electron;
-    }
   },
   watch: {
     /**

--- a/src/components/ElectronBottomControls.vue
+++ b/src/components/ElectronBottomControls.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <button
+      class="fixed-size"
+      id="fwFile"
+      @click="autoFlashFirmware"
+      :title="$t('message.flashFirmware.title')"
+      :disabled="disableDownloadBinary"
+    >
+      <font-awesome-icon icon="download" size="lg" fixed-width />
+      {{ $t('message.flashFirmware.label') }}
+    </button>
+    <button
+      class="fixed-size"
+      id="fwFile"
+      @click="flashFirmware"
+      :title="$t('message.flashFile.title')"
+      :disabled="disableFlashFile"
+    >
+      <font-awesome-icon icon="download" size="lg" fixed-width />
+      {{ $t('message.flashFile.label') }}
+    </button>
+  </div>
+</template>
+<script>
+import first from 'lodash/first';
+import isUndefined from 'lodash/isUndefined';
+import { mapState } from 'vuex';
+
+export default {
+  name: 'ElectronBottomControls',
+  props: {
+    disableDownloadBinary: {
+      type: Boolean,
+      required: true,
+      default: true
+    }
+  },
+  computed: {
+    ...mapState('app', ['keyboard', 'firmwareBinaryURL', 'firmwareFile']),
+    disableFlashFile() {
+      return !window.Bridge.enableFlashing;
+    },
+    disableFlashSource() {
+      return (
+        !window.Bridge.enableFlashing ||
+        isUndefined(this.firmwareBinaryURL) ||
+        this.firmwareBinaryURL === ''
+      );
+    }
+  },
+  methods: {
+    flashFirmware() {
+      window.Bridge.autoFlash = false;
+      window.Bridge.flashFile();
+    },
+    autoFlashFirmware() {
+      window.Bridge.autoFlash = true;
+      window.Bridge.flashURL(
+        first(this.firmwareBinaryURL),
+        this.keyboard,
+        this.firmwareFile
+      );
+    }
+  }
+};
+</script>

--- a/src/electron.js
+++ b/src/electron.js
@@ -2,6 +2,8 @@ import store from './store';
 
 export default {
   init() {
+    store.commit('app/enableElectron')
+
     //We use the Bridge as a way to share functions between electron and vue
     window.Bridge.statusAppend = txt => {
       txt = '\n' + txt;

--- a/src/electron.js
+++ b/src/electron.js
@@ -1,0 +1,12 @@
+import store from './store';
+
+module.exports = {
+  initElectron: () => {
+    //We use the Bridge as a way to share functions between electron and vue
+    window.Bridge.statusAppend = txt => {
+      txt = '\n' + txt;
+      store.commit('status/append', txt);
+      store.dispatch('status/scrollToEnd');
+    };
+  }
+};

--- a/src/electron.js
+++ b/src/electron.js
@@ -1,7 +1,7 @@
 import store from './store';
 
-module.exports = {
-  initElectron: () => {
+export default {
+  init() {
     //We use the Bridge as a way to share functions between electron and vue
     window.Bridge.statusAppend = txt => {
       txt = '\n' + txt;

--- a/src/electron.js
+++ b/src/electron.js
@@ -6,8 +6,7 @@ export default {
 
     //We use the Bridge as a way to share functions between electron and vue
     window.Bridge.statusAppend = txt => {
-      txt = '\n' + txt;
-      store.commit('status/append', txt);
+      store.commit('status/append', `\n${txt}`);
       store.dispatch('status/scrollToEnd');
     };
   }

--- a/src/i18n/en/index.js
+++ b/src/i18n/en/index.js
@@ -60,7 +60,7 @@ export default {
       },
       flashFirmware: {
         label: 'Auto-Flash',
-        title: 'Automaticly Flash compiled Firmware to MCU'
+        title: 'Automatically Flash compiled Firmware to MCU'
       },
       flashFile: {
         label: 'Custom-Flash',

--- a/src/i18n/en/index.js
+++ b/src/i18n/en/index.js
@@ -58,6 +58,14 @@ export default {
         label: 'Firmware',
         title: 'Download firmware file for flashing'
       },
+      flashFirmware: {
+        label: 'Auto-Flash',
+        title: 'Automaticly Flash compiled Firmware to MCU'
+      },
+      flashFile: {
+        label: 'Custom-Flash',
+        title: 'Flash User Selected file to MCU'
+      },
       ColorwayTip: {
         title: 'Ctrl + Alt + N to cycle next colorway'
       },

--- a/src/main.js
+++ b/src/main.js
@@ -46,23 +46,17 @@ import {
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ga from './ga';
-// Electron specific Code
+import { initElectron } from './electron';
+// Find out if we are are running inside electon
+window.electron = false;
 if (
   typeof navigator === 'object' &&
   typeof navigator.userAgent === 'string' &&
   navigator.userAgent.indexOf('Electron') >= 0
 ) {
   window.electron = true; //We set a global value to be used later
-  //We use the Bridge as a way to share functions between electron and vue
-  window.Bridge.statusAppend = txt => {
-    txt = '\n' + txt;
-    store.commit('status/append', txt);
-    store.dispatch('status/scrollToEnd');
-  };
-} else {
-  window.electron = false;
+  initElectron(); // initializes code specific for the electron app
 }
-// End of electon specific code
 
 Vue.component('Veil', Veil);
 Vue.component('v-select', vSelect);

--- a/src/main.js
+++ b/src/main.js
@@ -46,7 +46,8 @@ import {
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ga from './ga';
-import { isObject, isString } from 'lodash';
+import isObject from 'lodash/isObject';
+import isString from 'lodash/isString';
 import electron from './electron';
 // Find out if we are are running inside electon
 if (

--- a/src/main.js
+++ b/src/main.js
@@ -48,15 +48,12 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ga from './ga';
 import electron from './electron';
 // Find out if we are are running inside electon
-window.electron = false;
 if (
   typeof navigator === 'object' &&
   typeof navigator.userAgent === 'string' &&
   navigator.userAgent.indexOf('Electron') >= 0
-) {
-  window.electron = true; //We set a global value to be used later
-  electron.init(); // initializes code specific for the electron app
-}
+) electron.init(); // initializes code specific for the electron app
+
 
 Vue.component('Veil', Veil);
 Vue.component('v-select', vSelect);

--- a/src/main.js
+++ b/src/main.js
@@ -46,7 +46,7 @@ import {
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ga from './ga';
-import { initElectron } from './electron';
+import electron from './electron';
 // Find out if we are are running inside electon
 window.electron = false;
 if (
@@ -55,7 +55,7 @@ if (
   navigator.userAgent.indexOf('Electron') >= 0
 ) {
   window.electron = true; //We set a global value to be used later
-  initElectron(); // initializes code specific for the electron app
+  electron.init(); // initializes code specific for the electron app
 }
 
 Vue.component('Veil', Veil);

--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,22 @@ import {
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ga from './ga';
+// Electron specific Code
+if (
+  typeof navigator === 'object' &&
+  typeof navigator.userAgent === 'string' &&
+  navigator.userAgent.indexOf('Electron') >= 0
+) {
+  window.electron = true; //We set a global value to be used later
+  //We use the Bridge as a way to share functions between electron and vue
+  window.Bridge.statusAppend = txt => {
+    store.commit('status/append', txt);
+    store.dispatch('status/scrollToEnd');
+  };
+} else {
+  window.electron = false;
+}
+// End of electon specific code
 
 Vue.component('Veil', Veil);
 Vue.component('v-select', vSelect);

--- a/src/main.js
+++ b/src/main.js
@@ -46,14 +46,15 @@ import {
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ga from './ga';
+import { isObject, isString } from 'lodash';
 import electron from './electron';
 // Find out if we are are running inside electon
 if (
-  typeof navigator === 'object' &&
-  typeof navigator.userAgent === 'string' &&
-  navigator.userAgent.indexOf('Electron') >= 0
-) electron.init(); // initializes code specific for the electron app
-
+  isObject(navigator) &&
+  isString(navigator.userAgent) &&
+  navigator.userAgent.includes('Electron')
+)
+  electron.init(); // initializes code specific for the electron app
 
 Vue.component('Veil', Veil);
 Vue.component('v-select', vSelect);

--- a/src/main.js
+++ b/src/main.js
@@ -55,6 +55,7 @@ if (
   window.electron = true; //We set a global value to be used later
   //We use the Bridge as a way to share functions between electron and vue
   window.Bridge.statusAppend = txt => {
+    txt = '\n' + txt;
     store.commit('status/append', txt);
     store.dispatch('status/scrollToEnd');
   };

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -51,6 +51,7 @@ const steno_keyboards = ['gergo', 'georgi'];
 const getters = {
   firmwareFile: state => state.firmwareFile,
   filter: state => state.filter,
+  keyboard: state => state.keyboard,
   /**
    * keymapName
    * @param {object} state of store

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -43,7 +43,8 @@ const state = {
   author: '',
   notes: '',
   tutorialEnabled: false,
-  darkmodeEnabled: localStorageLoad('darkmode') === '1' || false
+  darkmodeEnabled: localStorageLoad('darkmode') === '1' || false,
+  electron: false
 };
 
 const steno_keyboards = ['gergo', 'georgi'];
@@ -52,6 +53,7 @@ const getters = {
   firmwareFile: state => state.firmwareFile,
   filter: state => state.filter,
   keyboard: state => state.keyboard,
+  electron: state => state.electron,
   /**
    * keymapName
    * @param {object} state of store
@@ -171,6 +173,9 @@ const mutations = {
   },
   disableCompile(state) {
     state.compileDisabled = true;
+  },
+  enableElectron(state) {
+    state.electron = true;
   },
   requestPreview(state) {
     state.previewRequested = true;


### PR DESCRIPTION
submitted to allow for a wider testing without having to host this on local machine for each test OS for flashing configuration. Also in preperation for beta release for wider testing of https://github.com/e11i0t23/qmk_configurator_electron

The Code added to main.js is required to detect weather the site is being run inside electron app or inside a web browser. In the first case we then share a simple function to allow for adding text to terminal with the app

When run in electron the download button is replaced by two alternative buttons, one for flashing a file compiled by config as well as an alternative for flashing a user pre-compiled this helps with testing the app and its multitude of flashers without having to recompile firmware but has been left in as is a useable feature.