### PR TITLE
Add Extended Space Cadet keys

### DIFF
--- a/src/store/modules/keycodes/quantum.js
+++ b/src/store/modules/keycodes/quantum.js
@@ -251,12 +251,12 @@ export default [
   {
     name: 'LS/(',
     code: 'KC_LSPO',
-    title: 'Left shift when held, ( when tapped'
+    title: 'Left Shift when held, ( when tapped'
   },
   {
     name: 'RS/)',
     code: 'KC_RSPC',
-    title: 'Right shift when held, ) when tapped'
+    title: 'Right Shift when held, ) when tapped'
   },
   {
     name: 'LC/(',

--- a/src/store/modules/keycodes/quantum.js
+++ b/src/store/modules/keycodes/quantum.js
@@ -257,5 +257,30 @@ export default [
     name: 'RS/)',
     code: 'KC_RSPC',
     title: 'Right shift when held, ) when tapped'
+  },
+  {
+    name: 'LC/(',
+    code: 'KC_LCPO',
+    title: 'Left Control when held, ( when tapped'
+  },
+  {
+    name: 'RC/)',
+    code: 'KC_RCPC',
+    title: 'Right Control when held, ) when tapped'
+  },
+  {
+    name: 'LA/(',
+    code: 'KC_LAPO',
+    title: 'Left Alt when held, ( when tapped'
+  },
+  {
+    name: 'RA/)',
+    code: 'KC_RAPC',
+    title: 'Right Alt when held, ) when tapped'
+  },
+  {
+    name: 'RS / Enter',
+    code: 'KC_SFTENT',
+    title: 'Right Shift when held, Enter when tapped'
   }
 ];


### PR DESCRIPTION
## Description / Commit Log

### Add Extended Space Cadet keys (42b76cd)

Add Control and Alt variants and Right Shift / Enter to Configurator's Quantum tab.

Requested by BafS#4387 on QMK Discord.

### Update key titles (db5196b)

Capitalize "Shift" to be consistent with Alt and Control.

![image](https://user-images.githubusercontent.com/18669334/63153439-2910b700-bfc3-11e9-9a0e-1e64080f7013.png)