### PR TITLE
Fixes for Noxary 260 and KBDfans KBD67 Mk.II RGB

### DIFF
--- a/public/keymaps/kbdfans_kbd67_mkiirgb_default.json
+++ b/public/keymaps/kbdfans_kbd67_mkiirgb_default.json
@@ -1,8 +1,8 @@
 {
-  "keyboard": "kbdfans/kbd67mkiirgb",
-  "keymap": "default_a2b855f",
-  "commit": "a2b855febbaadb5b422e1096ddbdc8b5ff48ea4a",
-  "layout": "LAYOUT",
+  "keyboard": "kbdfans/kbd67/mkiirgb",
+  "keymap": "default_37b6a2a",
+  "commit": "37b6a2abbd96eaf3d6d724ac09c789d54a67d962",
+  "layout": "LAYOUT_65_ansi_blocker",
   "layers": [
     [
       "KC_GESC",         "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_HOME",

--- a/public/keymaps/noxary_260_default.json
+++ b/public/keymaps/noxary_260_default.json
@@ -1,8 +1,8 @@
 {
   "keyboard": "noxary/260",
-  "keymap": "default_9d5b4ec",
-  "commit": "9d5b4ec97549f3b20465b1e96fb781176a1814ea",
-  "layout": "LAYOUT",
+  "keymap": "default_0f9e265",
+  "commit": "0f9e2659c96370377e36ddab0508498e151bfc62",
+  "layout": "LAYOUT_all",
   "layers": [
     [
       "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_BSPC",


### PR DESCRIPTION
Fixes for renamed layout macros and path moves.