### PR TITLE
Updated Keyboard Exclusion List and Redirect Table: 2020-04-19

### DIFF
--- a/public/keymaps/p/projectkb_alice_rev1_default.json
+++ b/public/keymaps/p/projectkb_alice_rev1_default.json
@@ -1,5 +1,5 @@
 {
-  "keyboard": "projectkb/alice",
+  "keyboard": "projectkb/alice/rev1",
   "keymap": "default",
   "commit": "e6b9980bd45c186f7360df68c24b6e05a80c10dc",
   "layout": "LAYOUT_default",

--- a/public/keymaps/p/projectkb_alice_rev2_default.json
+++ b/public/keymaps/p/projectkb_alice_rev2_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "projectkb/alice/rev2",
+  "keymap": "default_c2f9e01",
+  "commit": "c2f9e018abbbb1aa8029001fe224b6082127e3a7",
+  "layout": "LAYOUT_default",
+  "layers": [
+    [
+      "KC_ESC",  "KC_TILD", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_DEL",  "KC_BSPC",
+      "KC_PGUP", "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",               "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_PGDN", "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",               "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+                 "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",               "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_RGUI",
+                 "KC_LCTL",            "KC_LALT", "KC_SPC",  "MO(1)",                                    "KC_SPC",             "KC_RALT",            "KC_RCTL"
+    ],
+    [
+      "RGB_TOG",  "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_DEL",
+      "RGB_MOD",  "KC_TRNS", "KC_TRNS", "KC_UP",   "KC_TRNS", "KC_TRNS", "KC_TRNS",            "RGB_SAI", "RGB_HUI", "RGB_VAI", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "RGB_RMOD", "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS",            "RGB_SAD", "RGB_HUD", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+                  "KC_TRNS", "BL_INC",  "BL_DEC",  "BL_TOGG", "BL_BRTG", "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+                  "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",            "KC_TRNS",            "RESET"
+    ]
+  ]
+}

--- a/public/keymaps/y/yd60mq_12led_default.json
+++ b/public/keymaps/y/yd60mq_12led_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "yd60mq/12led",
+  "keymap": "default_607e2f6",
+  "commit": "607e2f6c310f2404933e791561912a0a35587aae",
+  "layout": "LAYOUT_all",
+  "layers": [
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSLS", "KC_GRV",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUHS", "KC_ENT",
+      "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_DEL",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "MO(1)",   "KC_SPC",  "MO(1)",                         "KC_RALT", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "RESET",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_DEL",
+      "KC_TRNS", "RGB_TOG", "KC_UP",   "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "BL_DEC",  "BL_TOGG", "BL_INC",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/y/yd60mq_16led_default.json
+++ b/public/keymaps/y/yd60mq_16led_default.json
@@ -1,5 +1,5 @@
 {
-  "keyboard": "yd60mq",
+  "keyboard": "yd60mq/16led",
   "keymap": "default_607e2f6",
   "commit": "607e2f6c310f2404933e791561912a0a35587aae",
   "layout": "LAYOUT_all",

--- a/public/keymaps/y/ymd75_rev1_default.json
+++ b/public/keymaps/y/ymd75_rev1_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "ymd75/rev1",
+  "keymap": "default_2b06623",
+  "commit": "2b06623fa0c8652e62abe96b1e89853974950c53",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_PSCR", "KC_DEL",  "MO(1)",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_HOME",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_END",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",  "KC_PGUP",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_PGDN",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                        "KC_RALT", "KC_RGUI", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_SAI", "RGB_VAI", "RGB_HUD", "RGB_SAD", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_VOLD", "KC_VOLU", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "BL_TOGG", "BL_INC",  "BL_DEC",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "BL_STEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/y/ymd75_rev2_default.json
+++ b/public/keymaps/y/ymd75_rev2_default.json
@@ -1,5 +1,5 @@
 {
-  "keyboard": "ymd75",
+  "keyboard": "ymd75/rev2",
   "keymap": "default_2b06623",
   "commit": "2b06623fa0c8652e62abe96b1e89853974950c53",
   "layout": "LAYOUT",

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -528,6 +528,7 @@ function getExclusionList() {
     'uzu42',
     'vitamins_included',
     'yd60mq',
+    'ymd75',
     'yosino58',
     'zinc'
   ].reduce((acc, k) => {

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -511,6 +511,7 @@ function getExclusionList() {
     'planck',
     'preonic',
     'primekb/prime_l',
+    'projectkb/alice',
     'ps2avrGB',
     'qwertyydox',
     'redox',

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -527,6 +527,7 @@ function getExclusionList() {
     'treadstone48',
     'uzu42',
     'vitamins_included',
+    'yd60mq',
     'yosino58',
     'zinc'
   ].reduce((acc, k) => {

--- a/src/remap.js
+++ b/src/remap.js
@@ -146,6 +146,9 @@ const lookup = {
   'westfoxtrot/cypher': {
     target: 'westfoxtrot/cypher/rev1'
   },
+  yd60mq: {
+    target: 'yd60mq/12led'
+  },
   zeal60: {
     target: 'wilba_tech/zeal60'
   },

--- a/src/remap.js
+++ b/src/remap.js
@@ -149,6 +149,9 @@ const lookup = {
   yd60mq: {
     target: 'yd60mq/12led'
   },
+  ymd75: {
+    target: 'ymd75/rev1'
+  },
   zeal60: {
     target: 'wilba_tech/zeal60'
   },

--- a/src/remap.js
+++ b/src/remap.js
@@ -96,6 +96,9 @@ const lookup = {
   'primekb/prime_l_v2': {
     target: 'primekb/prime_l/v2'
   },
+  'projectkb/alice': {
+    target: 'projectkb/alice/rev1'
+  },
   'rama/koyu': {
     target: 'wilba_tech/rama_works_koyu'
   },


### PR DESCRIPTION
## New Rules:

### projectkb/alice

- redirect: projectkb/alice -> projectkb/alice/rev1
- fork keymap to rev1 and rev2 versions

### yd60mq

- redirect: yd60mq -> yd60mq/12led
- fork keymap to 12led and 16led versions

### ymd75

- redirect: ymd75 -> ymd75/rev1
- fork keymap to rev1 and rev2 versions

