### PR TITLE
Added default keymap for keeb.werk nano.slider

### DIFF
--- a/public/keymaps/k/keebwerk_nano_slider_default.json
+++ b/public/keymaps/k/keebwerk_nano_slider_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "keebwerk/nano_slider",
-  "keymap": "default_4f1a62c",
-  "commit": "4f1a62ca1d8e1cd1528305bda6a315489738c29f",
+  "keymap": "default_7873b49",
+  "commit": "7873b49d40cef838268575d5b31a1d377b218787",
   "layout":"LAYOUT",
   "layers":[
     [

--- a/public/keymaps/k/keebwerk_nano_slider_default.json
+++ b/public/keymaps/k/keebwerk_nano_slider_default.json
@@ -1,0 +1,23 @@
+{
+  "keyboard": "keebwerk/nano_slider",
+  "keymap": "default_4f1a62c",
+  "commit": "4f1a62ca1d8e1cd1528305bda6a315489738c29f",
+  "layout":"LAYOUT",
+  "layers":[
+    [
+      "TO(1)",
+      "KC_1",     "KC_2",     "KC_3",
+      "KC_4",     "KC_5",     "KC_6",     "KC_0"
+    ],
+    [
+      "TO(2)",
+      "RGB_TOG",  "RGB_MOD",  "RGB_VAI",
+      "KC_TRNS",  "RGB_RMOD", "RGB_VAD",  "KC_TRNS"
+    ],
+    [
+      "TO(0)",
+      "KC_VOLD",  "KC_VOLU",  "KC_F24",
+      "KC_MRWD",  "KC_MFFD",  "KC_F23",  "KC_MPLY"
+    ]
+  ]
+}


### PR DESCRIPTION
The reason for the difference in the third layer, is that the third layer in the C implementation is mainly there as a demo layer, showing users how they can make custom keycodes and macros. Since this won't work in the configurator, I added some other functionality. 

The slider currently won't work, but I'm working on moving the slider function to a weak default function for the keyboard. 