### PR TITLE
Add dynamic width to ANY input (fixed PR)

### DIFF
--- a/src/components/AnyKey.vue
+++ b/src/components/AnyKey.vue
@@ -65,7 +65,7 @@ export default {
     focus() {
       this.stopListening();
       this.hasFocus = true;
-      this.charLength = this.value.length;
+      this.charLength = this.value ? this.value.length : 3;
       this.$refs.input.selectionStart = this.$refs.input.selectionEnd = 1000;
     },
     updateWidth(value) {

--- a/src/components/AnyKey.vue
+++ b/src/components/AnyKey.vue
@@ -13,13 +13,14 @@
     @dragleave.prevent="dragleave"
     @dragover.prevent="dragover"
     @dragenter.prevent="dragenter"
-  ><div>{{ displayName }}<div><input
+  ><div :class="`${hasFocus ? 'key-layer-title-focus' : 'key-layer-title'}`">{{ displayName }}<div><input
   class="key-layer-input"
   @focus.prevent.stop="focus"
   @blur.prevent.stop="blur"
   @click.prevent.stop="clickignore"
   ref="input"
   spellcheck="false"
+  :style="`width:calc(${this.charLength}ch + 6px);`"
   v-model="value" /></div></div><div
         v-if="visible"
         class="remove"
@@ -32,12 +33,19 @@ import BaseKey from './BaseKey';
 export default {
   name: 'any-key',
   extends: BaseKey,
+  data() {
+    return {
+      charLength: 3,
+      hasFocus: false
+    };
+  },
   computed: {
     value: {
       get() {
         return this.meta.text;
       },
       set(value) {
+        this.updateWidth(value);
         this.setText({
           layer: this.$store.state.keymap.layer,
           index: this.id,
@@ -50,11 +58,18 @@ export default {
     ...mapMutations('keymap', ['setText']),
     blur() {
       this.startListening();
+      this.hasFocus = false;
+      this.charLength = 3;
       this.setSelected(undefined);
     },
     focus() {
       this.stopListening();
+      this.hasFocus = true;
+      this.charLength = this.value.length;
       this.$refs.input.selectionStart = this.$refs.input.selectionEnd = 1000;
+    },
+    updateWidth(value) {
+      this.charLength = value.length;
     },
     clickignore() {
       this.stopListening();

--- a/src/components/LayerKey.vue
+++ b/src/components/LayerKey.vue
@@ -13,7 +13,7 @@
     @dragleave.prevent="dragleave"
     @dragover.prevent="dragover"
     @dragenter.prevent="dragenter"
-    ><div>{{ displayName }}<div><input
+    ><div :class="`${hasFocus ? 'key-layer-title-focus' : 'key-layer-title'}`">{{ displayName }}<div><input
     class="key-layer-input"
     :class="errorClasses"
     type="number"
@@ -40,7 +40,8 @@ export default {
   extends: BaseKey,
   data() {
     return {
-      error: false
+      error: false,
+      hasFocus: false
     };
   },
   computed: {
@@ -83,9 +84,11 @@ export default {
     blur() {
       this.startListening();
       this.setSelected(undefined);
+      this.hasFocus = false;
     },
     focus() {
       this.stopListening();
+      this.hasFocus = true;
     }
   }
 };

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -590,6 +590,7 @@ button {
 
 .key-layer-input {
   width: 24px;
+  min-width: 24px;
   height: 24px;
   border-radius: 2px;
   border: 1px solid;
@@ -599,6 +600,18 @@ button {
   -webkit-box-sizing: border-box;
   padding: 1px;
   text-align: center;
+  transition: width 100ms ease-out;
+  &:focus {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -7px);
+    z-index: 2;
+    transition: width 0ms linear;
+  }
+}
+.key-layer-title-focus {
+  padding-bottom: 24px;
 }
 
 #keycodes {


### PR DESCRIPTION
Hi @yanfali (apologies for closing and reopening PR),

**Whats in this PR**
An update to make the input on the any key dynamic to accomodate large combinations of strings e.g.
![Kapture 2020-04-19 at 12 07 57](https://user-images.githubusercontent.com/15189005/79678171-d9624980-823b-11ea-90c9-5566abf420bc.gif)

**Why**
Previously the input would remain static and this made it hard to look at all the content in the input  a small workaround to this was to use the json import so that I could see the whole string.

Ive only applied this update to the any key and have left the other inputs which use a similar layout such as layer selection

Tests are all passing, if theres any amendments / updates Id be happy to chat through them!

(Also with self isolation I have a bit more time so if there are any other quality of life improvements id be happy to help contribute where I can)

Thanks