### PR TITLE
Remove the border style on the key when we're inside the print view

### DIFF
--- a/src/components/PrintKey.vue
+++ b/src/components/PrintKey.vue
@@ -64,4 +64,8 @@ export default {
   height: 0;
   clear: both;
 }
+
+.print-keymap > .keycode-select {
+  border: none !important;
+}
 </style>


### PR DESCRIPTION
Fixes #487
This remove the selected border on when you're on the print view.

I went with a simple css fix to keep the same logic for how we render the normal keyboard and how we render the print version.

I wasn't sure about where I put the css bit so if it needs to be somewhere else tell me