### PR TITLE
Fix */PrintScreen key on converter/xt_usb default keymap

### DIFF
--- a/public/keymaps/converter_xt_usb_default.json
+++ b/public/keymaps/converter_xt_usb_default.json
@@ -8,7 +8,7 @@
       "KC_F1",   "KC_F2",   "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",            "KC_NLCK",            "KC_SLCK",
       "KC_F3",   "KC_F4",   "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC",            "KC_P7",   "KC_P8",   "KC_P9",   "KC_PMNS",
       "KC_F5",   "KC_F6",   "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_GRV",  "KC_ENT",  "KC_P4",   "KC_P5",   "KC_P6",
-      "KC_F7",   "KC_F8",   "KC_LSFT", "KC_BSLS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_PSCR", "KC_P1",   "KC_P2",   "KC_P3",   "KC_PPLS",
+      "KC_F7",   "KC_F8",   "KC_LSFT", "KC_BSLS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_PAST", "KC_P1",   "KC_P2",   "KC_P3",   "KC_PPLS",
       "KC_F9",   "KC_F10",  "KC_LALT",                                                        "KC_SPC",                                                         "KC_CAPS",            "KC_P0",              "KC_PDOT"
     ]
   ]


### PR DESCRIPTION
Relates to qmk/qmk_firmware#7039.

This key is actually the numpad `*` when pressed without Shift or Ctrl:

https://en.wikipedia.org/wiki/File:IBM_Model_F_XT.png