### PR TITLE
Candybar: update to address different layouts.

### DIFF
--- a/public/keymaps/c/candybar_lefty_default.json
+++ b/public/keymaps/c/candybar_lefty_default.json
@@ -1,0 +1,20 @@
+{
+  "keyboard": "candybar/lefty",
+  "keymap": "",
+  "commit": "",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_P7",   "KC_P8",   "KC_P9",   "KC_PAST", "KC_ESC",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_DEL",  "KC_BSPC",
+      "KC_P4",   "KC_P5",   "KC_P6",   "KC_PMNS", "KC_TAB",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN",            "KC_ENT",
+      "KC_P1",   "KC_P2",   "KC_P3",   "KC_PPLS", "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM",            "KC_DOT",  "KC_UP",   "KC_RSFT",
+      "MO(1)",   "KC_P0",   "KC_PDOT", "KC_PENT", "KC_LCTL", "KC_LGUI", "KC_LALT",            "KC_SPC",  "KC_SPC",  "KC_BSPC",            "KC_APP",  "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_P7",   "KC_P8",   "KC_P9",   "KC_VOLU", "RESET",   "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_LBRC", "KC_RBRC", "KC_INS",  "KC_BSPC",
+      "KC_P4",   "KC_P5",   "KC_P6",   "KC_VOLD", "KC_TAB",  "KC_A",    "KC_SLCK", "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_QUOT",            "KC_BSLS",
+      "KC_P1",   "KC_P2",   "KC_P3",   "KC_PEQL", "KC_LSFT",            "KC_Z",    "KC_X",    "KC_CAPS", "KC_V",    "KC_B",    "KC_NLCK", "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_PGUP",
+      "KC_END",  "KC_P0",   "KC_PDOT", "KC_PENT", "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",             "KC_SPC",  "KC_BSPC", "KC_APP",  "MO(1)",   "KC_HOME", "KC_PGDN"
+    ]
+  ]
+}

--- a/public/keymaps/c/candybar_lefty_default.json
+++ b/public/keymaps/c/candybar_lefty_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "candybar/lefty",
-  "keymap": "",
-  "commit": "",
+  "keymap": "default_18bc525",
+  "commit": "18bc5254932a842276627d8f055b6fb1d3345230",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/c/candybar_righty_default.json
+++ b/public/keymaps/c/candybar_righty_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "candybar/righty",
-  "keymap": "",
-  "commit": "",
+  "keymap": "default_18bc525",
+  "commit": "18bc5254932a842276627d8f055b6fb1d3345230",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/c/candybar_righty_default.json
+++ b/public/keymaps/c/candybar_righty_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "candybar",
-  "keymap": "default_0072fdd",
-  "commit": "0072fdd799ffe61bf64f12c23335da3adeb083e5",
+  "keyboard": "candybar/righty",
+  "keymap": "",
+  "commit": "",
   "layout": "LAYOUT",
   "layers": [
     [


### PR DESCRIPTION
Update to reflect project split into lefty and righty subprojects happening in QMK. This should not be merged until QMK PR is also merged, as it will break existing Candybar support in config.qmk.fm.