### PR TITLE
Add Spanish translation

### DIFF
--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -84,6 +84,7 @@
           <option value="en">English</option>
           <option value="de">Deutsch</option>
           <option value="fr">Français</option>
+          <option value="es">Español</option>
         </select>
       </div>
     </div>

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -1,0 +1,156 @@
+import potato from './potato';
+import print from './print';
+import tester from './tester';
+export default {
+  en: {
+    message: {
+      ...potato,
+      help: {
+        label: 'Abrir tutorial'
+      },
+      print: { ...print },
+      tester: { ...tester },
+      keyboard: {
+        label: 'teclado'
+      },
+      layout: {
+        label: 'plano'
+      },
+      keymapName: {
+        label: 'Nombre de keymap',
+        placeholder: 'nombre de keymap personalizado'
+      },
+      loadDefault: {
+        label: 'Cargar valor por defecto',
+        title: 'Cargar valor por defecto para plano de Firmware QMK'
+      },
+      compile: {
+        label: 'Compilar',
+        title: 'Compilar el keymap'
+      },
+      downloadKeymap: {
+        title: 'Descargar solamente keymap.c',
+        label: 'solo keymap'
+      },
+      downloadSource: {
+        title: 'Dsecargar código de Firmware QMK',
+        label: 'Código completo'
+      },
+      downloadJSON: {
+        title: 'Exportar archivo JSON de Keymap QMK',
+        label: 'Keymap.JSON'
+      },
+      importJSON: {
+        title: 'Importar archivo JSON de Keymap QMK'
+      },
+      importUrlJSON: {
+        title: 'Import archivo JSON de Keymap QMK de URL'
+      },
+      printKeymap: {
+        title: 'Imprimir capas de keymap',
+        label: 'Imprimir keymap'
+      },
+      testKeys: {
+        title: 'Probar entrada del teclado',
+        label: 'Probar teclado'
+      },
+      downloadFirmware: {
+        label: 'Firmware',
+        title: 'Descargar archivo de firmware para instalar'
+      },
+      flashFirmware: {
+        label: 'Auto-Instalar',
+        title: 'Automaticamente instalar Firmware compilado al MCU'
+      },
+      flashFile: {
+        label: 'Instalar personalizado',
+        title: 'Instalar archivo elegido al MCU'
+      },
+      ColorwayTip: {
+        title: 'Ctrl + Alt + N para cambiar al próximo color'
+      },
+      layer: {
+        label: 'Capa',
+        confirm: '¿Estás seguro de que quieres borrar la capa?',
+        title: 'Borrar capa'
+      },
+      keymap: {
+        label: 'Keymap'
+      },
+      downloadToolbox: {
+        label: 'Descargar QMK Toolbox'
+      },
+      keycodes: {
+        label: 'Códigos de teclas'
+      },
+      keycodesRef: {
+        label: 'Referencia de códigos de tecla'
+      },
+      keycodesTab: {
+        ANSI: {
+          label: 'ANSI'
+        },
+        'ISO/JIS': {
+          label: 'ISO/JIS'
+        },
+        Quantum: {
+          label: 'Quantum'
+        },
+        KeyboardSettings: {
+          label: 'Configuración de teclado'
+        },
+        AppMediaMouse: {
+          label: 'App, Media y Mouse'
+        }
+      },
+      settingsPanel: {
+        title: 'Configuración de Configurator',
+        fastInput: {
+          label: 'Entrada rápida',
+          title: 'ctrl + alt + f',
+          help:
+            'Ingresar teclas por media del teclado sin hacer clic en cada posición.'
+        },
+        displaySizes: {
+          label: 'Mostrar tamaño de teclas',
+          title: 'ctrl + alt + u',
+          help: 'Mostrar tamaños de keycaps en Unidades de Tecla'
+        },
+        toggleTutorial: {
+          label: 'Video Tutorial',
+          title: 'MechMerlin video how-to para Configurator',
+          help: 'MechMerlin video guía'
+        },
+        darkmode: {
+          label: 'Cambiar Modo oscuro',
+          title: 'Modo oscuro'
+        },
+        language: {
+          title: 'Idioma'
+        },
+        on: {
+          label: 'Sí'
+        },
+        off: {
+          label: 'No'
+        }
+      },
+      errors: {
+        invalidQMKKeymap:
+          'Lo siento, pero parece que este no es un archivo válido de keymap QMK.',
+        kbfirmwareJSONUnsupported:
+          'Lo siento, el Configurator QMK no permite importar archivos JSON de kbfirmware.',
+        unknownJSON: 'Lo siento, este no parece ser un archivo keymap QMK.',
+        unsupportedBrowser:
+          'Estás usando un navegador incompatible. Por favor usa'
+      },
+      statsTemplate:
+        '\nCargó {layers} capas y {count} códigos de tecla. Definió {any} Any tecla códigos de tecla\n',
+      maintain: 'Este proyecto se mantiene por colaboradores QMK como tú!',
+      hostedOn: 'Alojado en GitHub Pages',
+      serverStatus: 'Servidor',
+      apiVersion: 'Versión de API',
+      jobsWaiting: 'trabajo(s) esperando'
+    }
+  }
+};

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -14,7 +14,7 @@ export default {
         label: 'teclado'
       },
       layout: {
-        label: 'plano'
+        label: 'layout'
       },
       keymapName: {
         label: 'Nombre de keymap',
@@ -22,7 +22,7 @@ export default {
       },
       loadDefault: {
         label: 'Cargar Original',
-        title: 'Cargar valor por defecto para plano de Firmware QMK'
+        title: 'Cargar valor por defecto para layout de Firmware QMK'
       },
       compile: {
         label: 'Compilar',
@@ -33,7 +33,7 @@ export default {
         label: 'solo keymap'
       },
       downloadSource: {
-        title: 'Dsecargar código de Firmware QMK',
+        title: 'Descargar código de Firmware QMK',
         label: 'Código completo'
       },
       downloadJSON: {
@@ -44,7 +44,7 @@ export default {
         title: 'Importar archivo JSON de Keymap QMK'
       },
       importUrlJSON: {
-        title: 'Import archivo JSON de Keymap QMK de URL'
+        title: 'Importar archivo JSON de Keymap QMK desde URL'
       },
       printKeymap: {
         title: 'Imprimir capas de keymap',
@@ -60,7 +60,7 @@ export default {
       },
       flashFirmware: {
         label: 'Auto-Instalar',
-        title: 'Automaticamente instalar Firmware compilado al MCU'
+        title: 'Automáticamente instalar Firmware compilado al MCU'
       },
       flashFile: {
         label: 'Instalar personalizado',
@@ -146,7 +146,7 @@ export default {
       },
       statsTemplate:
         '\nCargó {layers} capas y {count} códigos de tecla. Definió {any} Any tecla códigos de tecla\n',
-      maintain: 'Este proyecto se mantiene por colaboradores QMK como tú!',
+      maintain: '¡Este proyecto se mantiene por colaboradores QMK como tú!',
       hostedOn: 'Alojado en GitHub Pages',
       serverStatus: 'Servidor',
       apiVersion: 'Versión de API',

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -109,7 +109,7 @@ export default {
           label: 'Entrada rápida',
           title: 'ctrl + alt + f',
           help:
-            'Ingresar teclas por media del teclado sin hacer clic en cada posición.'
+            'Ingresar teclas por medio del teclado sin hacer click en cada posición.'
         },
         displaySizes: {
           label: 'Mostrar tamaño de teclas',

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -2,7 +2,7 @@ import potato from './potato';
 import print from './print';
 import tester from './tester';
 export default {
-  en: {
+  es: {
     message: {
       ...potato,
       help: {
@@ -21,7 +21,7 @@ export default {
         placeholder: 'nombre de keymap personalizado'
       },
       loadDefault: {
-        label: 'Cargar valor por defecto',
+        label: 'Cargar Original',
         title: 'Cargar valor por defecto para plano de Firmware QMK'
       },
       compile: {

--- a/src/i18n/es/potato.js
+++ b/src/i18n/es/potato.js
@@ -1,0 +1,32 @@
+export default {
+  potato: {
+    1: 'Henry Spalding primero plantó papas en Idaho en 1837.',
+    2: '“Papas fritas” fueron dadas a conocer en America cuando Thomas Jefferson las sirvió en una cena de la Casa Blanca.',
+    3: 'Fanáticos estadounidenses de papas ingirieron más de 4 millones de toneladas de papas fritas en varias formas y tamaños en 2017.',
+    4: 'Las papas son un potente afrodisiaco, según un médico irlandés.',
+    5: 'El estadounidense promedio come 140 libras de papas cada año. Los alemanes comen más de 200 libras al año.',
+    6: 'La papa más grande pesó 18 libras y 4 onzas, según el Libro de Records Mundiales de Guinness. Fue cultivada en Inglaterra en 1795.',
+    7: 'Las papas son el cuarto alimento básico del mundo – después de trigo, maíz y arroz.',
+    8: 'Las papas son cultivadas en más de 125 países.',
+    9: 'Cada año el mundo produce una cantidad de papas suficientes para cubrir una carretera de cuatro carriles que rodea el mundo seis veces.',
+    10: 'China es el mayor proveedor de papas del mundo.',
+    11: 'Las papas fueron la primera verdura cultivada en el espacio.',
+    12: 'Las papas son completamente libres de gluten.',
+    13: 'Una de las medidas básicas de tiempo de los Inca fue el tiempo necesario para cocinar una papa.',
+    14: 'Si una papa está expuesta a la luz mientras crece, se pondrá verde y llegará a ser venenosa.',
+    15: 'Se requiere 10,000 libras de papas para preparar 2,500 libras de papitas.',
+    16: 'Hoy en día hay más de 4,000 variedades de papas.',
+    17: 'Las papas pertenecen a una familia pequeña, las belladonas o solanáceas.',
+    18: 'Durante la Fiebre del oro de Klondike (1897-1898), las papas prácticamente valían su peso en oro.',
+    19: 'Walter Raleigh introdujo las papas en Inglaterra en 1589 en los 40,000 acres de terreno cerca de Cork.',
+    20: 'Las papas están disponibles todo el año gracias a que se cosechan en alguna parte del mundo cada mes del año.',
+    21: 'Nativos de Africa y Asia, los ñames (camotes) varían en tamaño desde el tamaño de una papa pequeña hasta el temaño de récord de 130 libras.',
+    22: 'El 19 de agosto y el 27 de octubre son el Día Noacional de la Papa.',
+    23: 'Las papas también se usan para elaborar bebidas alcohólicas tal como el vodka, poitín o aquavit.',
+    24: 'Las papas son entre las verduras más ecológicas. Son fáciles de cultivar y no requieren cantidades masivas de abono y aditivos químicos para prosperar como muchas otras verduras.',
+    25: 'La papa proviene de la región del sur de Perú donde fue domesticada por primera vez entre 8000 a. C. y 5000 a. C.',
+    26: 'La palabra inglesa "potato" proviene de la palabra española "patata".',
+    27: 'Las plantas de papas suelen ser polinizadas por insectos como abejas.',
+    28: 'Una papa se compone de 80% agua y 20% materia sólida.'
+  }
+};

--- a/src/i18n/es/print.js
+++ b/src/i18n/es/print.js
@@ -3,7 +3,7 @@ export default {
     label: 'Teclado'
   },
   layout: {
-    label: 'Plano'
+    label: 'Layout'
   },
   layer: {
     label: 'Capa'

--- a/src/i18n/es/print.js
+++ b/src/i18n/es/print.js
@@ -1,0 +1,35 @@
+export default {
+  keyboard: {
+    label: 'Teclado'
+  },
+  layout: {
+    label: 'Plano'
+  },
+  layer: {
+    label: 'Capa'
+  },
+  anonymous: {
+    label: 'Anónimo'
+  },
+  author: {
+    title: 'Autor',
+    placeholder: 'Opcionalmente, Tu Nombre'
+  },
+  date: {
+    title: 'Fecha'
+  },
+  source: {
+    title: 'Fuente'
+  },
+  print: {
+    title: 'Imprimir'
+  },
+  back: {
+    title: 'Atrás'
+  },
+  notes: {
+    title: 'Notas',
+    placeholder: 'Notas sobre esta configuración',
+    empty: 'Mi keymap genial'
+  }
+};

--- a/src/i18n/es/tester.js
+++ b/src/i18n/es/tester.js
@@ -1,0 +1,35 @@
+export default {
+  page: {
+    label: 'Probador de teclado'
+  },
+  keycodeStatus: {
+    label: 'Códigos de teclas detectados'
+  },
+  back: {
+    label: 'Atrás',
+    title: 'Regresar a Configurator'
+  },
+  reset: {
+    label: 'Restablecer',
+    title: 'Restablecer las teclas detectadas'
+  },
+  letters: {
+    keycode: {
+      label: 'código de tecla'
+    },
+    code: {
+      label: 'código'
+    },
+    key: {
+      label: 'tecla'
+    }
+  },
+  docs: {
+    paragraph:
+      'Nota: Tecla y código detectado pueden ser diferentes según tu localidad. Docs'
+  },
+  chatter: {
+    label: 'Umbral de chatter (ms)',
+    detectedAlert: '¡se ha detectado chatter!'
+  }
+};

--- a/src/i18n/es/tester.js
+++ b/src/i18n/es/tester.js
@@ -30,6 +30,6 @@ export default {
   },
   chatter: {
     label: 'Umbral de chatter (ms)',
-    detectedAlert: '¡se ha detectado chatter!'
+    detectedAlert: '¡Se ha detectado chatter!'
   }
 };

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -3,10 +3,12 @@ import ja from './ja';
 import zh from './zh';
 import fr from './fr';
 import de from './de';
+import es from './es';
 export default {
   ...en,
   ...ja,
   ...de,
   ...fr,
-  ...zh
+  ...zh,
+  ...es
 };

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,14 +1,14 @@
+import de from './de';
 import en from './en';
+import es from './es';
+import fr from './fr';
 import ja from './ja';
 import zh from './zh';
-import fr from './fr';
-import de from './de';
-import es from './es';
 export default {
-  ...en,
-  ...ja,
   ...de,
+  ...en,
+  ...es,
   ...fr,
-  ...zh,
-  ...es
+  ...ja,
+  ...zh
 };


### PR DESCRIPTION
I have created the Spanish (es) translation folder and added all the necessary translations. I also added Spanish as an option in the Language dropdown in [SettingsPanel.vue](https://github.com/qmk/qmk_configurator/blob/master/src/components/SettingsPanel.vue) on line 83. This was not part of the translation readme (should it be? 🤷‍♂️). 