### PR TITLE
Add a helpful switch count to UI

### DIFF
--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -41,6 +41,10 @@
           </select>
         </p>
         <visualKeymap :profile="false" />
+        <span class="keymap--count"
+          ><span class="keymap--counter">{{ size() }}</span
+          >Keys</span
+        >
       </div>
     </div>
   </div>
@@ -76,7 +80,7 @@ export default {
   computed: {
     ...mapState(['continuousInput']),
     ..._mapState('app', ['appInitialized']),
-    ...mapGetters(['colorwayIndex', 'colorways']),
+    ...mapGetters(['colorwayIndex', 'colorways', 'size']),
     curIndex: {
       get() {
         return this.colorwayIndex;
@@ -136,6 +140,15 @@ export default {
 }
 .keymap--label {
   float: left;
+}
+.keymap--counter {
+  display: inline-block;
+  padding: 0 5px;
+  margin-top: 2px;
+}
+.keymap--count {
+  float: right;
+  color: #999;
 }
 .keymap--keyset {
   float: right;

--- a/src/store/modules/keymap.js
+++ b/src/store/modules/keymap.js
@@ -40,7 +40,7 @@ const getters = {
   getLayer: state => _layer => {
     return state.keymap[_layer];
   },
-  size: state => _layer => {
+  size: state => (_layer = 0) => {
     return size(state.keymap[_layer]);
   },
   isDirty: state => state.dirty,


### PR DESCRIPTION
![Screen Shot 2019-09-14 at 20 23 00](https://user-images.githubusercontent.com/2275667/64916212-887ef580-d72e-11e9-9e22-8c629a113235.png)

 - is useful when trying to figure out the number of switches in a
 layout