### PR TITLE
New Default Keymaps (Section V)

### DIFF
--- a/public/keymaps/vinta_default.json
+++ b/public/keymaps/vinta_default.json
@@ -1,0 +1,15 @@
+{
+  "keyboard": "vinta",
+  "keymap": "default_4d98c69",
+  "commit": "4d98c69e0297973789564ce508f2e8dafe69c32b",
+  "layout": "LAYOUT_69_ansi",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_GRV",  "KC_DEL",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC",            "KC_BSPC", "KC_PGUP",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",                       "KC_ENT",  "KC_PGDN",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",            "KC_UP",   "KC_END",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",                                   "KC_RALT", "RESET",   "KC_RCTL",            "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ]
+  ]
+}


### PR DESCRIPTION
This PR is brought to you by the letter V.

Just one keymap, for the Vinta. The V60 Type R doesn't compile in Configurator; it needs a refactor on the qmk_firmware side.