### PR TITLE
Display rotated keys in the configuration screens

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -44,6 +44,9 @@ export default {
     y: Number,
     x: Number,
     u: Number,
+    r: Number,
+    rx: Number,
+    ry: Number,
     colorway: String,
     displaySizes: {
       type: Boolean,
@@ -144,11 +147,26 @@ export default {
       if (this.h > 0) {
         styles.push(`height: ${this.h}px;`);
       }
-      if (this.y > 0) {
-        styles.push(`top: ${this.y}px;`);
-      }
-      if (this.x > 0) {
-        styles.push(`left: ${this.x}px;`);
+      if (this.r && this.r != 0) {
+        if (this.ry > 0) {
+          styles.push(`top: ${this.ry}px;`);
+        }
+        if (this.rx > 0) {
+          styles.push(`left: ${this.rx}px;`);
+        }
+        styles.push(
+          `transform: rotate(${this.r}deg) translateX(${Math.round(
+            this.x - this.rx,
+            3
+          )}px) translateY(${Math.round(this.y - this.ry, 3)}px);`
+        );
+      } else {
+        if (this.y > 0) {
+          styles.push(`top: ${this.y}px;`);
+        }
+        if (this.x > 0) {
+          styles.push(`left: ${this.x}px;`);
+        }
       }
       if (this.meta && this.meta.name.length >= 2) {
         let keySize = 0.61;

--- a/src/components/BaseKeymap.vue
+++ b/src/components/BaseKeymap.vue
@@ -13,10 +13,13 @@ export default {
         u: h > w ? h : w
       };
     },
-    calcKeyKeymapPos(x, y) {
+    calcKeyKeymapPos(x, y, r, rx, ry) {
       return {
         x: x * this.config.KEY_X_SPACING,
-        y: y * this.config.KEY_Y_SPACING
+        y: y * this.config.KEY_Y_SPACING,
+        r: r,
+        rx: rx * this.config.KEY_X_SPACING,
+        ry: ry * this.config.KEY_Y_SPACING
       };
     },
     setSize(max) {
@@ -27,10 +30,16 @@ export default {
       const layoutArray = this.layouts[layout];
       const max = layoutArray.reduce(
         (acc, pos) => {
-          let _pos = Object.assign({ w: 1, h: 1 }, pos);
-          const coor = this.calcKeyKeymapPos(_pos.x, _pos.y);
+          let _pos = Object.assign({ w: 1, h: 1, r: 0, rx: 0, ry: 0 }, pos);
+          const coor = this.calcKeyKeymapPos(
+            _pos.x,
+            _pos.y,
+            _pos.r,
+            _pos.rx,
+            _pos.ry
+          );
           const dims = this.calcKeyKeymapDims(_pos.w, _pos.h);
-          acc.x = Math.max(acc.x, coor.x + dims.w);
+          acc.x = Math.max(acc.x, coor.x + dims.w); // TODO: use sin,cos with coor.x,y (icluding w/h)
           acc.y = Math.max(acc.y, coor.y + dims.h);
           return acc;
         },

--- a/src/components/PrintKeymap.vue
+++ b/src/components/PrintKeymap.vue
@@ -58,8 +58,14 @@ export default {
       this.profile && console.time('currentLayer');
       const colorway = this.colorway;
       let curLayer = layout.map((pos, index) => {
-        let _pos = Object.assign({ w: 1, h: 1 }, pos);
-        const coor = this.calcKeyKeymapPos(_pos.x, _pos.y);
+        let _pos = Object.assign({ w: 1, h: 1, r: 0 }, pos);
+        const coor = this.calcKeyKeymapPos(
+          _pos.x,
+          _pos.y,
+          _pos.r,
+          _pos.rx,
+          _pos.ry
+        );
         const dims = this.calcKeyKeymapDims(_pos.w, _pos.h);
         return Object.assign(
           {

--- a/src/components/VisualKeymap.vue
+++ b/src/components/VisualKeymap.vue
@@ -84,8 +84,14 @@ export default {
       this.profile && console.time('currentLayer');
       const colorway = this.colorway;
       let curLayer = layout.map((pos, index) => {
-        let _pos = Object.assign({ w: 1, h: 1 }, pos);
-        const coor = this.calcKeyKeymapPos(_pos.x, _pos.y);
+        let _pos = Object.assign({ w: 1, h: 1, r: 0 }, pos);
+        const coor = this.calcKeyKeymapPos(
+          _pos.x,
+          _pos.y,
+          _pos.r,
+          _pos.rx,
+          _pos.ry
+        );
         const dims = this.calcKeyKeymapDims(_pos.w, _pos.h);
         return Object.assign(
           {

--- a/src/components/VisualTesterKeymap.vue
+++ b/src/components/VisualTesterKeymap.vue
@@ -147,8 +147,14 @@ export default {
       // eslint-disable-next-line no-console
       this.profile && console.time('currentLayer');
       const curLayer = this.activeLayoutMeta.map((pos, index) => {
-        const _pos = Object.assign({ w: 1, h: 1 }, pos);
-        const coor = this.calcKeyKeymapPos(_pos.x, _pos.y);
+        const _pos = Object.assign({ w: 1, h: 1, r: 0 }, pos);
+        const coor = this.calcKeyKeymapPos(
+          _pos.x,
+          _pos.y,
+          _pos.r,
+          _pos.rx,
+          _pos.ry
+        );
         const dims = this.calcKeyKeymapDims(_pos.w, _pos.h);
         return Object.assign(
           {


### PR DESCRIPTION
Currently, the configuration screens are more grid focused.
They work great, but it would be nice to have more flexibility in displaying keyboard layouts.

I started with the kle for the [alice keyboard].
I also created an [alternate layout]() to see just how close to the real thing we could get and if I could design the file more closely tied to the wiring.

### getting the info.json file

I updated the kle2json tool to pass along the rotational information ( [firmware PR] )

This is what the preliminary results look like. I was hoping to get some feedback in terms of whether you liked this direction or wanted to pursue a different course.

### Updated info.json file but no ui changes

I felt that the info file with rotational information should display fine on the screen with no code changes. So, here is the results without this PR applied.

<img width="465" alt="alice_configurator_fallback" src="https://user-images.githubusercontent.com/1930/80681819-6eacdb80-8a8f-11ea-90e5-cbf023175808.png">

### After this PR is applied

<img width="473" alt="alice_confiturator_drag_drop" src="https://user-images.githubusercontent.com/1930/80681893-8e440400-8a8f-11ea-9e8d-4fe9bc386064.png">

### Original Alice KLE file 

The original kle file is also looks great out of the box. It just didn't feel designed well.

<img width="445" alt="orig_kle_configuration" src="https://user-images.githubusercontent.com/1930/80681955-a6b41e80-8a8f-11ea-93d5-efe63c37867a.png">

### original Alice without this PR

You can see the different in the fallback. (which doesn't really matter, it just shows that kle can produce good and bad files

<img width="428" alt="orig_configurator_fallback" src="https://user-images.githubusercontent.com/1930/80682743-11198e80-8a91-11ea-81e1-6263f62d3803.png">


### Outstanding

- Fix the calculation of the keyboard size
- Fix the dimensions object to pass fewer parameters into that function.
- get feedback

### TMI

my alternate kle file (and the corresponding info.json file ) are quite readable to some

I rotated the rows around the first key (the `3` and the `0`:

```
[{x:0.45},"PrtScr", {y:0.1,x:0.3},"esc","1",{y:-0.1},"2",{x:8.35},"-",{y:0.1},"+",{w:2},"del"],
[{y:-0.1, x:0.25},"PgUp",{y:0.1,x:0.20,w:1.5},"tab","q",{x:9,y:-0.1},"p",{y:0.1},"[","]",{w:1.5},"\\"],
[{y:-0.1},"PgDwn",{x:0.3,y:0.1,a:7,w:1.75},"Ctrl","a",{x:9.4},";","'",{w:2.25},"enter"],
[{x:1.1, w:2},"shift", "z",{x:9.25},".","?",{w:1.5},"shift","fn"],
[{x:1.1, w:1.5},"code",{x:13.65,w:1.5}, "code"],
[{r:0,d:true,x:0,y:1, w:9},"http://www.keyboard-layout-editor.com/#/gists/06fdf1f07aa805205271d64bce193bc4"],
[{r:12,rx:4.75,ry:1.15,y:-1},"3","4","5","6"],
[{r:12,rx:4.75,ry:1.15,x:-0.6},"w","e","r","t"],
[{r:12,rx:4.75,ry:1.15,y:1,x:-0.3},"s","d","f","g"],
[{r:12,rx:4.75,ry:1.15,y:2,x:-0.05},"x","c","v", "b"],
[{r:12,rx:4.75,ry:1.15,y:3,x:1.1},{w:2},"sp",{w:1.25},"fn"],
[{r:12,rx:4.75,ry:1.15,y:3.1,x:-0.4},{w:1.5},"alt"],
[{r:-12,rx:13.15,ry:0.975,y:-1,x:-4.05},"7","8","9","0"],
[{r:-12,rx:13.15,ry:0.975,y:0,x:-4.46},"y","u","i","o"],
[{r:-12,rx:13.15,ry:0.975,y:1,x:-4.17},"h","j","k","l"],
[{r:-12,rx:13.15,ry:0.975,y:2,x:-4.48},"b","n","m",","],
[{r:-12,rx:13.15,ry:0.975,y:3,x:-4.48},{w:2.75},"sp"],
[{r:-12,rx:13.15,ry:0.975,y:3,x:-4.48},{x:2.75},{w:1.5, y:0.14},"alt"],
```

[alice keyboard]: http://www.keyboard-layout-editor.com/#/gists/7f17a55de07d88c1f975089b07f053b1
[alternate layout]: http://www.keyboard-layout-editor.com/#/gists/06fdf1f07aa805205271d64bce193bc4 
[firmware PR]: https://github.com/qmk/qmk_firmware/pull/8980