### PR TITLE
Remove macOS-specific Volume Keycodes

### DIFF
--- a/src/i18n/it/index.js
+++ b/src/i18n/it/index.js
@@ -108,7 +108,8 @@ export default {
         fastInput: {
           label: 'Ingresso rapido',
           title: 'ctrl + alt + f',
-          help: 'Inserire i tasti tramite la tastiera senza fare clic su ciascuna posizione.'
+          help:
+            'Inserire i tasti tramite la tastiera senza fare clic su ciascuna posizione.'
         },
         displaySizes: {
           label: 'Mostra dimensione chiave',
@@ -136,11 +137,11 @@ export default {
       },
       errors: {
         invalidQMKKeymap:
-          "Ma sembra che questo non sia un file valido keymap QMK.",
+          'Ma sembra che questo non sia un file valido keymap QMK.',
         kbfirmwareJSONUnsupported:
-          "Il Configuratore QMK non consente di importare i file JSON da kbfirmware.",
-        unknownJSON: "Questo non sembra essere un file keymap QMK.",
-        unsupportedBrowser: "Stai usando un browser incompatibile. Utilizzare"
+          'Il Configuratore QMK non consente di importare i file JSON da kbfirmware.',
+        unknownJSON: 'Questo non sembra essere un file keymap QMK.',
+        unsupportedBrowser: 'Stai usando un browser incompatibile. Utilizzare'
       },
       statsTemplate:
         '\nCarico {layers} livellos e {count} codici chiave. Definito {any} Any chiave codice chiave\n',

--- a/src/store/modules/keycodes/app-media-mouse.js
+++ b/src/store/modules/keycodes/app-media-mouse.js
@@ -104,14 +104,9 @@ export default [
   { name: 'Vol +', code: 'KC_VOLU', title: 'Volume Up' },
   { name: 'Media Stop', code: 'KC_MSTP', title: 'Media Stop' },
   { name: 'Play', code: 'KC_MPLY', title: 'Play/Pause' },
-
-  { label: 'Multimedia Keys (macOS)', width: 'label' },
-
-  { name: 'Prev Track', code: 'KC_MRWD', title: 'Previous Track (macOS)' },
-  { name: 'Next Track', code: 'KC_MFFD', title: 'Next Track (macOS)' },
-  { name: 'Mute', code: 'KC__MUTE', title: 'Mute Audio (macOS)' },
-  { name: 'Vol -', code: 'KC__VOLDOWN', title: 'Volume Down (macOS)' },
-  { name: 'Vol +', code: 'KC__VOLUP', title: 'Volume Up (macOS)' },
+  { width: 250 },
+  { name: 'Prev Track', code: 'KC_MRWD', title: 'Previous Track / Rewind (macOS)' },
+  { name: 'Next Track', code: 'KC_MFFD', title: 'Next Track / Fast Forward (macOS)' },
   { width: 250 },
   { name: 'Eject', code: 'KC_EJCT', title: 'Eject (macOS)' },
 

--- a/src/store/modules/keycodes/app-media-mouse.js
+++ b/src/store/modules/keycodes/app-media-mouse.js
@@ -105,8 +105,16 @@ export default [
   { name: 'Media Stop', code: 'KC_MSTP', title: 'Media Stop' },
   { name: 'Play', code: 'KC_MPLY', title: 'Play/Pause' },
   { width: 250 },
-  { name: 'Prev Track', code: 'KC_MRWD', title: 'Previous Track / Rewind (macOS)' },
-  { name: 'Next Track', code: 'KC_MFFD', title: 'Next Track / Fast Forward (macOS)' },
+  {
+    name: 'Prev Track',
+    code: 'KC_MRWD',
+    title: 'Previous Track / Rewind (macOS)'
+  },
+  {
+    name: 'Next Track',
+    code: 'KC_MFFD',
+    title: 'Next Track / Fast Forward (macOS)'
+  },
   { width: 250 },
   { name: 'Eject', code: 'KC_EJCT', title: 'Eject (macOS)' },
 


### PR DESCRIPTION
They don't work in Windows/Linux and thereby confuse users. Also updated titles on the macOS Previous/Next Track keycodes (they behave differently than the standard codes do on macOS).