### PR TITLE
Update default keymaps for LFKeyboards LFK78

### DIFF
--- a/public/keymaps/l/lfkeyboards_lfk78_revb_default.json
+++ b/public/keymaps/l/lfkeyboards_lfk78_revb_default.json
@@ -1,0 +1,29 @@
+{
+  "keyboard": "lfkeyboards/lfk78/revb",
+  "keymap": "default_8c3ff3f",
+  "commit": "8c3ff3f32c49c649ef6632d10f8fb15ef60d990d",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_F1",   "KC_F2",        "KC_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",      "KC_INS",  "KC_PGUP",
+      "KC_F3",   "KC_F4",        "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",      "KC_DEL",  "KC_PGDN",
+      "KC_F5",   "KC_F6",        "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_F7",   "KC_F8",        "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT",      "KC_UP",
+      "KC_F9",   "KC_F10",       "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "KC_RCTL", "MO(1)",        "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS",      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",       "KC_TRNS", "KC_HOME",
+      "KC_TRNS", "KC_TRNS",      "KC_NO",   "KC_HOME", "KC_UP",   "KC_END",  "KC_PGUP", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",        "KC_TRNS", "KC_END",
+      "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_PGDN", "KC_NO",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_NO",   "KC_NO",              "KC_NO",
+      "KC_TRNS", "KC_TRNS",      "KC_TRNS",            "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_NO",              "TG(2)",        "KC_TRNS",
+      "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_ENT",                                   "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_NO",   "KC_NO",        "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "BL_DEC",  "BL_INC",  "BL_TOGG",      "RGB_TOG", "RGB_VAI",
+      "KC_NO",   "KC_NO",        "MU_MOD",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",        "RGB_MOD", "RGB_VAD",
+      "KC_NO",   "KC_NO",        "AU_TOG",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",              "RESET",
+      "KC_NO",   "KC_NO",        "KC_NO",              "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "MU_TOG",  "KC_NO",   "KC_NO",   "KC_NO",              "KC_NO",        "RGB_HUI",
+      "KC_NO",   "KC_NO",        "KC_NO",   "KC_NO",   "KC_NO",                                    "KC_NO",                                    "KC_NO",   "KC_NO",   "KC_NO",        "RGB_SAD", "RGB_HUD", "RGB_SAI"
+    ]
+  ]
+}

--- a/public/keymaps/l/lfkeyboards_lfk78_revc_default.json
+++ b/public/keymaps/l/lfkeyboards_lfk78_revc_default.json
@@ -1,0 +1,29 @@
+{
+  "keyboard": "lfkeyboards/lfk78/revc",
+  "keymap": "default_8c3ff3f",
+  "commit": "8c3ff3f32c49c649ef6632d10f8fb15ef60d990d",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_F1",   "KC_F2",        "KC_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",      "KC_INS",  "KC_PGUP",
+      "KC_F3",   "KC_F4",        "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",      "KC_DEL",  "KC_PGDN",
+      "KC_F5",   "KC_F6",        "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_F7",   "KC_F8",        "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT",      "KC_UP",
+      "KC_F9",   "KC_F10",       "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "KC_RCTL", "MO(1)",        "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS",      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",       "KC_TRNS", "KC_HOME",
+      "KC_TRNS", "KC_TRNS",      "KC_NO",   "KC_HOME", "KC_UP",   "KC_END",  "KC_PGUP", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",        "KC_TRNS", "KC_END",
+      "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_PGDN", "KC_NO",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_NO",   "KC_NO",              "KC_NO",
+      "KC_TRNS", "KC_TRNS",      "KC_TRNS",            "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_NO",              "TG(2)",        "KC_TRNS",
+      "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_ENT",                                   "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_NO",   "KC_NO",        "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "BL_DEC",  "BL_INC",  "BL_TOGG",      "RGB_TOG", "RGB_VAI",
+      "KC_NO",   "KC_NO",        "MU_MOD",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",        "RGB_MOD", "RGB_VAD",
+      "KC_NO",   "KC_NO",        "AU_TOG",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",              "RESET",
+      "KC_NO",   "KC_NO",        "KC_NO",              "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "MU_TOG",  "KC_NO",   "KC_NO",   "KC_NO",              "KC_NO",        "RGB_HUI",
+      "KC_NO",   "KC_NO",        "KC_NO",   "KC_NO",   "KC_NO",                                    "KC_NO",                                    "KC_NO",   "KC_NO",   "KC_NO",        "RGB_SAD", "RGB_HUD", "RGB_SAI"
+    ]
+  ]
+}

