### PR TITLE
Fix default nightmare keymap - align and remove extra keys

### DIFF
--- a/public/keymaps/nightmare_default.json
+++ b/public/keymaps/nightmare_default.json
@@ -14,13 +14,13 @@
         "KC_TRNS",    "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL", "KC_DEL",
         "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_RGHT", "KC_TRNS",
         "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
-        "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+        "KC_TRNS",               "KC_TRNS", "KC_TRNS",                       "KC_TRNS",                       "KC_TRNS",                       "KC_TRNS"
       ],
       [
         "KC_TRNS", "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_UP",   "KC_TRNS", "KC_TRNS",
         "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_RGHT", "KC_TRNS",
         "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_DOWN", "KC_TRNS", "KC_TRNS",
-        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+        "KC_TRNS",            "KC_TRNS", "KC_TRNS",                       "KC_TRNS",                       "KC_TRNS",                       "KC_TRNS"
       ]
     ]
   }


### PR DESCRIPTION
Found by `TheToteGoat` on Discord, building the default keymap provided at <https://config.qmk.fm/#/nightmare/LAYOUT_default> produces:

```
Compiling: keyboards/nightmare/nightmare.c                                                          [OK]      
Compiling: keyboards/nightmare/keymaps/default_2a948e7/keymap.c                                    keyboards/nightmare/keymaps/default_2a948e7/keymap.c:5:457: error: macro "LAYOUT_default" passed 52 arguments, but takes just 49
```

Deleting all layers, and recreating from scratch allows the keyboard to build successfully.