### PR TITLE
CI : add json lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 
 script:
   - yarn run prettier:check
+  - yarn run prettier:json:check
   - yarn run lint
   - yarn run test:unit
   - yarn run test:cypress:ci

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint",
     "prettier:check": "prettier -c \"./src/**/*.{js,vue,scss,css,json}\"",
     "prettier:fix": "prettier -c \"./src/**/*.{js,vue,scss,css,json}\" --write",
+    "prettier:json:check": "prettier -c \"./public/**/*.json\"; if [[ $? == 1 ]]; then exit 0; else exit 1; fi",
     "test:cypress": "cypress run",
     "test:cypress:ci": "start-server-and-test serve http://localhost:8080 test:cypress",
     "test:unit": "vue-cli-service test:unit"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint",
     "prettier:check": "prettier -c \"./src/**/*.{js,vue,scss,css,json}\"",
     "prettier:fix": "prettier -c \"./src/**/*.{js,vue,scss,css,json}\" --write",
-    "prettier:json:check": "prettier -c \"./public/**/*.json\"; if [ $? == 1 ]; then exit 0; else exit 1; fi",
+    "prettier:json:check": "prettier -c \"./public/**/*.json\"; if [ $? = 1 ]; then exit 0; else exit 1; fi",
     "test:cypress": "cypress run",
     "test:cypress:ci": "start-server-and-test serve http://localhost:8080 test:cypress",
     "test:unit": "vue-cli-service test:unit"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint",
     "prettier:check": "prettier -c \"./src/**/*.{js,vue,scss,css,json}\"",
     "prettier:fix": "prettier -c \"./src/**/*.{js,vue,scss,css,json}\" --write",
-    "prettier:json:check": "prettier -c \"./public/**/*.json\"; if [[ $? == 1 ]]; then exit 0; else exit 1; fi",
+    "prettier:json:check": "prettier -c \"./public/**/*.json\"; if [ $? == 1 ]; then exit 0; else exit 1; fi",
     "test:cypress": "cypress run",
     "test:cypress:ci": "start-server-and-test serve http://localhost:8080 test:cypress",
     "test:unit": "vue-cli-service test:unit"

--- a/public/keymaps/zlant_default.json
+++ b/public/keymaps/zlant_default.json
@@ -17,4 +17,4 @@
       "RGB_VAI", "RGB_VAD", "RESET",   "KC_PSCR", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PGDN", "KC_END",  "KC_TRNS", "KC_DEL"
     ]
   ]
-},
+}

--- a/public/keymaps/zlant_default.json
+++ b/public/keymaps/zlant_default.json
@@ -17,4 +17,4 @@
       "RGB_VAI", "RGB_VAD", "RESET",   "KC_PSCR", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PGDN", "KC_END",  "KC_TRNS", "KC_DEL"
     ]
   ]
-}
+},


### PR DESCRIPTION
This adds the json linting in the `public/keymaps` folder. 
Also this only checks if there is no error in the files, it does not check the syntax, otherwise the matrix would not be readable for maintainers. That's why there is this weird command :
```bash
"prettier:json:check": "prettier -c \"./public/**/*.json\"; if [ $? = 1 ]; then exit 0; else exit 1; fi",
```
So, if a syntax error happens or anything else it throws an exit code > 1 , if it's just linting issue it throws 1.

Also as you can see in the commits / pipelines i've added a crashtest to be sure that in case of an invalid json it triggers error.