--- a/public/keymaps/l/lfkeyboards_lfk78_revj_default.json
+++ b/public/keymaps/l/lfkeyboards_lfk78_revj_default.json
@@ -1,28 +1,28 @@
 {
-  "keyboard": "lfkeyboards/lfk78",
-  "keymap": "default_e2d3c92",
-  "commit": "e2d3c92199d6cc42a39c5d8729dfff61d78dd7d1",
+  "keyboard": "lfkeyboards/lfk78/revj",
+  "keymap": "default_8c3ff3f",
+  "commit": "8c3ff3f32c49c649ef6632d10f8fb15ef60d990d",
   "layout": "LAYOUT",
   "layers": [
     [
       "KC_F1",   "KC_F2",        "KC_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",      "KC_INS",  "KC_PGUP",
       "KC_F3",   "KC_F4",        "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",      "KC_DEL",  "KC_PGDN",
       "KC_F5",   "KC_F6",        "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
-      "KC_F7",   "KC_F8",        "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",                       "KC_RSFT",      "KC_UP",
+      "KC_F7",   "KC_F8",        "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT",      "KC_UP",
       "KC_F9",   "KC_F10",       "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "KC_RCTL", "MO(1)",        "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
       "KC_TRNS", "KC_TRNS",      "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",       "KC_TRNS", "KC_HOME",
       "KC_TRNS", "KC_TRNS",      "KC_NO",   "KC_HOME", "KC_UP",   "KC_END",  "KC_PGUP", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",        "KC_TRNS", "KC_END",
       "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_PGDN", "KC_NO",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_NO",   "KC_NO",              "KC_NO",
-      "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_NO",                         "TG(2)",        "KC_TRNS",
+      "KC_TRNS", "KC_TRNS",      "KC_TRNS",            "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_NO",              "TG(2)",        "KC_TRNS",
       "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_ENT",                                   "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ],
     [
-      "KC_NO",   "KC_NO",        "TO(0)",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "BL_DEC",  "BL_INC",  "BL_TOGG",      "RGB_TOG", "RGB_VAI",
+      "KC_NO",   "KC_NO",        "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "BL_DEC",  "BL_INC",  "BL_TOGG",      "RGB_TOG", "RGB_VAI",
       "KC_NO",   "KC_NO",        "MU_MOD",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",        "RGB_MOD", "RGB_VAD",
-      "KC_NO",   "KC_NO",        "AU_TOG",  "KC_TRNS", "KC_TRNS", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",              "RESET",
-      "KC_NO",   "KC_NO",        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "MU_TOG",  "KC_NO",   "KC_NO",   "KC_NO",                         "KC_NO",        "RGB_HUI",
+      "KC_NO",   "KC_NO",        "AU_TOG",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",              "RESET",
+      "KC_NO",   "KC_NO",        "KC_NO",              "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "MU_TOG",  "KC_NO",   "KC_NO",   "KC_NO",              "KC_NO",        "RGB_HUI",
       "KC_NO",   "KC_NO",        "KC_NO",   "KC_NO",   "KC_NO",                                    "KC_NO",                                    "KC_NO",   "KC_NO",   "KC_NO",        "RGB_SAD", "RGB_HUD", "RGB_SAI"
     ]
   ]

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -489,6 +489,7 @@ function getExclusionList() {
     'launchpad',
     'lets_split',
     'lets_split_eh',
+    'lfkeyboards/lfk78',
     'lily58',
     'maartenwut/atom47',
     'maxipad',

--- a/src/remap.js
+++ b/src/remap.js
@@ -68,6 +68,9 @@ const lookup = {
   kudox: {
     target: 'kudox/rev1'
   },
+  'lfkeyboards/lfk78': {
+    target: 'lfkeyboards/lfk78/revj'
+  },
   'mechlovin/hannah910': {
     target: 'mechlovin/hannah910/rev1'
   },


### PR DESCRIPTION
Updated in https://github.com/qmk/qmk_firmware/pull/7835.
