### PR TITLE
Changes for electron app

### DIFF
--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -72,6 +72,23 @@
           {{ $t('compile.label') }}
         </button>
       </div>
+      <div class="topctrl-processors" v-if="this.electron">
+        <label
+          class="drop-label"
+          :class="fontAdjustClasses"
+          :title="$t('processorInput')"
+          >{{ $t('processorInput') }}: </label
+        >
+        <input
+          id="processor-name"
+          type="text"
+          v-model="processor"
+          :placeholder="processor"
+          spellcheck="false"
+          @focus="focus"
+          @blur="blur"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -102,6 +119,8 @@ export default {
     ...mapState('app', [
       'keyboard',
       'keyboards',
+      'processor',
+      'electron',
       'layouts',
       'configuratorSettings',
       'compileDisabled'
@@ -111,6 +130,14 @@ export default {
     },
     realKeymapName() {
       return this.$store.getters['app/keymapName'];
+    },
+    processor: {
+      get() {
+        return this.$store.state.app.processor;
+      },
+      set(value) {
+        return this.updateProcessor(value)
+      }
     },
     keyboard: {
       get() {
@@ -205,7 +232,8 @@ export default {
       'setLayout',
       'stopListening',
       'startListening',
-      'previewRequested'
+      'previewRequested',
+      'setProcessor'
     ]),
     ...mapActions('app', [
       'fetchKeyboards',
@@ -367,6 +395,9 @@ export default {
     updateFilter(filter) {
       this.$store.commit('app/setFilter', filter);
     },
+    updateProcessor(p) {
+      this.setProcessor(p);
+    },
     opened() {
       this.stopListening();
       Vue.nextTick(() => {
@@ -461,6 +492,17 @@ export default {
   border: 1px solid;
   width: 288px;
   width: 30rem;
+}
+#processor-name {
+  width: 97px;
+  padding: 2px;
+  border: 0.3px solid;
+  border-radius: 1.5px;
+}
+.topctrl-processors {
+  grid-row: middle;
+  grid-column: right;
+  justify-self: end;
 }
 .drop-label {
   display: inline-block;

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -64,6 +64,16 @@
           {{ $t('loadDefault.label') }}
         </button>
         <button
+          v-if="this.electron"
+          id="compile"
+          :title="$t('compileFlash.title')"
+          v-bind:disabled="compileDisabled"
+          @click="compile"
+        >
+          {{ $t('compileFlash.label') }}
+        </button>
+        <button
+          v-else
           id="compile"
           :title="$t('compile.title')"
           v-bind:disabled="compileDisabled"
@@ -494,7 +504,7 @@ export default {
   width: 30rem;
 }
 #processor-name {
-  width: 97px;
+  width: 115px;
   padding: 2px;
   border: 0.3px solid;
   border-radius: 1.5px;
@@ -502,7 +512,7 @@ export default {
 .topctrl-processors {
   grid-row: middle;
   grid-column: right;
-  justify-self: end;
+  justify-self: start;
 }
 .drop-label {
   display: inline-block;

--- a/src/components/ElectronBottomControls.vue
+++ b/src/components/ElectronBottomControls.vue
@@ -3,16 +3,6 @@
     <button
       class="fixed-size"
       id="fwFile"
-      @click="autoFlashFirmware"
-      :title="$t('flashFirmware.title')"
-      :disabled="disableDownloadBinary"
-    >
-      <font-awesome-icon icon="download" size="lg" fixed-width />
-      {{ $t('flashFirmware.label') }}
-    </button>
-    <button
-      class="fixed-size"
-      id="fwFile"
       @click="flashFirmware"
       :title="$t('flashFile.title')"
       :disabled="disableFlashFile"
@@ -53,13 +43,6 @@ export default {
     flashFirmware() {
       window.Bridge.flashFile();
     },
-    autoFlashFirmware() {
-      window.Bridge.flashURL(
-        first(this.firmwareBinaryURL),
-        this.keyboard,
-        this.firmwareFile
-      );
-    }
   }
 };
 </script>

--- a/src/components/ElectronBottomControls.vue
+++ b/src/components/ElectronBottomControls.vue
@@ -51,11 +51,9 @@ export default {
   },
   methods: {
     flashFirmware() {
-      window.Bridge.autoFlash = false;
       window.Bridge.flashFile();
     },
     autoFlashFirmware() {
-      window.Bridge.autoFlash = true;
       window.Bridge.flashURL(
         first(this.firmwareBinaryURL),
         this.keyboard,

--- a/src/electron.js
+++ b/src/electron.js
@@ -13,6 +13,7 @@ export default {
         store.commit('status/append', `\n${txt}`);
         store.dispatch('status/scrollToEnd');
       };
+      window.Bridge.processor = () => {return store.state.app.processor}
     }
   }
 };

--- a/src/i18n/en.csv
+++ b/src/i18n/en.csv
@@ -16,6 +16,8 @@ statsTemplate,\nLoaded {layers} layers and {count} keycodes. Defined {any} Any k
 ColorwayTip:title,Ctrl + Alt + N to cycle next colorway
 compile:label,Compile
 compile:title,Compile Keymap
+compileFlash:label,Compile & Flash
+compileFlash:title,Compile Keymap and then flash to keyboard
 downloadFirmware:label,Firmware
 downloadFirmware:title,Download firmware file for flashing
 downloadJSON:label,Keymap.JSON

--- a/src/i18n/en.csv
+++ b/src/i18n/en.csv
@@ -129,3 +129,4 @@ tester:reset:label,Reset
 tester:reset:title,Reset detected keys
 toggleTerminal:label,Click to Expand
 toggleTerminal:title,Toggle the Terminal display
+processorInput,Processor

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -624,6 +624,13 @@ function check_status() {
               data.result.firmware_keymap_url
             );
             store.commit('app/setFirmwareFile', data.result.firmware_filename);
+            if (store.state.app.electron){
+              window.Bridge.flashURL(
+                first(data.result.firmware_binary_url),
+                store.state.app.keyboard,
+                data.result.firmware_filename
+              );
+            }
             enableCompileButton();
             enableOtherButtons();
             break;

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -112,6 +112,7 @@ const actions = {
     return axios
       .get(backend_keyboards_url + '/' + state.keyboard)
       .then(resp => {
+        commit('setProcessor', resp.data.keyboards[state.keyboard].processor)
         commit('processLayouts', resp);
         return resp;
       });

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -170,6 +170,9 @@ const mutations = {
   },
   toggleSnowflakes(state) {
     state.snowflakes = !state.snowflakes;
+  },
+  setProcessor(state, processor) {
+    state.processor = processor;
   }
 };
 

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -55,6 +55,7 @@ const state = {
   notes: '',
   tutorialEnabled: false,
   electron: false,
+  processor: '',
   languages: [
     { value: 'en', label: 'English' },
     { value: 'de', label: 'Deutsch' },
@@ -66,7 +67,7 @@ const state = {
     { value: 'pl-PL', label: 'Polski' },
     { value: 'ms', label: 'Bahasa Malaysia' }
   ],
-  snowflakes: false
+  snowflakes: false,
 };
 
 export default {


### PR DESCRIPTION
The added code adds an input box for processor under compile/load default buttons when run in the [electron app](https://github.com/e11i0t23/qmk_configurator_electron) (not visible any other time). It auto updates the processor based on loaded keyboard using data already being retrieved from the api

Additionally i have removed the autoflash button and changed compile so when in electron after compiling it goes to automatically flash the keyboard
