### PR TITLE
Fix keycount when clearing base layer

### DIFF
--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -42,7 +42,7 @@
         </p>
         <visualKeymap :profile="false" />
         <span class="keymap--count"
-          ><span class="keymap--counter">{{ size() }}</span
+          ><span class="keymap--counter">{{ keyCount }}</span
           >Keys</span
         >
       </div>
@@ -55,7 +55,8 @@ import capitalize from 'lodash/capitalize';
 import {
   mapMutations as _mapMutations,
   createNamespacedHelpers,
-  mapState as _mapState
+  mapState as _mapState,
+  mapGetters as _mapGetters
 } from 'vuex';
 const { mapState, mapGetters, mapMutations } = createNamespacedHelpers(
   'keymap'
@@ -78,8 +79,9 @@ export default {
     LayerControl
   },
   computed: {
-    ...mapState(['continuousInput']),
     ..._mapState('app', ['appInitialized']),
+    ..._mapGetters('app', ['keyCount']),
+    ...mapState(['continuousInput']),
     ...mapGetters(['colorwayIndex', 'colorways', 'size']),
     curIndex: {
       get() {

--- a/src/store/modules/app/getters.js
+++ b/src/store/modules/app/getters.js
@@ -1,3 +1,5 @@
+import size from 'lodash/size';
+import isUndefined from 'lodash/isUndefined';
 const getters = {
   firmwareFile: state => state.firmwareFile,
   validateKeyboard: state => keyboard => {
@@ -23,6 +25,12 @@ const getters = {
     // issue #331 whitelist what we send to API for keymapName and save to disk
     exportName = exportName.replace(/[^a-z0-9_-]/gi, '');
     return exportName;
+  },
+  keyCount: state => {
+    if (size(state.layouts) > 0 && !isUndefined(state.layout)) {
+      return state.layouts[state.layout].length;
+    }
+    return 0;
   }
 };
 

--- a/src/store/modules/keymap.js
+++ b/src/store/modules/keymap.js
@@ -7,7 +7,7 @@ import colorways from '@/components/colorways';
 import defaults from './config';
 
 const state = {
-  keymap: [{}],
+  keymap: [[]], // array of arrays
   layer: 0,
   dirty: false,
   selectedIndex: undefined,
@@ -256,7 +256,10 @@ const mutations = {
     state.dirty = false;
   },
   clear(state) {
-    state.keymap = Vue.set(state, 'keymap', []);
+    mutations.initKeymap(state, {
+      layer: 0,
+      layout: state.keymap[0].map(() => {})
+    });
     state.dirty = false;
   },
   changeLayer(state, newLayer) {
@@ -330,7 +333,14 @@ const mutations = {
       mutations.initKeymap(state, { layer, layout: state.keymap[0] });
     } else {
       // TODO probably need to do something differently here
-      Vue.set(state.keymap, layer, []);
+      if (state.keymap[0].length > 0) {
+        mutations.initKeymap(state, {
+          layer,
+          layout: state.keymap[0].map(() => {})
+        });
+      } else {
+        Vue.set(state.keymap, layer, [[]]);
+      }
     }
   },
   setLoadingKeymapPromise(state, resolve) {


### PR DESCRIPTION
Fix for issue #501 

use the layout count rather than the keymap as we clear the base
layer and rely on the visual keymap to not send us incorrect
indices.  It may contain less than the entire keymap codes but
this is an internal detail that shouldn't be exposed to the UI.

The currently selected layout should always contain the correct number
of keys.

 - use a getter as this way it's cached until the layout or keyboard
 changes.

committed: #       modified:   src/components/Main.vue #       modified:
src/store/modules/app/getters.js # # Untracked files: #       CNAME