### PR TITLE
Display ISO enters

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -44,6 +44,7 @@ export default {
     y: Number,
     x: Number,
     u: Number,
+    enter: Boolean,
     colorway: String,
     displaySizes: {
       type: Boolean,
@@ -137,14 +138,17 @@ export default {
           classes.push(`${this.colorway}-key`);
         }
       }
+      if (this.enter) {
+        classes.push("kiso")
+      }
       return classes.join(' ');
     },
     mystyles() {
       let styles = [];
-      if (this.w > 0) {
+      if (! this.enter && this.w > 0) {
         styles.push(`width: ${this.w}px;`);
       }
-      if (this.h > 0) {
+      if (!this.enter && this.h > 0) {
         styles.push(`height: ${this.h}px;`);
       }
       if (this.y > 0) {
@@ -272,5 +276,32 @@ export default {
     0px 0px 0px 1px rgba(0, 0, 0, 0.3);
   border-left: 1px solid rgba(0, 0, 0, 0.1);
   border-right: 1px solid rgba(0, 0, 0, 0.1);
+}
+.key.kiso {
+  width: calc(
+    0.5 * var(--default-key-x-spacing) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+
+  padding: 0px;
+  margin-left: calc(var(--default-key-x-spacing) * -0.25);
+  border-radius: 6px 6px 0px 6px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 2px 0px 2px inset,
+    rgba(0, 0, 0, 0.3) 0px 0px 0px 1px;
+}
+.kiso::after {
+  background: inherit;
+  position: absolute;
+  content: '';
+
+  right: -1px;
+  top: var(--default-key-height);
+  height: var(--default-key-x-spacing);
+  width: calc(1.25 * var(--default-key-width));
+  border-radius: 0px 0px 6px 6px;
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: rgba(0, 0, 0, 0.1) 0px -2px 0px 2px inset,
+    rgba(0, 0, 0, 0.3) 0px 2px 0px 1px;
 }
 </style>

--- a/src/components/BaseKeymap.vue
+++ b/src/components/BaseKeymap.vue
@@ -12,6 +12,10 @@ export default {
       return {
         '--default-smaller-key-font-size': `${smolKeySize}rem`,
         '--default-key-font-size': `${keySize}rem`,
+        '--default-key-height': `${this.config.KEY_HEIGHT}px`,
+        '--default-key-width': `${this.config.KEY_WIDTH}px`,
+        '--default-key-x-spacing': `${this.config.KEY_X_SPACING}px`,
+        '--default-key-y-spacing': `${this.config.KEY_Y_SPACING}px`,
         width: `${this.width}px`,
         height: `${this.height}px`
       };
@@ -26,7 +30,8 @@ export default {
         h:
           h * this.config.KEY_Y_SPACING -
           (this.config.KEY_Y_SPACING - this.config.KEY_HEIGHT),
-        u: h > w ? h : w
+        u: h > w ? h : w,
+        enter: (h == 2 && w == 1.25)
       };
     },
     calcKeyKeymapPos(x, y) {


### PR DESCRIPTION
This makes iso enters look more like the iso enter.

## Dependency

This depends upon @yanfali 's change to make styles more performant. (the first 2 commits)

<img width="496" alt="configurator-iso-enter" src="https://user-images.githubusercontent.com/1930/80857369-9d59bc00-8c1f-11ea-9fb0-660a9eb65a72.png">

It handles scaling way up.

<img width="109" alt="configurator-scaled-up" src="https://user-images.githubusercontent.com/1930/80857402-e9a4fc00-8c1f-11ea-9f0c-ddf14f4659dc.png">

I tried to add as few styling as possible.
I did need to force overriding some `.key` values. So I added the precedence `.key.kiso`

Let me know what you think.
Thanks again for the great product