### PR TITLE
Fix location of docker_run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ EXPOSE 80/tcp
 
 COPY --from=build /qmk_configurator/dist /qmk_configurator/dist
 COPY conf/nginx.conf.in /etc/nginx/nginx.conf.in
-COPY bin/docker_run.sh /qmk_configurator/docker_run.sh
+COPY bin/docker_run.sh /qmk_configurator/bin/docker_run.sh
 
-CMD /bin/bash -i /qmk_configurator/docker_run.sh
+CMD /bin/bash -i /qmk_configurator/bin/docker_run.sh


### PR DESCRIPTION
This is needed so that qmk/qmk_web_stack can launch qmk_configurator with or without a volume mount.