### PR TITLE
add env variable handling for API url

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VUE_APP_API_URL=https://api.qmk.fm

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VUE_APP_API_URL=https://api.qmk.fm

--- a/src/store/modules/constants.js
+++ b/src/store/modules/constants.js
@@ -1,6 +1,9 @@
 import template from 'lodash/template';
 
-export const backend_baseurl = 'https://api.qmk.fm';
+export const backend_baseurl = process.env.VUE_APP_API_URL;
+if (!backend_baseurl) {
+  throw 'Backend URL has not been specified';
+}
 export const backend_keyboards_url = `${backend_baseurl}/v1/keyboards`;
 export const backend_compile_url = `${backend_baseurl}/v1/compile`;
 export const backend_status_url = `${backend_baseurl}/v1`;


### PR DESCRIPTION
fix #413 
Based on the vue cli constaints : https://cli.vuejs.org/guide/mode-and-env.html#modes

.env file is loaded and can be modified for a local development environment.
.env.production is used when we use `yarn build`

Also if the runtime doesn't find the variable, it throw exception at startup.