### PR TITLE
Fixed key label positioning

### DIFF
--- a/src/components/AnyKey.vue
+++ b/src/components/AnyKey.vue
@@ -13,14 +13,14 @@
     @dragleave.prevent="dragleave"
     @dragover.prevent="dragover"
     @dragenter.prevent="dragenter"
-  >{{ displayName }}<input
-    class="key-layer-input"
-    @focus.prevent.stop="focus"
-    @blur.prevent.stop="blur"
-    @click.prevent.stop="clickignore"
-    ref="input"
-    spellcheck="false"
-    v-model="value" /><div
+  ><div>{{ displayName }}<div><input
+  class="key-layer-input"
+  @focus.prevent.stop="focus"
+  @blur.prevent.stop="blur"
+  @click.prevent.stop="clickignore"
+  ref="input"
+  spellcheck="false"
+  v-model="value" /></div></div><div
         v-if="visible"
         class="remove"
         @click.stop="remove"

--- a/src/components/ContainerKey.vue
+++ b/src/components/ContainerKey.vue
@@ -13,13 +13,13 @@
     @dragover.prevent="dragover"
     @dragenter="dragenter"
     @dragleave="dragleave"
-    >{{ displayName }}<div
-      class="key-contents"
-      :class="contentClasses"
-      @dragenter.prevent="dragenterContents"
-      @dragleave.prevent="dragleaveContents"
-      @click.prevent.stop="clickContents"
-      >{{ contents }}</div><div
+    ><div>{{ displayName }}<div
+    class="key-contents"
+    :class="contentClasses"
+    @dragenter.prevent="dragenterContents"
+    @dragleave.prevent="dragleaveContents"
+    @click.prevent.stop="clickContents"
+    >{{ contents }}</div></div><div
         v-if="visible"
         class="remove"
         @click.stop="remove"

--- a/src/components/LayerContainerKey.vue
+++ b/src/components/LayerContainerKey.vue
@@ -14,13 +14,13 @@
     @dragover.prevent="dragover"
     @dragenter="dragenter"
     @dragleave="dragleave"
-  >LT {{ meta.layer }}<div
-      class="key-contents"
-      :class="contentClasses"
-      @dragenter.prevent="dragenterContents"
-      @dragleave.prevent="dragleaveContents"
-      @click.prevent.stop="clickContents"
-    >{{ contents }}</div>
+  ><div>LT {{ meta.layer }}<div
+  class="key-contents"
+  :class="contentClasses"
+  @dragenter.prevent="dragenterContents"
+  @dragleave.prevent="dragleaveContents"
+  @click.prevent.stop="clickContents"
+  >{{ contents }}</div></div>
     <div v-if="visible" class="remove" @click.stop="remove">x</div>
   </div>
 </template>

--- a/src/components/LayerKey.vue
+++ b/src/components/LayerKey.vue
@@ -13,17 +13,17 @@
     @dragleave.prevent="dragleave"
     @dragover.prevent="dragover"
     @dragenter.prevent="dragenter"
-    >{{ displayName }}<div><input
-      class="key-layer-input"
-      :class="errorClasses"
-      type="number"
-      min="0"
-      max="15"
-      :value="value"
-      @focus="focus"
-      @blur="blur"
-      @input="input"
-      /></div><div
+    ><div>{{ displayName }}<div><input
+    class="key-layer-input"
+    :class="errorClasses"
+    type="number"
+    min="0"
+    max="15"
+    :value="value"
+    @focus="focus"
+    @blur="blur"
+    @input="input"
+    /></div></div><div
         v-if="visible"
         class="remove"
         @click.stop="remove"

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -764,7 +764,6 @@ button {
 .key-container,
 .key-layer {
   font-size: 10px;
-  display: block;
 }
 
 .key-contents {


### PR DESCRIPTION
Key labels (in particular ones containing inputs – like ANY, MO, etc.) are now horizontally & vertically centered, regardless of key size (Fixes https://github.com/qmk/qmk_configurator/issues/126)

![Fixed key label positioning](https://user-images.githubusercontent.com/153263/66488747-be559680-eaae-11e9-876b-6730976bc267.png)
