### PR TITLE
Fixed bug with spinner where text was appearing gray.

### DIFF
--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -202,8 +202,8 @@ html {
       border-color: #000;
     }
     .spinner {
-      & .message,
-      & .status {
+      .message,
+      .status {
         color: #eee;
       }
     }

--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -202,8 +202,8 @@ html {
       border-color: #000;
     }
     .spinner {
-      &.message,
-      &.status {
+      & .message,
+      & .status {
         color: #eee;
       }
     }


### PR DESCRIPTION
Fixed .spinner css class so that the child classes (.message and .status) would actually have the style applied to them.

## Before
![image](https://user-images.githubusercontent.com/25801283/66271360-b1e8f800-e87a-11e9-849e-8f2cbe1074da.png)

## After
![image](https://user-images.githubusercontent.com/25801283/66271377-dc3ab580-e87a-11e9-9112-146318b0cb30.png)