### PR TITLE
Feat: Add brightness up and down keycodes

### DIFF
--- a/src/store/modules/keycodes/app-media-mouse.js
+++ b/src/store/modules/keycodes/app-media-mouse.js
@@ -82,6 +82,18 @@ export default [
     title: 'Browser Favorites (Windows)',
     width: 1500
   },
+  {
+    name: 'Brightness Up',
+    code: 'KC_BRIU',
+    title: 'Increase the brightness of screen (Laptop)',
+    width: 1500
+  },
+  {
+    name: 'Brightness Down',
+    code: 'KC_BRID',
+    title: 'Decrease the brightness of screen (Laptop)',
+    width: 1500
+  },
 
   { label: 'Multimedia Keys', width: 'label' },
 


### PR DESCRIPTION
This PR fixes the issue #535.

Two keycodes, `KC_BRIU` and `KC_BRID`, are added under `App, Media and Mouse` tab and in the `Application` section.

Reference: [QMK Keycodes](https://docs.qmk.fm/#/keycodes_basic)

Screenshot 
![image](https://user-images.githubusercontent.com/1403932/66648323-fc9db200-ec76-11e9-8aca-c572dacca8be.png)

Any suggestion or feedback is very welcome.
