### PR TITLE
Add nightmare default layout

### DIFF
--- a/public/keymaps/nightmare_default.json
+++ b/public/keymaps/nightmare_default.json
@@ -1,0 +1,27 @@
+{
+    "keyboard": "nightmare",
+    "keymap": "default_2a948e7",
+    "commit": "2a948e77715f0bd11d4b80315cf84c68890014d4",
+    "layout": "LAYOUT_default",
+    "layers": [
+      [
+        "KC_HOME",    "KC_GESC",        "KC_Q",    "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I",    "KC_O",   "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",
+        "KC_END",     "LCTL_T(KC_TAB)", "KC_A",    "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K",    "KC_L",   "KC_SCLN", "KC_QUOT", "KC_ENT",
+        "KC_PGUP",    "KC_LSFT",        "KC_Z",    "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_RSFT", "MO(1)",
+        "KC_PGDN",                      "KC_LGUI", "KC_LALT",              "KC_SPC",               "KC_RCTL",                      "MO(2)"
+      ],
+      [
+        "KC_TRNS",    "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL", "KC_DEL",
+        "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_RGHT", "KC_TRNS",
+        "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+        "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+      ],
+      [
+        "KC_TRNS", "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_UP",   "KC_TRNS", "KC_TRNS",
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_RGHT", "KC_TRNS",
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_DOWN", "KC_TRNS", "KC_TRNS",
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+      ]
+    ]
+  }
+  


### PR DESCRIPTION
Adding default layout for the nightmare keyboard. Noticed there wasn't one since it was a recent merge into qmk. Not sure if this is standard practice around here, but hopefully a little less work for @noroadsleft! Tried to follow the standard as closely as possible, and tested changes on local dev server.

Layout from [qmk #6796](https://github.com/qmk/qmk_firmware/pull/6796)