### PR TITLE
add keymaps: C

### DIFF
--- a/public/keymaps/cannonkeys_an_c_default.json
+++ b/public/keymaps/cannonkeys_an_c_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "cannonkeys/an_c",
+  "keymap": "default_3915c8e",
+  "commit": "3915c8eb00138852a4385701c9ebc71f63654a4b",
+  "layout": "LAYOUT_60_ansi",
+  "layers": [
+    [
+      "KC_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "KC_RGUI", "MO(1)",   "KC_RCTL"
+    ],
+    [
+      "KC_GESC", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",
+      "RGB_TOG", "RGB_MOD", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "BL_BRTG", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "BL_INC",             "BL_DEC",  "BL_TOGG", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_GRV",  "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET"
+    ]
+  ]
+}

--- a/public/keymaps/cannonkeys_chimera65_default.json
+++ b/public/keymaps/cannonkeys_chimera65_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "cannonkeys/chimera65",
+  "keymap": "default_59af2cb",
+  "commit": "59af2cbe640191345175bf34fd65f78ab1036647",
+  "layout": "LAYOUT_default",
+  "layers": [
+    [
+      "KC_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_DEL",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_DEL",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUBS", "KC_ENT",             "KC_PGUP",
+      "KC_LSFT", "KC_NUHS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",            "KC_UP",   "KC_PGDN",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_GESC", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "BL_BRTG", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "BL_INC",  "BL_DEC",  "BL_TOGG", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_GRV",  "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/cannonkeys_iron165_default.json
+++ b/public/keymaps/cannonkeys_iron165_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "cannonkeys/iron165",
+  "keymap": "default_455a0c5",
+  "commit": "455a0c597854b417c4dc02a462433043bddfa830",
+  "layout": "LAYOUT_default",
+  "layers": [
+    [
+      "KC_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_GRV",  "KC_BSLS",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",            "KC_DEL",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUBS", "KC_ENT",             "KC_PGUP",
+      "KC_LSFT", "KC_NUHS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",            "KC_UP",   "KC_PGDN",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "MO(1)",   "KC_RCTL",            "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_GESC", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "BL_BRTG", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "BL_INC",  "BL_DEC",  "BL_TOGG", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_GRV",  "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS",            "RESET",   "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/cannonkeys_ortho75_default.json
+++ b/public/keymaps/cannonkeys_ortho75_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "cannonkeys/ortho75",
+  "keymap": "default_cd59fe7",
+  "commit": "cd59fe78be54af41c9fa4e5a9474767d8b314cd6",
+  "layout": "LAYOUT_ortho_5x15",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_MINS", "KC_GRV",  "KC_EQL",  "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_LBRC", "KC_BSLS", "KC_RBRC", "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_QUOT",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_HOME", "KC_DEL",  "KC_PGUP", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_ENT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_END",  "KC_UP",   "KC_PGDN", "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "MO(1)",   "KC_SPC",  "KC_SPC",  "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_SPC",  "KC_SPC",  "MO(1)",   "KC_RALT", "KC_RGUI", "KC_RCTL"
+    ],
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",    "KC_F6",   "KC_NLCK", "KC_SLSH", "KC_ASTR", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_MSEL", "KC_CALC", "KC_MYCM", "KC_MAIL", "RGB_HUD",  "RGB_HUI", "KC_P7",   "KC_P8",   "KC_P9",   "KC_MINS", "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_SLCK", "KC_PAUS",
+      "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MSTP", "RGB_SAD",  "RGB_SAI", "KC_P4",   "KC_P5",   "KC_P6",   "KC_PLUS", "KC_TRNS", "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_VOLD", "KC_MUTE", "KC_VOLU", "KC_APP",  "RGB_VAD",  "RGB_VAI", "KC_P1",   "KC_P2",   "KC_P3",   "KC_PENT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "RGB_TOG", "MO(1)",   "RGB_RMOD", "RGB_MOD", "KC_P0",   "KC_TRNS", "KC_PDOT", "KC_PENT", "KC_PENT", "MO(1)",   "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/cannonkeys_savage65_default.json
+++ b/public/keymaps/cannonkeys_savage65_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "cannonkeys/savage65",
+  "keymap": "default_455a0c5",
+  "commit": "455a0c597854b417c4dc02a462433043bddfa830",
+  "layout": "LAYOUT_default",
+  "layers": [
+    [
+      "KC_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_DEL",  "KC_INS",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_DEL",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUBS", "KC_ENT",  "KC_PGUP",
+      "KC_LSFT", "KC_NUHS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_PGDN",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_GESC", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",  "KC_TRNS", "RGB_TOG",
+      "KC_TRNS", "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RGB_MOD",
+      "BL_BRTG", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "BL_INC",  "BL_DEC",  "BL_TOGG", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_GRV",  "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "RESET",   "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/cannonkeys_tmov2_default.json
+++ b/public/keymaps/cannonkeys_tmov2_default.json
@@ -1,0 +1,32 @@
+{
+  "keyboard": "cannonkeys/tmov2",
+  "keymap": "default_455a0c5",
+  "commit": "455a0c597854b417c4dc02a462433043bddfa830",
+  "layout": "LAYOUT_default",
+  "layers": [
+    [
+      "BL_INC",     "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",         "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",
+      "BL_DEC",     "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",         "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "RGB_MOD",    "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",         "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "MO(2)",
+      "RGB_TOG",               "KC_LALT", "KC_LGUI",                       "LT(1,KC_SPC)", "KC_SPC",                        "KC_RALT", "MO(3)"
+    ],
+    [
+      "KC_TRNS",    "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_DEL",
+      "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",               "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "RGB_TOG",    "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS",
+      "RGB_MOD",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "RGB_RMOD",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",               "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "RESET",      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",               "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/choco60_default.json
+++ b/public/keymaps/choco60_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "choco60",
+  "keymap": "default_abb6585",
+  "commit": "abb65857ffef2fcf2a735ce67c88dc987dae5e31",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",         "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_GRV",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",         "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",         "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",         "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "MO(1)",
+                 "KC_LALT", "KC_LGUI",                       "KC_SPC",       "KC_SPC",  "KC_SPC",             "KC_RGUI", "KC_RALT"
+    ],
+    [
+      "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",        "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_INS",  "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_SLCK", "KC_PAUS", "KC_UP",   "KC_RBRC", "KC_BSPC",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_TRNS", "KC_HOME", "KC_PGUP", "KC_LEFT", "KC_RGHT", "KC_ENT",
+      "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_TRNS", "KC_END",  "KC_PGDN", "KC_DOWN", "KC_RSFT", "MO(1)",
+                 "KC_TRNS", "KC_TRNS",                       "KC_TRNS",      "KC_TRNS", "KC_TRNS",            "KC_STOP", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/ckeys_handwire_101_default.json
+++ b/public/keymaps/ckeys_handwire_101_default.json
@@ -1,0 +1,50 @@
+{
+  "keyboard": "ckeys/handwire_101",
+  "keymap": "default_57fbf07",
+  "commit": "57fbf072f145bcf560c812a7976ba0f4f702f946",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_P7",   "KC_P8",   "KC_P9",   "LT(1,KC_PSLS)",
+      "KC_P4",   "KC_P5",   "KC_P6",   "KC_PAST",
+      "KC_P1",   "KC_P2",   "KC_P3",   "KC_PMNS",
+      "KC_P0",   "KC_PDOT", "KC_PEQL", "KC_PPLS"
+    ],
+    [
+      "TG(2)",   "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "TG(4)",   "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "TG(5)",   "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "TG(6)",   "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "TG(3)",
+      "MU_OFF",  "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "MU_ON",   "KC_TRNS", "KC_TRNS", "MU_MOD"
+    ],
+    [
+      "KC_M",    "KC_M",    "KC_M",    "KC_M",
+      "KC_M",    "KC_M",    "KC_M",    "KC_M",
+      "KC_M",    "KC_M",    "KC_M",    "KC_M",
+      "KC_M",    "KC_M",    "KC_M",    "KC_M"
+    ],
+    [
+      "KC_BTN5", "KC_TRNS", "KC_WH_U", "KC_TRNS",
+      "KC_TRNS", "KC_BTN1", "KC_MS_U", "KC_BTN2",
+      "KC_BTN4", "KC_MS_L", "KC_MS_D", "KC_MS_R",
+      "KC_BTN3", "KC_WH_L", "KC_WH_D", "KC_WH_R"
+    ],
+    [
+      "KC_TRNS", "TERM_ABOUT", "KC_TRNS", "KC_TRNS",
+      "TERM_OFF","TERM_PRINT", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "TERM_FLUSH", "KC_TRNS", "KC_TRNS",
+      "TERM_ON", "TERM_HELP",  "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "RESET",       "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "CKEYS_ABOUT", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",     "KC_TRNS", "KC_TRNS", "CK_OFF",
+      "KC_TRNS",     "KC_TRNS", "KC_TRNS", "CK_ON"
+    ]
+  ]
+}

--- a/public/keymaps/clueboard_66_hotswap_prototype_default.json
+++ b/public/keymaps/clueboard_66_hotswap_prototype_default.json
@@ -1,5 +1,5 @@
 {
-  "keyboard": "clueboard/66_hotswap/gen1",
+  "keyboard": "clueboard/66_hotswap/prototype",
   "keymap": "default_0f62383",
   "commit": "0f62383be57d2e3dacc79a76973295c73e805038",
   "layout": "LAYOUT",

--- a/public/keymaps/clueboard_california_default.json
+++ b/public/keymaps/clueboard_california_default.json
@@ -1,0 +1,16 @@
+{
+  "keyboard": "clueboard/california",
+  "keymap": "default_b62ee65",
+  "commit": "b62ee65c6d809bd10b4cd98c835a4a501a39b880",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_1",    "KC_2",
+      "KC_3",    "KC_4",
+                 "KC_5",
+                    "KC_6",    "KC_7",
+                            "KC_8",    "KC_9",
+                                               "BL_STEP"
+    ]
+  ]
+}

--- a/public/keymaps/cocoa40_default.json
+++ b/public/keymaps/cocoa40_default.json
@@ -1,0 +1,32 @@
+{
+  "keyboard": "cocoa40",
+  "keymap": "default_57958ce",
+  "commit": "57958ce88e91d53ac21611ae8da244c9d6a52721",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_GESC", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",         "KC_Y",         "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSPC",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",         "KC_H",         "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",         "KC_N",         "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "MO(3)",
+                 "KC_LALT", "KC_LGUI",                       "LT(1,KC_SPC)", "LT(2,KC_SPC)",                       "KC_RGUI", "KC_RALT"
+    ],
+    [
+      "KC_TAB",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+                 "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_MINS", "KC_PLUS", "KC_PIPE",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+                 "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+                 "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/converter_siemens_tastatur_default.json
+++ b/public/keymaps/converter_siemens_tastatur_default.json
@@ -1,0 +1,15 @@
+{
+  "keyboard": "converter/siemens_tastatur",
+  "keymap": "default_105c90b",
+  "commit": "105c90bd1c9be4b8239afd553c2a1afbd13986e1",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_SCLN", "KC_CIRC", "KC_BSPC", "KC_ENT",       "KC_0",    "KC_1",    "KC_2",    "KC_3",    "KC_4",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Z",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_RBRC", "KC_PLUS",                 "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_BSLS", "KC_RBRC", "KC_DLR",  "KC_EQL",       "KC_0",    "KC_1",    "KC_2",    "KC_3",    "KC_4",
+      "KC_LSFT", "KC_Y",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_MINS",                                       "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",
+                                                                        "KC_SPC"
+    ]
+  ]
+}

--- a/public/keymaps/cutie_club_wraith_default.json
+++ b/public/keymaps/cutie_club_wraith_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "cutie_club/wraith",
+  "keymap": "default_c7b28bf",
+  "commit": "c7b28bffc13d405bea2e0c0243437920659232f2",
+  "layout": "LAYOUT_iso",
+  "layers": [
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_PSCR", "MO(1)",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_INS",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC",            "KC_DEL",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_BSLS", "KC_ENT",  "KC_PGUP",
+      "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_PGDN",
+      "KC_LCTL",            "KC_LALT",                                             "KC_SPC",                                   "KC_RALT", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "RESET",   "KC_F13",  "KC_F14",  "KC_F15",  "KC_F16",  "KC_F17",  "KC_F18",  "KC_F19",  "KC_F20",  "KC_F21",  "KC_F22",  "KC_F23",  "KC_F24",  "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",            "KC_TRNS",                                             "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}


### PR DESCRIPTION
Keymaps added/updated:

- cannonkeys/an_c
- cannonkeys/chimera65
- cannonkeys/iron165
- cannonkeys/ortho75
- cannonkeys/savage65
- cannonkeys/tmov2
- choco60
- ckeys/handwire_101
- clueboard/66_hotswap/gen1
- clueboard/66_hotswap/prototype
- clueboard/california
- cocoa40
- converter/siemens_tastatur
- cutie_club/wraith
