### PR TITLE
Add default Wete keymap

### DIFF
--- a/public/keymaps/w/wete_default.json
+++ b/public/keymaps/w/wete_default.json
@@ -5,12 +5,12 @@
   "layout": "LAYOUT_ansi_rhnp",
   "layers": [
     [
-      "KC_INSERT", "KC_PSCREEN", "KC_PAUSE", "KC_SLCK",               "KC_ESC",     "KC_F1", "KC_F2", "KC_F3", "KC_F4",     "KC_F5", "KC_F6", "KC_F7", "KC_F8",     "KC_F9", "KC_F10", "KC_F11", "KC_F12",  "KC_DEL",
-      "KC_NUMLOCK", "KC_KP_SLASH", "KC_KP_ASTERISK", "KC_KP_MINUS",   "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL",       "KC_BSPC",         "KC_HOME",
-      "KC_KP_7", "KC_KP_8", "KC_KP_9", "KC_KP_PLUS",                  "KC_TAB",    "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC",      "KC_BSLS",      "KC_END",
-      "KC_KP_4", "KC_KP_5", "KC_KP_6",                              "KC_CAPS",    "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",           "KC_ENTER",     "KC_PGUP",
-      "KC_KP_1", "KC_KP_2", "KC_KP_3", "KC_KP_ENTER",                 "KC_LSFT",       "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH",     "KC_RSFT",   "KC_UP",    "KC_PGDN",
-          "KC_KP_0",    "KC_KP_DOT",                            "KC_LCTL",  "KC_LGUI",  "KC_LALT",                "KC_SPC",            "KC_RALT", "MO(1)",          "KC_LEFT", "KC_DOWN", "KC_RIGHT"
+      "KC_INS", "KC_PSCR", "KC_PAUS", "KC_SLCK",               "KC_ESC",     "KC_F1", "KC_F2", "KC_F3", "KC_F4",     "KC_F5", "KC_F6", "KC_F7", "KC_F8",     "KC_F9", "KC_F10", "KC_F11", "KC_F12",  "KC_DEL",
+      "KC_NLCK", "KC_PSLS", "KC_PAST", "KC_PMNS",   "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL",       "KC_BSPC",         "KC_HOME",
+      "KC_P7", "KC_P8", "KC_P9", "KC_PPLS",                  "KC_TAB",    "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC",      "KC_BSLS",      "KC_END",
+      "KC_P4", "KC_P5", "KC_P6",                              "KC_CAPS",    "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",           "KC_ENT",     "KC_PGUP",
+      "KC_P1", "KC_P2", "KC_P3", "KC_PENT",                 "KC_LSFT",       "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH",     "KC_RSFT",   "KC_UP",    "KC_PGDN",
+          "KC_P0",    "KC_PDOT",                            "KC_LCTL",  "KC_LGUI",  "KC_LALT",                "KC_SPC",            "KC_RALT", "MO(1)",          "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
       "KC_NO", "KC_NO", "KC_NO", "KC_NO",               "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",  "KC_NO",
@@ -19,6 +19,6 @@
       "KC_NO", "KC_NO", "KC_NO",                              "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",           "KC_NO",     "KC_NO",
       "KC_NO", "KC_NO", "KC_NO", "KC_NO",                 "KC_NO",       "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO",   "BL_INC",    "KC_NO",
             "KC_NO",    "KC_NO",                            "KC_NO",  "KC_NO",  "KC_NO",                "KC_NO",            "KC_NO", "KC_TRNS",          "BL_OFF", "BL_DEC", "BL_DEC"
-    ],
+    ]
   ]
 }

--- a/public/keymaps/w/wete_default.json
+++ b/public/keymaps/w/wete_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "wete",
+  "keymap": "default_93c5307",
+  "commit": "93c5307fd60c35780921570ccf41a1806847eb9c",
+  "layout": "LAYOUT_ansi_rhnp",
+  "layers": [
+    [
+      "KC_INSERT", "KC_PSCREEN", "KC_PAUSE", "KC_SLCK",               "KC_ESC",     "KC_F1", "KC_F2", "KC_F3", "KC_F4",     "KC_F5", "KC_F6", "KC_F7", "KC_F8",     "KC_F9", "KC_F10", "KC_F11", "KC_F12",  "KC_DEL",
+    "KC_NUMLOCK", "KC_KP_SLASH", "KC_KP_ASTERISK", "KC_KP_MINUS",   "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL",       "KC_BSPC",         "KC_HOME",
+    "KC_KP_7", "KC_KP_8", "KC_KP_9", "KC_KP_PLUS",                  "KC_TAB",    "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC",      "KC_BSLS",      "KC_END",
+    "KC_KP_4", "KC_KP_5", "KC_KP_6",                              "KC_CAPS",    "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",           "KC_ENTER",     "KC_PGUP",
+    "KC_KP_1", "KC_KP_2", "KC_KP_3", "KC_KP_ENTER",                 "KC_LSFT",       "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH",     "KC_RSFT",   "KC_UP",    "KC_PGDN",
+          "KC_KP_0",    "KC_KP_DOT",                            "KC_LCTL",  "KC_LGUI",  "KC_LALT",                "KC_SPC",            "KC_RALT", "MO(1)",          "KC_LEFT", "KC_DOWN", "KC_RIGHT"
+    ],
+    [
+      "KC_NO", "KC_NO", "KC_NO", "KC_NO",               "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",  "KC_NO",
+    "KC_NO", "KC_NO", "KC_NO", "KC_NO",   "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",       "KC_NO",         "KC_NO",
+    "KC_NO", "KC_NO", "KC_NO", "KC_NO",                  "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",      "KC_NO",      "KC_NO",
+    "KC_NO", "KC_NO", "KC_NO",                              "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",           "KC_NO",     "KC_NO",
+    "KC_NO", "KC_NO", "KC_NO", "KC_NO",                 "KC_NO",       "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO",   "BL_INC",    "KC_NO",
+          "KC_NO",    "KC_NO",                            "KC_NO",  "KC_NO",  "KC_NO",                "KC_NO",            "KC_NO", "KC_NO",          "BL_OFF", "BL_DEC", "BL_DEC"
+    ],
+  ]
+}

