### PR TITLE
Fix Massdrop Alt default keymap's layout macro

### DIFF
--- a/public/keymaps/massdrop_alt_default.json
+++ b/public/keymaps/massdrop_alt_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "massdrop/alt",
   "keymap": "default-ish",
-  "layout": "LAYOUT",
+  "layout": "LAYOUT_65_ansi_blocker",
   "layers": [
     [
       "KC_ESC",


### PR DESCRIPTION
Was changed in qmk_firmware.

Noticed in checking #611.
