### PR TITLE
Update Planck and Preonic keymaps

### DIFF
--- a/public/keymaps/planck_ez_default.json
+++ b/public/keymaps/planck_ez_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "planck/ez",
-  "keymap": "default_29824f3",
-  "commit": "29824f3cf7cb09337a4c579ea108418e4de99b8b",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
   "layout": "LAYOUT_planck_1x2uC",
   "layers": [
     [
@@ -26,7 +26,7 @@
       "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
       "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
       "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS",       "MO(6)",  "KC_MNXT",       "KC_VOLD",       "KC_VOLU", "KC_MPLY"
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS",       "MO(6)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
     ],
     [
       "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
@@ -42,7 +42,7 @@
     ],
     [
       "KC_TRNS", "RESET",   "DEBUG",   "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD",  "RGB_VAI", "RGB_VAD", "KC_DEL",
-      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "TO(0)",   "TO(1)",    "TO(2)",   "TO(5)",   "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "TO(5)",   "KC_TRNS",
       "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS",
       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS",       "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ]

--- a/public/keymaps/planck_light_default.json
+++ b/public/keymaps/planck_light_default.json
@@ -1,15 +1,50 @@
 {
-   "keyboard":"planck/light",
-   "keymap":"defaultish_8c03349",
-   "commit":"8c033497c62970087ae16c3e7c42fd72f3e1ecbe",
-   "layout":"LAYOUT_ortho_4x12",
-   "layers":[
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",  "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",  "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC", "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",  "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",    "KC_ASTR",    "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",    "KC_PLUS",    "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6", "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",  "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1"   ,"KC_NO", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_NO", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NO", "KC_NO", "KC_NO", "KC_C",    "KC_V",    "KC_NO", "KC_NO", "KC_N",    "KC_M",    "KC_NO", "KC_NO", "KC_NO"],
-      ["KC_TRNS", "RESET",   "DEBUG",    "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_DEL" , "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "KC_NO",  "KC_NO", "KC_NO",  "KC_NO",  "KC_TRNS", "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON", "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
-   ]
+  "keyboard": "planck/light",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_ortho_4x12",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",
+      "KC_NO",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC",
+      "KC_NO",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "TO(0)",   "KC_NO",   "KC_NO",   "KC_C",    "KC_V",    "KC_NO",   "KC_NO",   "KC_N",    "KC_M",    "KC_NO",   "KC_NO",   "KC_NO"
+    ],
+    [
+      "KC_TRNS", "RESET",   "DEBUG",   "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD",  "RGB_VAI", "RGB_VAD", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "TO(5)",   "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
 }

--- a/public/keymaps/planck_rev1_default.json
+++ b/public/keymaps/planck_rev1_default.json
@@ -1,15 +1,50 @@
 {
-   "keyboard":"planck/rev1",
-   "keymap":"defaultish_8c03349",
-   "commit":"8c033497c62970087ae16c3e7c42fd72f3e1ecbe",
-   "layout":"LAYOUT_ortho_4x12",
-   "layers":[
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",  "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",  "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC", "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",  "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",    "KC_ASTR",    "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",    "KC_PLUS",    "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6", "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",  "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1"   ,"KC_NO", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_NO", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NO", "KC_NO", "KC_NO", "KC_C",    "KC_V",    "KC_NO", "KC_NO", "KC_N",    "KC_M",    "KC_NO", "KC_NO", "KC_NO"],
-      ["KC_TRNS", "RESET",   "DEBUG",    "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_DEL" , "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "KC_NO",  "KC_NO", "KC_NO",  "KC_NO",  "KC_TRNS", "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON", "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
-   ]
+  "keyboard": "planck/rev1",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_ortho_4x12",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",
+      "KC_NO",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC",
+      "KC_NO",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "TO(0)",   "KC_NO",   "KC_NO",   "KC_C",    "KC_V",    "KC_NO",   "KC_NO",   "KC_N",    "KC_M",    "KC_NO",   "KC_NO",   "KC_NO"
+    ],
+    [
+      "KC_TRNS", "RESET",   "DEBUG",   "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD",  "RGB_VAI", "RGB_VAD", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "TO(5)",   "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
 }

--- a/public/keymaps/planck_rev2_default.json
+++ b/public/keymaps/planck_rev2_default.json
@@ -1,15 +1,50 @@
 {
-   "keyboard":"planck/rev2",
-   "keymap":"defaultish_8c03349",
-   "commit":"8c033497c62970087ae16c3e7c42fd72f3e1ecbe",
-   "layout":"LAYOUT_ortho_4x12",
-   "layers":[
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",  "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",  "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC", "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",  "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",    "KC_ASTR",    "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",    "KC_PLUS",    "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6", "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",  "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1"   ,"KC_NO", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_NO", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NO", "KC_NO", "KC_NO", "KC_C",    "KC_V",    "KC_NO", "KC_NO", "KC_N",    "KC_M",    "KC_NO", "KC_NO", "KC_NO"],
-      ["KC_TRNS", "RESET",   "DEBUG",    "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_DEL" , "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "KC_NO",  "KC_NO", "KC_NO",  "KC_NO",  "KC_TRNS", "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON", "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
-   ]
+  "keyboard": "planck/rev2",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_ortho_4x12",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",
+      "KC_NO",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC",
+      "KC_NO",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "TO(0)",   "KC_NO",   "KC_NO",   "KC_C",    "KC_V",    "KC_NO",   "KC_NO",   "KC_N",    "KC_M",    "KC_NO",   "KC_NO",   "KC_NO"
+    ],
+    [
+      "KC_TRNS", "RESET",   "DEBUG",   "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD",  "RGB_VAI", "RGB_VAD", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "TO(5)",   "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
 }

--- a/public/keymaps/planck_rev3_default.json
+++ b/public/keymaps/planck_rev3_default.json
@@ -1,15 +1,50 @@
 {
-   "keyboard":"planck/rev3",
-   "keymap":"defaultish_8c03349",
-   "commit":"8c033497c62970087ae16c3e7c42fd72f3e1ecbe",
-   "layout":"LAYOUT_ortho_4x12",
-   "layers":[
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",  "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",  "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC", "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",  "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",    "KC_ASTR",    "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",    "KC_PLUS",    "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6", "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",  "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1"   ,"KC_NO", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_NO", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NO", "KC_NO", "KC_NO", "KC_C",    "KC_V",    "KC_NO", "KC_NO", "KC_N",    "KC_M",    "KC_NO", "KC_NO", "KC_NO"],
-      ["KC_TRNS", "RESET",   "DEBUG",    "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_DEL" , "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "KC_NO",  "KC_NO", "KC_NO",  "KC_NO",  "KC_TRNS", "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON", "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
-   ]
+  "keyboard": "planck/rev3",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_ortho_4x12",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",
+      "KC_NO",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC",
+      "KC_NO",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "TO(0)",   "KC_NO",   "KC_NO",   "KC_C",    "KC_V",    "KC_NO",   "KC_NO",   "KC_N",    "KC_M",    "KC_NO",   "KC_NO",   "KC_NO"
+    ],
+    [
+      "KC_TRNS", "RESET",   "DEBUG",   "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD",  "RGB_VAI", "RGB_VAD", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "TO(5)",   "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
 }

--- a/public/keymaps/planck_rev4_default.json
+++ b/public/keymaps/planck_rev4_default.json
@@ -1,15 +1,50 @@
 {
-   "keyboard":"planck/rev4",
-   "keymap":"defaultish_8c03349",
-   "commit":"8c033497c62970087ae16c3e7c42fd72f3e1ecbe",
-   "layout":"LAYOUT_ortho_4x12",
-   "layers":[
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",  "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",  "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC", "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",  "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",    "KC_ASTR",    "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",    "KC_PLUS",    "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6", "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",  "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1"   ,"KC_NO", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_NO", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NO", "KC_NO", "KC_NO", "KC_C",    "KC_V",    "KC_NO", "KC_NO", "KC_N",    "KC_M",    "KC_NO", "KC_NO", "KC_NO"],
-      ["KC_TRNS", "RESET",   "DEBUG",    "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_DEL" , "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "KC_NO",  "KC_NO", "KC_NO",  "KC_NO",  "KC_TRNS", "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON", "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
-   ]
+  "keyboard": "planck/rev4",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_ortho_4x12",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",
+      "KC_NO",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC",
+      "KC_NO",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "TO(0)",   "KC_NO",   "KC_NO",   "KC_C",    "KC_V",    "KC_NO",   "KC_NO",   "KC_N",    "KC_M",    "KC_NO",   "KC_NO",   "KC_NO"
+    ],
+    [
+      "KC_TRNS", "RESET",   "DEBUG",   "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD",  "RGB_VAI", "RGB_VAD", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "TO(5)",   "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
 }

--- a/public/keymaps/planck_rev5_default.json
+++ b/public/keymaps/planck_rev5_default.json
@@ -1,15 +1,50 @@
 {
-   "keyboard":"planck/rev5",
-   "keymap":"defaultish_8c03349",
-   "commit":"8c033497c62970087ae16c3e7c42fd72f3e1ecbe",
-   "layout":"LAYOUT_ortho_4x12",
-   "layers":[
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",  "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",  "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC", "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",  "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",    "KC_ASTR",    "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",    "KC_PLUS",    "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6", "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",  "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1"   ,"KC_NO", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_NO", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NO", "KC_NO", "KC_NO", "KC_C",    "KC_V",    "KC_NO", "KC_NO", "KC_N",    "KC_M",    "KC_NO", "KC_NO", "KC_NO"],
-      ["KC_TRNS", "RESET",   "DEBUG",    "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_DEL" , "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "KC_NO",  "KC_NO", "KC_NO",  "KC_NO",  "KC_TRNS", "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON", "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
-   ]
+  "keyboard": "planck/rev5",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_ortho_4x12",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",
+      "KC_NO",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC",
+      "KC_NO",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "TO(0)",   "KC_NO",   "KC_NO",   "KC_C",    "KC_V",    "KC_NO",   "KC_NO",   "KC_N",    "KC_M",    "KC_NO",   "KC_NO",   "KC_NO"
+    ],
+    [
+      "KC_TRNS", "RESET",   "DEBUG",   "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD",  "RGB_VAI", "RGB_VAD", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "TO(5)",   "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
 }

--- a/public/keymaps/planck_rev6_default.json
+++ b/public/keymaps/planck_rev6_default.json
@@ -1,15 +1,50 @@
 {
-   "keyboard":"planck/rev6",
-   "keymap":"defaultish_8c03349",
-   "commit":"8c033497c62970087ae16c3e7c42fd72f3e1ecbe",
-   "layout":"LAYOUT_ortho_4x12",
-   "layers":[
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",  "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",  "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC", "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",  "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC", "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"],
-      ["KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",    "KC_ASTR",    "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",    "KC_PLUS",    "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6", "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-      ["KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",  "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1"   ,"KC_NO", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_NO", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NO", "KC_NO", "KC_NO", "KC_C",    "KC_V",    "KC_NO", "KC_NO", "KC_N",    "KC_M",    "KC_NO", "KC_NO", "KC_NO"],
-      ["KC_TRNS", "RESET",   "DEBUG",    "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_DEL" , "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "KC_NO",  "KC_NO", "KC_NO",  "KC_NO",  "KC_TRNS", "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON", "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
-   ]
+  "keyboard": "planck/rev6",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_ortho_4x12",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(6)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",    "KC_1",
+      "KC_NO",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC",
+      "KC_NO",   "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "TO(0)",   "KC_NO",   "KC_NO",   "KC_C",    "KC_V",    "KC_NO",   "KC_NO",   "KC_N",    "KC_M",    "KC_NO",   "KC_NO",   "KC_NO"
+    ],
+    [
+      "KC_TRNS", "RESET",   "DEBUG",   "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD",  "RGB_VAI", "RGB_VAD", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "TO(5)",   "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
 }

--- a/public/keymaps/preonic_rev1_default.json
+++ b/public/keymaps/preonic_rev1_default.json
@@ -1,14 +1,50 @@
 {
-  "keyboard":"preonic/rev1",
-  "keymap":"defaultish_80e7337",
-  "commit":"80e733798a808ba1cf0d5371360c152fbb933717",
-  "layout":"LAYOUT_preonic_grid",
-  "layers":[
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_F", "KC_P", "KC_G", "KC_J", "KC_L", "KC_U", "KC_Y", "KC_SCLN", "KC_DEL", "KC_ESC", "KC_A", "KC_R", "KC_S", "KC_T", "KC_D", "KC_H", "KC_N", "KC_E", "KC_I", "KC_O", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_K", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_QUOT", "KC_COMM", "KC_DOT", "KC_P", "KC_Y", "KC_F", "KC_G", "KC_C", "KC_R", "KC_L", "KC_DEL", "KC_ESC", "KC_A", "KC_O", "KC_E", "KC_U", "KC_I", "KC_D", "KC_H", "KC_T", "KC_N", "KC_S", "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q", "KC_J", "KC_K", "KC_X", "KC_B", "KC_M", "KC_W", "KC_V", "KC_Z", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
-    ["KC_TILD", "KC_EXLM", "KC_AT", "KC_HASH", "KC_DLR", "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_TILD", "KC_EXLM", "KC_AT", "KC_HASH", "KC_DLR", "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_DEL", "KC_DEL", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_UNDS", "KC_PLUS", "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12","S(KC_NUHS)","S(KC_NUBS)","KC_HOME", "KC_END", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_DEL", "KC_DEL", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_MINS", "KC_EQL", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-    ["KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_TRNS", "RESET", "DEBUG", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "TERM_ON", "TERM_OFF","KC_TRNS", "KC_TRNS", "KC_DEL", "KC_TRNS", "KC_TRNS", "MU_MOD", "AU_ON", "AU_OFF", "AG_NORM", "AG_SWAP", "DF(0)", "DF(1)", "DF(2)", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MUV_DE", "MUV_IN", "MU_ON", "MU_OFF", "MI_ON", "MI_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
+  "keyboard": "preonic/rev1",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_preonic_grid",
+  "layers": [
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(5)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(5)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",    "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_TRNS", "RESET",   "DEBUG",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
   ]
 }

--- a/public/keymaps/preonic_rev2_default.json
+++ b/public/keymaps/preonic_rev2_default.json
@@ -1,14 +1,50 @@
 {
-  "keyboard":"preonic/rev2",
-  "keymap":"defaultish_80e7337",
-  "commit":"80e733798a808ba1cf0d5371360c152fbb933717",
-  "layout":"LAYOUT_preonic_grid",
-  "layers":[
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_F", "KC_P", "KC_G", "KC_J", "KC_L", "KC_U", "KC_Y", "KC_SCLN", "KC_DEL", "KC_ESC", "KC_A", "KC_R", "KC_S", "KC_T", "KC_D", "KC_H", "KC_N", "KC_E", "KC_I", "KC_O", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_K", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_QUOT", "KC_COMM", "KC_DOT", "KC_P", "KC_Y", "KC_F", "KC_G", "KC_C", "KC_R", "KC_L", "KC_DEL", "KC_ESC", "KC_A", "KC_O", "KC_E", "KC_U", "KC_I", "KC_D", "KC_H", "KC_T", "KC_N", "KC_S", "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q", "KC_J", "KC_K", "KC_X", "KC_B", "KC_M", "KC_W", "KC_V", "KC_Z", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
-    ["KC_TILD", "KC_EXLM", "KC_AT", "KC_HASH", "KC_DLR", "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_TILD", "KC_EXLM", "KC_AT", "KC_HASH", "KC_DLR", "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_DEL", "KC_DEL", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_UNDS", "KC_PLUS", "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12","S(KC_NUHS)","S(KC_NUBS)","KC_HOME", "KC_END", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_DEL", "KC_DEL", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_MINS", "KC_EQL", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-    ["KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_TRNS", "RESET", "DEBUG", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "TERM_ON", "TERM_OFF","KC_TRNS", "KC_TRNS", "KC_DEL", "KC_TRNS", "KC_TRNS", "MU_MOD", "AU_ON", "AU_OFF", "AG_NORM", "AG_SWAP", "DF(0)", "DF(1)", "DF(2)", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MUV_DE", "MUV_IN", "MU_ON", "MU_OFF", "MI_ON", "MI_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
+  "keyboard": "preonic/rev2",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_preonic_grid",
+  "layers": [
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(5)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(5)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",    "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_TRNS", "RESET",   "DEBUG",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
   ]
 }

--- a/public/keymaps/preonic_rev3_default.json
+++ b/public/keymaps/preonic_rev3_default.json
@@ -1,14 +1,50 @@
 {
-  "keyboard":"preonic/rev3",
-  "keymap":"defaultish_80e7337",
-  "commit":"80e733798a808ba1cf0d5371360c152fbb933717",
-  "layout":"LAYOUT_preonic_grid",
-  "layers":[
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_Q", "KC_W", "KC_F", "KC_P", "KC_G", "KC_J", "KC_L", "KC_U", "KC_Y", "KC_SCLN", "KC_DEL", "KC_ESC", "KC_A", "KC_R", "KC_S", "KC_T", "KC_D", "KC_H", "KC_N", "KC_E", "KC_I", "KC_O", "KC_QUOT", "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_K", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_TAB", "KC_QUOT", "KC_COMM", "KC_DOT", "KC_P", "KC_Y", "KC_F", "KC_G", "KC_C", "KC_R", "KC_L", "KC_DEL", "KC_ESC", "KC_A", "KC_O", "KC_E", "KC_U", "KC_I", "KC_D", "KC_H", "KC_T", "KC_N", "KC_S", "KC_SLSH", "KC_LSFT", "KC_SCLN", "KC_Q", "KC_J", "KC_K", "KC_X", "KC_B", "KC_M", "KC_W", "KC_V", "KC_Z", "KC_ENT", "KC_RSFT", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)", "KC_SPC", "KC_SPC", "MO(4)", "KC_LEFT", "KC_DOWN", "KC_UP", "KC_RGHT"],
-    ["KC_TILD", "KC_EXLM", "KC_AT", "KC_HASH", "KC_DLR", "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_BSPC", "KC_TILD", "KC_EXLM", "KC_AT", "KC_HASH", "KC_DLR", "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_DEL", "KC_DEL", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_UNDS", "KC_PLUS", "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12","S(KC_NUHS)","S(KC_NUBS)","KC_HOME", "KC_END", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-    ["KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_DEL", "KC_DEL", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_MINS", "KC_EQL", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TRNS", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"],
-    ["KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_TRNS", "RESET", "DEBUG", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "TERM_ON", "TERM_OFF","KC_TRNS", "KC_TRNS", "KC_DEL", "KC_TRNS", "KC_TRNS", "MU_MOD", "AU_ON", "AU_OFF", "AG_NORM", "AG_SWAP", "DF(0)", "DF(1)", "DF(2)", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MUV_DE", "MUV_IN", "MU_ON", "MU_OFF", "MI_ON", "MI_OFF", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"]
+  "keyboard": "preonic/rev3",
+  "keymap": "default_97b8ade",
+  "commit": "97b8ade1aa7dd96027d10dc92da2a2ccbde61b8c",
+  "layout": "LAYOUT_preonic_grid",
+  "layers": [
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",    "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",    "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_DEL",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "BL_STEP", "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_UNDS",       "KC_PLUS",       "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "LSFT(KC_NUHS)", "LSFT(KC_NUBS)", "KC_HOME", "KC_END",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(5)",         "KC_MNXT",       "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NUHS", "KC_NUBS", "KC_PGUP", "KC_PGDN", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(5)",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",    "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_TRNS", "RESET",   "DEBUG",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "TERM_ON", "TERM_OFF", "KC_TRNS", "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "MU_MOD",  "AU_ON",   "AU_OFF",  "AG_NORM", "AG_SWAP", "DF(0)",   "DF(1)",    "DF(2)",   "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "MUV_DE",  "MUV_IN",  "MU_ON",   "MU_OFF",  "MI_ON",   "MI_OFF",  "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
   ]
 }


### PR DESCRIPTION
Adds emulated tri-layer functionality for all Planck and Preonic revisions.

Partial fix for #564.