--- a/public/keymaps/w/wete_default.json
+++ b/public/keymaps/w/wete_default.json
@@ -6,19 +6,19 @@
   "layers": [
     [
       "KC_INSERT", "KC_PSCREEN", "KC_PAUSE", "KC_SLCK",               "KC_ESC",     "KC_F1", "KC_F2", "KC_F3", "KC_F4",     "KC_F5", "KC_F6", "KC_F7", "KC_F8",     "KC_F9", "KC_F10", "KC_F11", "KC_F12",  "KC_DEL",
-    "KC_NUMLOCK", "KC_KP_SLASH", "KC_KP_ASTERISK", "KC_KP_MINUS",   "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL",       "KC_BSPC",         "KC_HOME",
-    "KC_KP_7", "KC_KP_8", "KC_KP_9", "KC_KP_PLUS",                  "KC_TAB",    "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC",      "KC_BSLS",      "KC_END",
-    "KC_KP_4", "KC_KP_5", "KC_KP_6",                              "KC_CAPS",    "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",           "KC_ENTER",     "KC_PGUP",
-    "KC_KP_1", "KC_KP_2", "KC_KP_3", "KC_KP_ENTER",                 "KC_LSFT",       "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH",     "KC_RSFT",   "KC_UP",    "KC_PGDN",
+      "KC_NUMLOCK", "KC_KP_SLASH", "KC_KP_ASTERISK", "KC_KP_MINUS",   "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL",       "KC_BSPC",         "KC_HOME",
+      "KC_KP_7", "KC_KP_8", "KC_KP_9", "KC_KP_PLUS",                  "KC_TAB",    "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC",      "KC_BSLS",      "KC_END",
+      "KC_KP_4", "KC_KP_5", "KC_KP_6",                              "KC_CAPS",    "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",           "KC_ENTER",     "KC_PGUP",
+      "KC_KP_1", "KC_KP_2", "KC_KP_3", "KC_KP_ENTER",                 "KC_LSFT",       "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH",     "KC_RSFT",   "KC_UP",    "KC_PGDN",
           "KC_KP_0",    "KC_KP_DOT",                            "KC_LCTL",  "KC_LGUI",  "KC_LALT",                "KC_SPC",            "KC_RALT", "MO(1)",          "KC_LEFT", "KC_DOWN", "KC_RIGHT"
     ],
     [
       "KC_NO", "KC_NO", "KC_NO", "KC_NO",               "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",  "KC_NO",
-    "KC_NO", "KC_NO", "KC_NO", "KC_NO",   "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",       "KC_NO",         "KC_NO",
-    "KC_NO", "KC_NO", "KC_NO", "KC_NO",                  "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",      "KC_NO",      "KC_NO",
-    "KC_NO", "KC_NO", "KC_NO",                              "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",           "KC_NO",     "KC_NO",
-    "KC_NO", "KC_NO", "KC_NO", "KC_NO",                 "KC_NO",       "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO",   "BL_INC",    "KC_NO",
-          "KC_NO",    "KC_NO",                            "KC_NO",  "KC_NO",  "KC_NO",                "KC_NO",            "KC_NO", "KC_NO",          "BL_OFF", "BL_DEC", "BL_DEC"
+      "KC_NO", "KC_NO", "KC_NO", "KC_NO",   "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",       "KC_NO",         "KC_NO",
+      "KC_NO", "KC_NO", "KC_NO", "KC_NO",                  "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",      "KC_NO",      "KC_NO",
+      "KC_NO", "KC_NO", "KC_NO",                              "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",           "KC_NO",     "KC_NO",
+      "KC_NO", "KC_NO", "KC_NO", "KC_NO",                 "KC_NO",       "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO",   "BL_INC",    "KC_NO",
+            "KC_NO",    "KC_NO",                            "KC_NO",  "KC_NO",  "KC_NO",                "KC_NO",            "KC_NO", "KC_TRNS",          "BL_OFF", "BL_DEC", "BL_DEC"
     ],
   ]
 }


### PR DESCRIPTION
Adding the default keymap for the configurator following qmk/qmk_firmware#8229.