### PR TITLE
Add rel="noopener" property to links opening in new tab

### DIFF
--- a/src/components/BrowserWarn.vue
+++ b/src/components/BrowserWarn.vue
@@ -2,11 +2,17 @@
   <div id="browser-warn" v-show="isNotSupported && !isDimissed">
     <a class="dismiss" title="dismiss" v-on:click="dismiss">X</a>
     {{ $t('errors.unsupportedBrowser') }}
-    <a href="https://www.google.com/intl/en_us/chrome/" target="_blank"
+    <a
+      href="https://www.google.com/intl/en_us/chrome/"
+      target="_blank"
+      rel="noopener"
       >Google Chrome</a
     >
     /
-    <a href="https://www.mozilla.org/en-US/firefox/new/" target="_blank"
+    <a
+      href="https://www.mozilla.org/en-US/firefox/new/"
+      target="_blank"
+      rel="noopener"
       >Mozilla Firefox</a
     >
   </div>

--- a/src/components/Keycodes.vue
+++ b/src/components/Keycodes.vue
@@ -10,7 +10,7 @@
         <span class="hint">
           <a
             href="https://docs.qmk.fm/#/keycodes"
-            title="Keycodes reference"
+            :title="$t('keycodesRef.label')"
             target="_blank"
             rel="noopener"
             >{{ $t('keycodesRef.label') }}</a

--- a/src/components/Keycodes.vue
+++ b/src/components/Keycodes.vue
@@ -12,6 +12,7 @@
             href="https://docs.qmk.fm/#/keycodes"
             title="Keycodes reference"
             target="_blank"
+            rel="noopener"
             >{{ $t('keycodesRef.label') }}</a
           >
         </span>

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -8,6 +8,7 @@
     <div class="hint hint-right">
       <a
         href="https://github.com/qmk/qmk_toolbox/releases"
+        :title="$t('downloadToolbox.label')"
         target="_blank"
         rel="noopener"
         >{{ $t('downloadToolbox.label') }}</a

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -6,9 +6,12 @@
       <controllerBottom />
     </div>
     <div class="hint hint-right">
-      <a target="_blank" href="https://github.com/qmk/qmk_toolbox/releases">
-        {{ $t('downloadToolbox.label') }}
-      </a>
+      <a
+        href="https://github.com/qmk/qmk_toolbox/releases"
+        target="_blank"
+        rel="noopener"
+        >{{ $t('downloadToolbox.label') }}</a
+      >
     </div>
     <div class="split-content">
       <div class="left-side">

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -24,7 +24,7 @@
       </div>
     </div>
     <div class="bes-discord">
-      <a v-if="hasError" target="_blank" :href="discordLink">
+      <a v-if="hasError" target="_blank" rel="noopener" :href="discordLink">
         Error? Let us know on QMK Discord.
       </a>
     </div>


### PR DESCRIPTION
I saw that links opened in new tab don't have `rel="noopener"` property. It potentially can cause issues. 
[You can find more informations here](https://developers.google.com/web/tools/lighthouse/audits/noopener). 

Also I found out that in one link `title` property was missing and in another `title` was static string written in English, so I fixed it as well