### PR TITLE
Remove trailing extension name when importing JSON

### DIFF
--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -384,7 +384,11 @@ export default {
           const msg = this.$t('statsTemplate', stats);
           this.deferredMessage(msg);
           this.viewReadme(this.keyboard).then(() => {
-            this.setKeymapName(data.keymap);
+            let keymapName = data.keymap;
+            if (keymapName.endsWith('.json')) {
+              keymapName = keymapName.replace(/.json$/, '');
+            }
+            this.setKeymapName(keymapName);
             this.setDirty();
           });
         });


### PR DESCRIPTION
 - check for and remove trailing extension for JSON when importing
   keymap

Issue #719