### PR TITLE
Fix EEP_RST key on ergodox ez default keymap

### DIFF
--- a/public/keymaps/e/ergodox_ez_default.json
+++ b/public/keymaps/e/ergodox_ez_default.json
@@ -28,7 +28,7 @@
       "KC_TRNS", "KC_EXLM", "KC_AT",   "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_TRNS",
       "KC_TRNS", "KC_HASH", "KC_DLR",  "KC_LPRN", "KC_RPRN", "KC_GRV",
       "KC_TRNS", "KC_PERC", "KC_CIRC", "KC_LBRC", "KC_RBRC", "KC_TILD", "KC_TRNS",
-      "EPP_RST", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "EEP_RST", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
                                                              "RGB_MOD", "KC_TRNS",
                                                                         "KC_TRNS",
                                                   "RGB_VAD", "RGB_VAI", "KC_TRNS",


### PR DESCRIPTION
Currently fails with the following error:
```console
Compiling: keyboards/ergodox_ez/matrix.c                                                            
Compiling: keyboards/ergodox_ez/led_i2c.c                                                           
Compiling: keyboards/ergodox_ez/ergodox_ez.c                                                        
Compiling: keyboards/ergodox_ez/keymaps/layout_ergodox_mine.json/keymap.c                          In file included from [K:
[K’ undeclared here (not in a function)
  PR, KC_1, KC_2, KC_3, KC_BSLS, KC_TRNS, KC_TRNS, KC_DOT, KC_0, KC_EQL, KC_TRNS, RGB_TOG, KC_NO, KC_TRNS, KC_TRNS, RGB_HUD, RGB_HUI),
[K
[K’
     { k00, k10, k20, k30, k40, KC_NO },   \
[K
 
 | 
 | 
 | 
makeap.o] Error 1
make: *** ine.json] Error 1
ake finished with errors
```