### PR TITLE
Murcielago: change keymap according to qmk defaults

### DIFF
--- a/public/keymaps/m/murcielago_rev1_default.json
+++ b/public/keymaps/m/murcielago_rev1_default.json
@@ -5,32 +5,32 @@
   "layout": "LAYOUT",
   "layers": [
     [
-      "KC_EQL",   "KC_1",           "KC_2",    "KC_3",   "KC_4",         "KC_5",                       "KC_6",          "KC_7",   "KC_8",   "KC_9",         "KC_0",   "KC_MINS",
-      "KC_LBRC",  "KC_Q",           "KC_W",    "KC_E",   "KC_R",         "KC_T",                       "KC_Y",          "KC_U",   "KC_I",   "KC_O",         "KC_P",   "KC_RBRC",
-      "KC_DEL",   "KC_A",           "KC_S",    "KC_D",   "KC_F",         "KC_G",                       "KC_H",          "KC_J",   "KC_K",   "KC_L",         "KC_SCLN","KC_QUOT",
-      "KC_LSFT",  "KC_Z",           "KC_X",    "KC_C",   "KC_V",         "KC_B",   "KC_ESC", "KC_TAB", "KC_N",          "KC_M",   "KC_COMM","KC_DOT",       "KC_SLSH","KC_RSFT",
-                  "LALT_T(KC_CAPS)","KC_LGUI", "MO(2)",  "KC_BSPC",      "KC_LCTL",                    "RALT_T(KC_ENT)","KC_SPC", "MO(1)",  "KC_RGUI",      "KC_MPLY"
+      "KC_EQL",       "KC_1",       "KC_2",       "KC_3",       "KC_4",       "KC_5",                                 "KC_6",       "KC_7",       "KC_8",       "KC_9",       "KC_0",         "KC_MINS",     
+      "KC_TAB",       "KC_Q",       "KC_W",       "KC_E",       "KC_R",       "KC_T",                                 "KC_Y",       "KC_U",       "KC_I",       "KC_O",       "KC_P",         "KC_BSLS",      
+      "KC_DEL",       "KC_A",       "KC_S",       "KC_D",       "KC_F",       "KC_G",                                 "KC_H",       "KC_J",       "KC_K",       "KC_L",       "KC_SCLN",      "KC_QUOT",     
+      "KC_LSFT",      "KC_Z",       "KC_X",       "KC_C",       "KC_V",       "KC_B",         "KC_GESC",  "KC_ENT",   "KC_N",       "KC_M",       "KC_COMM",    "KC_DOT",     "KC_SLSH",      "KC_RSFT",     
+                      "KC_LALT",    "KC_LGUI",    "MO(2)",      "KC_BSPC",    "KC_LCTL",                              "KC_RALT",    "KC_SPC",     "MO(1)",      "OSL(3)",     "KC_MPLY"
     ],
     [
-      "KC_NO",    "KC_F1",          "KC_F2",   "KC_F3",  "KC_F4",        "KC_F5",                      "KC_F6",         "KC_F7",  "KC_F8",  "KC_F9",        "KC_F10", "KC_F11",
-      "KC_NO",    "KC_EXLM",        "KC_AT",   "KC_HASH","KC_DLR",       "KC_PERC",                    "KC_NO", "LCTL(KC_LEFT)",  "KC_UP",  "LCTL(KC_RGHT)","KC_NO",  "KC_F12",
-      "KC_NO",    "KC_PIPE",        "KC_LPRN", "KC_LBRC","KC_LCBR",      "KC_LT",                      "KC_HOME",     "KC_LEFT",  "KC_DOWN","KC_RGHT",      "KC_END", "KC_NO",
-      "KC_NO",    "KC_TILD",        "KC_EQL",  "KC_PLUS","KC_BSLS",      "KC_NO",  "KC_NO",  "KC_NO",  "KC_NO", "LCTL(KC_BSPC)",  "KC_INS", "LCTL(KC_DEL)", "KC_NO",  "KC_NO",
-                  "KC_NO",          "KC_NO",   "MO(3)",  "KC_NO",        "KC_NO",                      "KC_NO",         "KC_NO",  "KC_TRNS","KC_NO",        "KC_NO"
+      "KC_F12",       "KC_F1",      "KC_F2",      "KC_F3",      "KC_F4",      "KC_F5",                                "KC_F6",      "KC_F7",      "KC_F8",     "KC_F9",       "KC_F10",       "KC_F11",    
+      "KC_NO",        "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",                                "KC_NO",  "LCTL(KC_LEFT)",  "KC_UP",  "LCTL(KC_RGHT)",  "KC_NO",        "KC_NO",     
+      "KC_NO",        "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",                                "KC_HOME",    "KC_LEFT",    "KC_DOWN",   "KC_RGHT",     "KC_END",       "KC_NO",   
+      "KC_TRNS",      "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",        "KC_NO",    "KC_NO",    "KC_NO",  "LCTL(KC_BSPC)",  "KC_INS", "LCTL(KC_DEL)",   "KC_NO",        "KC_NO",     
+                      "KC_TRNS",    "KC_NO",      "KC_NO",      "KC_NO",      "KC_TRNS",                              "KC_NO",      "KC_NO",      "KC_TRNS",   "KC_NO",       "KC_NO"
     ],
     [
-      "RESET",    "KC_F1",          "KC_F2",   "KC_F3",  "KC_F4",        "KC_F5",                      "KC_F6",         "KC_F7",  "KC_F8",  "KC_F9",        "KC_F10", "KC_F11",
-      "KC_NO",    "KC_NO",  "LCTL(KC_LEFT)",   "KC_UP",  "LCTL(KC_RGHT)","KC_NO",                      "KC_CIRC",       "KC_AMPR","KC_ASTR","RALT(KC_5)",   "KC_QUES","KC_F12",
-      "KC_NO",    "KC_HOME",      "KC_LEFT",   "KC_DOWN","KC_RGHT",      "KC_END",                     "KC_GT",         "KC_RCBR","KC_RBRC","KC_RPRN",      "KC_PIPE","KC_NO",
-      "KC_NO",    "KC_NO",  "LCTL(KC_BSPC)",   "KC_INS", "LCTL(KC_DEL)", "KC_NO", "KC_NO",  "KC_NO",   "KC_NO",         "KC_SLSH","KC_MINS","KC_UNDS",      "KC_GRV", "KC_NO",
-                  "KC_NO",          "KC_NO",   "KC_TRNS","KC_NO",        "KC_NO",                      "KC_NO",         "KC_NO",  "MO(3)",  "KC_NO",        "KC_NO"
+      "KC_F12",       "KC_F1",      "KC_F2",      "KC_F3",      "KC_F4",      "KC_F5",                                "KC_F6",      "KC_F7",      "KC_F8",      "KC_F9",      "KC_F10",       "KC_F11",    
+      "KC_NO",        "KC_NO",      "KC_NO",      "KC_LPRN",    "KC_RPRN",    "KC_NO",                                "KC_NO",      "KC_P7",      "KC_P8",      "KC_P9",      "KC_NO",        "KC_NO",    
+      "KC_CAPS",      "KC_NO",      "KC_TILD",    "KC_LCBR",    "KC_RCBR",    "KC_NO",                                "KC_PPLS",    "KC_P4",      "KC_P5",      "KC_P6",      "KC_PMNS",      "KC_NO",    
+      "KC_NO",        "KC_NO",      "KC_GRV",     "KC_LBRC",    "KC_RBRC",    "KC_NO",        "KC_NO",    "KC_PENT",  "KC_PAST",    "KC_P1",      "KC_P2",      "KC_P3",      "KC_PSLS",      "KC_NO",    
+                      "KC_NO",      "KC_NO",      "KC_TRNS",    "KC_NO",      "KC_NO",                                "KC_NO",      "KC_P0",      "KC_NO",      "KC_NO",      "KC_NLCK"
     ],
     [
-      "RESET",    "KC_F1",          "KC_F2",   "KC_F3",  "KC_F4",        "KC_F5",                      "KC_F6",         "KC_F7",  "KC_F8",  "KC_F9",        "KC_F10", "KC_F11",
-      "KC_NO",    "KC_EXLM",        "KC_AT",   "KC_HASH","KC_DLR",       "KC_PERC",                    "KC_CIRC",       "KC_AMPR","KC_ASTR","RALT(KC_5)",   "KC_QUES","KC_F12",
-      "KC_NO",    "KC_PIPE",        "KC_LPRN", "KC_LBRC","KC_LCBR",      "KC_LT",                      "KC_GT",         "KC_RCBR","KC_RBRC","KC_RPRN",      "KC_PIPE","KC_NO",
-      "KC_NO",    "KC_TILD",        "KC_EQL",  "KC_PLUS","KC_BSLS",      "KC_NO",  "KC_NO",  "KC_NO",  "KC_NO",         "KC_SLSH","KC_MINS","KC_UNDS",      "KC_GRV", "KC_NO",
-                  "KC_NO",          "KC_NO",   "KC_TRNS","KC_NO",        "KC_NO",                      "KC_NO",         "KC_NO",  "KC_TRNS","KC_NO",        "KC_NO"
+      "KC_F12",       "KC_F1",      "KC_F2",      "KC_F3",      "KC_F4",      "KC_F5",                                "KC_F6",      "KC_F7",      "KC_F8",      "KC_F9",      "KC_F10",       "KC_F11",    
+      "LCTL(KC_F12)", "LCTL(KC_F1)","LCTL(KC_F2)","LCTL(KC_F3)","LCTL(KC_F4)","LCTL(KC_F5)",                          "LCTL(KC_F6)","LCTL(KC_F7)","LCTL(KC_F8)","LCTL(KC_F9)","LCTL(KC_F10)", "LCTL(KC_F11)",
+      "LALT(KC_F12)", "LALT(KC_F1)","LALT(KC_F2)","LALT(KC_F3)","LALT(KC_F4)","LALT(KC_F5)",                          "LALT(KC_F6)","LALT(KC_F7)","LALT(KC_F8)","LALT(KC_F9)","LALT(KC_F10)", "LALT(KC_F11)",    
+      "KC_NO",        "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",        "KC_NO",    "KC_NO",    "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",        "KC_NO",     
+                      "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",      "KC_NO",                                "KC_NO",      "KC_NO",      "KC_NO",      "KC_TRNS",    "KC_NO"
     ]
   ]
 }

--- a/public/keymaps/m/murcielago_rev1_default.json
+++ b/public/keymaps/m/murcielago_rev1_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "murcielago/rev1",
   "keymap": "default",
-  "commit": "fadd3cb4617fe7e48c802c4470a50df36e6c5109",
+  "commit": "e2699773879f17e70e05dd043f2231786c6a61ad",
   "layout": "LAYOUT",
   "layers": [
     [


### PR DESCRIPTION
Just a small change to the default keymap.
The previous RESET keycodes don't make a lot of sense if only one half is connected, as they cannot be reached in that case.

Also, make SHIFT transparent on function layers, or text cannot be selected in combination with arrows keys.