### PR TITLE
Move per key height and width calculations back into CSS

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -34,6 +34,65 @@ let substitute = Object.assign(
   colorways.platformIcons(window.navigator.platform)
 );
 
+const _getUnitClass = (unit, rotated) => {
+  if (rotated) {
+    switch (unit) {
+      case 2:
+        return 'k2uh';
+      case 1.25:
+        'k125uh';
+        return 'k125uh';
+      case 1.5:
+        return 'k15uh';
+      case 1.75:
+        return 'k175uh';
+      default:
+        return 'kiso';
+    }
+  }
+  switch (unit) {
+    case 1:
+      return 'k1u';
+    case 1.25:
+      return 'k125u';
+    case 1.5:
+      return 'k15u';
+    case 1.75:
+      return 'k175u';
+    case 2:
+      return 'k2u';
+    case 2.25:
+      return 'k225u';
+    case 2.75:
+      return 'k275u';
+    case 3:
+      return 'k3u';
+    case 4:
+      return 'k4u';
+    case 6:
+      return 'k6u';
+    case 6.25:
+      return 'k625u';
+    case 7:
+      return 'k7u';
+    default:
+      return 'k1u';
+  }
+};
+
+const cache = new Map();
+
+const getUnitClass = (unit, rotated) => {
+  const key = `${unit}-${rotated}`;
+  let hit = cache.has(key);
+  if (hit) {
+    return cache.get(key);
+  }
+  const value = _getUnitClass(unit, rotated);
+  cache.set(key, value);
+  return value;
+};
+
 export default {
   name: 'base-key',
   props: {
@@ -113,7 +172,7 @@ export default {
         classes.push('smaller');
       }
       const { KEY_WIDTH, KEY_HEIGHT } = this.config;
-      classes.push(this.getUnitClass(this.u, this.h > this.w));
+      classes.push(getUnitClass(this.u, this.h > this.w));
       if (!isUndefined(this.meta) && !this.printable) {
         if (this.colorwayOverride && this.colorwayOverride[this.meta.code]) {
           // Colorway specific overrides by keycode
@@ -160,49 +219,6 @@ export default {
       'setSelectedContent'
     ]),
     ...mapMutations('app', ['stopListening', 'startListening']),
-    getUnitClass(unit, rotated) {
-      if (rotated) {
-        switch (unit) {
-          case 2:
-            return 'k2uh';
-          case 1.25:
-            'k125uh';
-            return 'k125uh';
-          case 1.5:
-            return 'k15uh';
-          case 1.75:
-            return 'k175uh';
-          default:
-            return 'kiso';
-        }
-      }
-      switch (unit) {
-        case 1:
-          return 'k1u';
-        case 1.25:
-          return 'k125u';
-        case 1.5:
-          return 'k15u';
-        case 1.75:
-          return 'k175u';
-        case 2:
-          return 'k2u';
-        case 2.25:
-          return 'k225u';
-        case 2.75:
-          return 'k275u';
-        case 3:
-          return 'k3u';
-        case 6:
-          return 'k6u';
-        case 6.25:
-          return 'k625u';
-        case 7:
-          return 'k7u';
-        default:
-          return 'k1u';
-      }
-    },
     clicked() {
       let id = this.id;
       if (this.isSelected) {
@@ -355,6 +371,12 @@ export default {
 .k3u {
   width: calc(
     calc(2 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k4u {
+  width: calc(
+    calc(3 * var(--default-key-x-spacing)) + var(--default-key-width)
   );
   height: var(--default-key-height);
 }

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -34,9 +34,12 @@ let substitute = Object.assign(
   colorways.platformIcons(window.navigator.platform)
 );
 
-const _getUnitClass = (unit, rotated) => {
-  if (rotated) {
-    switch (unit) {
+const _getUnitClass = (unith, unitw) => {
+  if (unith > unitw) {
+    if (unith === 2 && unitw == 1.25) {
+      return 'kiso';
+    }
+    switch (unith) {
       case 2:
         return 'k2uh';
       case 1.25:
@@ -47,10 +50,9 @@ const _getUnitClass = (unit, rotated) => {
       case 1.75:
         return 'k175uh';
       default:
-        return 'kiso';
     }
   }
-  switch (unit) {
+  switch (unitw) {
     case 1:
       return 'k1u';
     case 1.25:
@@ -82,13 +84,13 @@ const _getUnitClass = (unit, rotated) => {
 
 const cache = new Map();
 
-const getUnitClass = (unit, rotated) => {
-  const key = `${unit}-${rotated}`;
+const getUnitClass = (unitheight, unitwidth) => {
+  const key = `${unitheight}-${unitwidth}`;
   let hit = cache.has(key);
   if (hit) {
     return cache.get(key);
   }
-  const value = _getUnitClass(unit, rotated);
+  const value = _getUnitClass(unitheight, unitwidth);
   cache.set(key, value);
   return value;
 };
@@ -102,7 +104,8 @@ export default {
     h: Number,
     y: Number,
     x: Number,
-    u: Number,
+    uh: Number,
+    uw: Number,
     colorway: String,
     displaySizes: {
       type: Boolean,
@@ -128,7 +131,11 @@ export default {
     },
     displayName() {
       if (this.displaySizes) {
-        return this.u;
+        return this.uh > this.uw
+          ? this.u === 1
+            ? this.uh
+            : `${this.uw} /\n ${this.uh}`
+          : this.uw;
       }
       if (isUndefined(this.meta)) {
         return;
@@ -172,7 +179,7 @@ export default {
         classes.push('smaller');
       }
       const { KEY_WIDTH, KEY_HEIGHT } = this.config;
-      classes.push(getUnitClass(this.u, this.h > this.w));
+      classes.push(getUnitClass(this.uh, this.uw));
       if (!isUndefined(this.meta) && !this.printable) {
         if (this.colorwayOverride && this.colorwayOverride[this.meta.code]) {
           // Colorway specific overrides by keycode

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -113,6 +113,7 @@ export default {
         classes.push('smaller');
       }
       const { KEY_WIDTH, KEY_HEIGHT } = this.config;
+      classes.push(this.getUnitClass(this.u, this.h > this.w));
       if (!isUndefined(this.meta) && !this.printable) {
         if (this.colorwayOverride && this.colorwayOverride[this.meta.code]) {
           // Colorway specific overrides by keycode
@@ -141,12 +142,6 @@ export default {
     },
     mystyles() {
       let styles = [];
-      if (this.w > 0) {
-        styles.push(`width: ${this.w}px;`);
-      }
-      if (this.h > 0) {
-        styles.push(`height: ${this.h}px;`);
-      }
       if (this.y > 0) {
         styles.push(`top: ${this.y}px;`);
       }
@@ -165,6 +160,49 @@ export default {
       'setSelectedContent'
     ]),
     ...mapMutations('app', ['stopListening', 'startListening']),
+    getUnitClass(unit, rotated) {
+      if (rotated) {
+        switch (unit) {
+          case 2:
+            return 'k2uh';
+          case 1.25:
+            'k125uh';
+            return 'k125uh';
+          case 1.5:
+            return 'k15uh';
+          case 1.75:
+            return 'k175uh';
+          default:
+            return 'kiso';
+        }
+      }
+      switch (unit) {
+        case 1:
+          return 'k1u';
+        case 1.25:
+          return 'k125u';
+        case 1.5:
+          return 'k15u';
+        case 1.75:
+          return 'k175u';
+        case 2:
+          return 'k2u';
+        case 2.25:
+          return 'k225u';
+        case 2.75:
+          return 'k275u';
+        case 3:
+          return 'k3u';
+        case 6:
+          return 'k6u';
+        case 6.25:
+          return 'k625u';
+        case 7:
+          return 'k7u';
+        default:
+          return 'k1u';
+      }
+    },
     clicked() {
       let id = this.id;
       if (this.isSelected) {
@@ -272,5 +310,102 @@ export default {
     0px 0px 0px 1px rgba(0, 0, 0, 0.3);
   border-left: 1px solid rgba(0, 0, 0, 0.1);
   border-right: 1px solid rgba(0, 0, 0, 0.1);
+}
+.k1u {
+  width: calc(var(--default-key-width));
+  height: calc(var(--default-key-height));
+}
+//(w - 1) * this.config.KEY_X_SPACING + this.config.KEY_WIDTH
+.k125u {
+  width: calc(
+    calc(0.25 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k15u {
+  width: calc(
+    calc(0.5 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k175u {
+  width: calc(
+    calc(0.75 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k2u {
+  width: calc(
+    calc(1 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k225u {
+  width: calc(
+    calc(1.25 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k275u {
+  width: calc(
+    calc(1.75 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k3u {
+  width: calc(
+    calc(2 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k6u {
+  width: calc(
+    calc(5 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k625u {
+  width: calc(
+    calc(5.25 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k7u {
+  width: calc(
+    calc(6 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: var(--default-key-height);
+}
+.k2uh {
+  width: var(--default-key-width);
+  height: calc(
+    calc(1 * var(--default-key-y-spacing)) + var(--default-key-height)
+  );
+}
+.k125uh {
+  width: var(--default-key-width);
+  height: calc(
+    calc(0.25 * var(--default-key-y-spacing)) + var(--default-key-height)
+  );
+}
+.k15uh {
+  width: var(--default-key-width);
+  height: calc(
+    calc(0.5 * var(--default-key-y-spacing)) + var(--default-key-height)
+  );
+}
+.k175uh {
+  width: var(--default-key-width);
+  height: calc(
+    calc(0.75 * var(--default-key-y-spacing)) + var(--default-key-height)
+  );
+}
+.kiso {
+  width: calc(
+    calc(0.25 * var(--default-key-x-spacing)) + var(--default-key-width)
+  );
+  height: calc(
+    calc(1 * var(--default-key-y-spacing)) + var(--default-key-height)
+  );
 }
 </style>

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -429,12 +429,27 @@ export default {
     calc(0.75 * var(--default-key-y-spacing)) + var(--default-key-height)
   );
 }
-.kiso {
-  width: calc(
-    calc(0.25 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: calc(
-    calc(1 * var(--default-key-y-spacing)) + var(--default-key-height)
-  );
+.key.kiso {
+  width: calc(0.5 * var(--default-key-x-spacing) + var(--default-key-width));
+  height: var(--default-key-height);
+  padding: 0px;
+  margin-left: calc(var(--default-key-x-spacing) * -0.25);
+  border-radius: 6px 6px 0px 6px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 2px 0px 2px inset,
+    rgba(0, 0, 0, 0.3) 0px 0px 0px 1px;
+}
+.kiso::after {
+  background: inherit;
+  position: absolute;
+  content: '';
+  right: -1px;
+  top: var(--default-key-height);
+  height: var(--default-key-x-spacing);
+  width: calc(1.25 * var(--default-key-width));
+  border-radius: 0px 0px 6px 6px;
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: rgba(0, 0, 0, 0.1) 0px -2px 0px 2px inset,
+    rgba(0, 0, 0, 0.3) 0px 2px 0px 1px;
 }
 </style>

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -132,7 +132,7 @@ export default {
     displayName() {
       if (this.displaySizes) {
         return this.uh > this.uw
-          ? this.u === 1
+          ? this.uw === 1
             ? this.uh
             : `${this.uw} /\n ${this.uh}`
           : this.uw;
@@ -175,7 +175,7 @@ export default {
       if (this.inSwap) {
         classes.push('swapme');
       }
-      if (this.meta && this.meta.name.length >= 2) {
+      if (this.meta && this.meta.name.length >= 2 && !this.displaySizes) {
         classes.push('smaller');
       }
       const { KEY_WIDTH, KEY_HEIGHT } = this.config;

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -35,7 +35,7 @@ let substitute = Object.assign(
 );
 
 const _getUnitClass = (unith, unitw) => {
-  if (unith > unitw) {
+  if (unith > unitw || unith < 1) {
     if (unith === 2 && unitw == 1.25) {
       return 'kiso';
     }
@@ -50,6 +50,7 @@ const _getUnitClass = (unith, unitw) => {
       case 1.75:
         return 'k175uh';
       default:
+        return 'custom';
     }
   }
   switch (unitw) {
@@ -78,7 +79,7 @@ const _getUnitClass = (unith, unitw) => {
     case 7:
       return 'k7u';
     default:
-      return 'k1u';
+      return 'custom';
   }
 };
 
@@ -213,6 +214,13 @@ export default {
       }
       if (this.x > 0) {
         styles.push(`left: ${this.x}px;`);
+      }
+      if (getUnitClass(this.uh, this.uw) === 'custom') {
+        // explicitly override the height and width calculations for the keymap and provide custom values
+        styles = styles.concat([
+          `--default-key-height: ${this.config.KEY_HEIGHT * this.uh}px;`,
+          `--default-key-width: ${this.config.KEY_WIDTH * this.uw}px;`
+        ]);
       }
 
       return styles.join('');
@@ -410,6 +418,10 @@ export default {
   height: calc(
     calc(1 * var(--default-key-y-spacing)) + var(--default-key-height)
   );
+}
+.custom {
+  width: var(--default-key-width);
+  height: var(--default-key-height);
 }
 .k125uh {
   width: var(--default-key-width);

--- a/src/components/BaseKeymap.vue
+++ b/src/components/BaseKeymap.vue
@@ -30,7 +30,8 @@ export default {
         h:
           h * this.config.KEY_Y_SPACING -
           (this.config.KEY_Y_SPACING - this.config.KEY_HEIGHT),
-        u: h > w ? h : w
+        uh: h,
+        uw: w
       };
     },
     calcKeyKeymapPos(x, y) {

--- a/src/components/BaseKeymap.vue
+++ b/src/components/BaseKeymap.vue
@@ -12,6 +12,10 @@ export default {
       return {
         '--default-smaller-key-font-size': `${smolKeySize}rem`,
         '--default-key-font-size': `${keySize}rem`,
+        '--default-key-height': `${this.config.KEY_HEIGHT}px`,
+        '--default-key-width': `${this.config.KEY_WIDTH}px`,
+        '--default-key-x-spacing': `${this.config.KEY_X_SPACING}px`,
+        '--default-key-y-spacing': `${this.config.KEY_Y_SPACING}px`,
         width: `${this.width}px`,
         height: `${this.height}px`
       };

--- a/src/components/PrintKey.vue
+++ b/src/components/PrintKey.vue
@@ -42,7 +42,7 @@ export default {
   },
   methods: {
     breakLines(name) {
-      if (this.u < 1.75) {
+      if (this.uw < 1.75) {
         name = name.replace(' ', '\n').replace('_', '_\n');
       }
       return name;

--- a/src/components/TesterKey.vue
+++ b/src/components/TesterKey.vue
@@ -39,7 +39,7 @@ export default {
   },
   methods: {
     breakLines(name) {
-      if (this.u < 1.75) {
+      if (this.uw < 1.75) {
         name = name.replace(' ', '\n').replace('_', '_\n');
       }
       return name;


### PR DESCRIPTION
Take advantage of CSS Custom Variables and CSS calc to move height and width calculations into CSS where they really belong rather than per DOM key element.

 - ISO CSS contributed by @kbrock thanks so much for this work!

### Pros:
 - remove explicit height and width in each key style
 - reduces parsing load on the DOM
 - allows overriding through use of classes. Styles have highest specificity

### Cons:
 - pushes some work in the CSS parser
 - may be somewhat difficult to understand

