### PR TITLE
Murcielago default layout

### DIFF
--- a/public/keymaps/m/murcielago_rev1_default.json
+++ b/public/keymaps/m/murcielago_rev1_default.json
@@ -1,0 +1,36 @@
+{
+  "keyboard": "murcielago/rev1",
+  "keymap": "default_6a1a08a1",
+  "commit": "6a1a08a162ab1d03e823cb21df3f2e427bd1508c",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_EQL",   "KC_1",           "KC_2",    "KC_3",   "KC_4",         "KC_5",                       "KC_6",          "KC_7",   "KC_8",   "KC_9",         "KC_0",   "KC_MINS",
+      "KC_LBRC",  "KC_Q",           "KC_W",    "KC_E",   "KC_R",         "KC_T",                       "KC_Y",          "KC_U",   "KC_I",   "KC_O",         "KC_P",   "KC_RBRC",
+      "KC_DEL",   "KC_A",           "KC_S",    "KC_D",   "KC_F",         "KC_G",                       "KC_H",          "KC_J",   "KC_K",   "KC_L",         "KC_SCLN","KC_QUOT",
+      "KC_LSFT",  "KC_Z",           "KC_X",    "KC_C",   "KC_V",         "KC_B",   "KC_ESC", "KC_TAB", "KC_N",          "KC_M",   "KC_COMM","KC_DOT",       "KC_SLSH","KC_RSFT",
+                  "LALT_T(KC_CAPS)","KC_LGUI", "MO(2)",  "KC_BSPC",      "KC_LCTL",                    "RALT_T(KC_ENT)","KC_SPC", "MO(1)",  "KC_RGUI",      "KC_MPLY"
+    ],
+    [
+      "KC_NO",    "KC_F1",          "KC_F2",   "KC_F3",  "KC_F4",        "KC_F5",                      "KC_F6",         "KC_F7",  "KC_F8",  "KC_F9",        "KC_F10", "KC_F11",
+      "KC_NO",    "KC_EXLM",        "KC_AT",   "KC_HASH","KC_DLR",       "KC_PERC",                    "KC_NO", "LCTL(KC_LEFT)",  "KC_UP",  "LCTL(KC_RGHT)","KC_NO",  "KC_F12",
+      "KC_NO",    "KC_PIPE",        "KC_LPRN", "KC_LBRC","KC_LCBR",      "KC_LT",                      "KC_HOME",     "KC_LEFT",  "KC_DOWN","KC_RGHT",      "KC_END", "KC_NO",
+      "KC_NO",    "KC_TILD",        "KC_EQL",  "KC_PLUS","KC_BSLS",      "KC_NO",  "KC_NO",  "KC_NO",  "KC_NO", "LCTL(KC_BSPC)",  "KC_INS", "LCTL(KC_DEL)", "KC_NO",  "KC_NO",
+                  "KC_NO",          "KC_NO",   "MO(3)",  "KC_NO",        "KC_NO",                      "KC_NO",         "KC_NO",  "KC_TRNS","KC_NO",        "KC_NO"
+    ],
+    [
+      "RESET",    "KC_F1",          "KC_F2",   "KC_F3",  "KC_F4",        "KC_F5",                      "KC_F6",         "KC_F7",  "KC_F8",  "KC_F9",        "KC_F10", "KC_F11",
+      "KC_NO",    "KC_NO",  "LCTL(KC_LEFT)",   "KC_UP",  "LCTL(KC_RGHT)","KC_NO",                      "KC_CIRC",       "KC_AMPR","KC_ASTR","RALT(KC_5)",   "KC_QUES","KC_F12",
+      "KC_NO",    "KC_HOME",      "KC_LEFT",   "KC_DOWN","KC_RGHT",      "KC_END",                     "KC_GT",         "KC_RCBR","KC_RBRC","KC_RPRN",      "KC_PIPE","KC_NO",
+      "KC_NO",    "KC_NO",  "LCTL(KC_BSPC)",   "KC_INS", "LCTL(KC_DEL)", "KC_NO", "KC_NO",  "KC_NO",   "KC_NO",         "KC_SLSH","KC_MINS","KC_UNDS",      "KC_GRV", "KC_NO",
+                  "KC_NO",          "KC_NO",   "KC_TRNS","KC_NO",        "KC_NO",                      "KC_NO",         "KC_NO",  "MO(3)",  "KC_NO",        "KC_NO"
+    ],
+    [
+      "RESET",    "KC_F1",          "KC_F2",   "KC_F3",  "KC_F4",        "KC_F5",                      "KC_F6",         "KC_F7",  "KC_F8",  "KC_F9",        "KC_F10", "KC_F11",
+      "KC_NO",    "KC_EXLM",        "KC_AT",   "KC_HASH","KC_DLR",       "KC_PERC",                    "KC_CIRC",       "KC_AMPR","KC_ASTR","RALT(KC_5)",   "KC_QUES","KC_F12",
+      "KC_NO",    "KC_PIPE",        "KC_LPRN", "KC_LBRC","KC_LCBR",      "KC_LT",                      "KC_GT",         "KC_RCBR","KC_RBRC","KC_RPRN",      "KC_PIPE","KC_NO",
+      "KC_NO",    "KC_TILD",        "KC_EQL",  "KC_PLUS","KC_BSLS",      "KC_NO",  "KC_NO",  "KC_NO",  "KC_NO",         "KC_SLSH","KC_MINS","KC_UNDS",      "KC_GRV", "KC_NO",
+                  "KC_NO",          "KC_NO",   "KC_TRNS","KC_NO",        "KC_NO",                      "KC_NO",         "KC_NO",  "KC_TRNS","KC_NO",        "KC_NO"
+    ]
+  ]
+}

--- a/public/keymaps/m/murcielago_rev1_default.json
+++ b/public/keymaps/m/murcielago_rev1_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "murcielago/rev1",
-  "keymap": "default_6a1a08a1",
-  "commit": "6a1a08a162ab1d03e823cb21df3f2e427bd1508c",
+  "keymap": "default",
+  "commit": "fadd3cb4617fe7e48c802c4470a50df36e6c5109",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -510,6 +510,7 @@ function getExclusionList() {
     'meira',
     'minidox',
     'montsinger/rebound',
+    'murcielago',
     'naked48',
     'naked60',
     'naked64',


### PR DESCRIPTION
After merging the board to qmk, I would like to add this default layout. I chose a commit ID that was yet unused. I hope that it is ok like this. It looks a bit messy, due to the long keycodes.

How can I make sure that only murcielago/rev1 appears in the configurator drop-down menu, and not murcielago alone (without rev1)? The latter does not build, which makes sense.