### PR TITLE
feat: add simplified chinese language support

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -9,6 +9,7 @@ import plPL from './pl-PL.csv';
 import ptBR from './pt-BR.csv';
 import ru from './ru.csv';
 import zh from './zh.csv';
+import zhCN from './zh-CN.csv';
 // During the import of the csv files
 // the loader will parse the files and generate
 // the translation objects
@@ -23,5 +24,6 @@ export default {
   ru,
   zh,
   'pl-PL': plPL,
-  'pt-BR': ptBR
+  'pt-BR': ptBR,
+  'zh-CN': zhCN
 };

--- a/src/i18n/zh-CN.csv
+++ b/src/i18n/zh-CN.csv
@@ -102,10 +102,10 @@ printKeymap:label,打印键位
 printKeymap:title,打印键位表
 settingsPanel:darkmode:help,使用 QMK 深色主题
 settingsPanel:darkmode:label,深色模式
-settingsPanel:displaySizes:help,以按键单位显示键帽尺寸
+settingsPanel:displaySizes:help,以按键单位(u)显示键帽尺寸
 settingsPanel:displaySizes:label,显示按键尺寸
 settingsPanel:displaySizes:title,ctrl + alt + u
-settingsPanel:fastInput:help,不敲击每个位置通过键盘输入按键
+settingsPanel:fastInput:help,直接通过键盘输入键位
 settingsPanel:fastInput:label,快速输入
 settingsPanel:fastInput:title,ctrl + alt + f
 settingsPanel:language:help,更改用户界面语言

--- a/src/i18n/zh-CN.csv
+++ b/src/i18n/zh-CN.csv
@@ -1,0 +1,136 @@
+Key,Translation
+apiVersion,API 版本
+apiVersionPrefix,API
+favoriteColor,收藏配色
+favoriteKeyboard,收藏键盘
+hostedOn,部署在 GitHub Pages
+jobsAhead,前往
+jobsWaiting,个任务等待中
+maintain,该项目由 QMK 开发者和贡献者维护
+ready,就绪
+searchKeycodes,搜索
+serverIs,服务
+serverStatus,服务状态
+settings,设置
+statsTemplate,"
+已加载 {layers} 个层和 {count} 个键位码，已定义 {any} 任意键位码
+"
+ColorwayTip:title,Ctrl + Alt + N 切换下一个配色
+compile:label,编译
+compile:title,编译键位
+downloadFirmware:label,固件
+downloadFirmware:title,下载固件
+downloadJSON:label,Keymap.JSON
+downloadJSON:title,导出 Keymap JSON 文件
+downloadKeymap:label,仅键位
+downloadKeymap:title,仅下载 keymap.c
+downloadSource:label,全部代码
+downloadSource:title,下载 QMK 固件代码
+downloadToolbox:label,获取 QMK Toolbox
+errors:invalidQMKKeymap,对不起，这不是一个合法的 QMK keymap 文件
+errors:kbfirmwareJSONUnsupported,对不起，QMK Configurator 不支持 kbfirmware JSON 文件。
+errors:unknownJSON,对不起，这似乎不是一个 QMK keymap 文件
+errors:unsupportedBrowser,你正在使用一个不支持的浏览器。建议使用
+flashFile:label,自定义刷写
+flashFile:title,刷写选择的固件文件到 MCU
+flashFirmware:label,自动刷写
+flashFirmware:title,自动将编译好的固件刷写到 MCU
+help:label,开启向导
+importJSON:title,导入 Keymap JSON 文件
+importUrlJSON:title,从 URL 导入 Keymap JSON 文件
+keyboard:label,键盘
+keycodes:label,键位码
+keycodesRef:label,键位码参考
+keycodesTab:ANSI:label,ANSI
+keycodesTab:AppMediaMouse:label,应用、多媒体和鼠标
+keycodesTab:ISO/JIS:label,ISO/JIS
+keycodesTab:KeyboardSettings:label,键盘设置
+keycodesTab:Quantum:label,量子
+keymap:label,键位
+keymapHelp:label,帮助
+keymapHelp:title,如何使用 keymap.json？
+keymapName:label,键位名
+keymapName:placeholder,自定义键位名
+layer:confirm,确认清除该层？
+layer:label,键位层
+layer:title,清除层
+layout:label,配列
+loadDefault:label,加载默认
+loadDefault:title,从 QMK 固件加载默认键位
+potato:1,亨利·斯伯丁于1837年在爱达荷首次种植马铃薯。
+potato:10,中国是最大的马铃薯生产国。
+potato:11,马铃薯是第一种在太空中种植的蔬菜。
+potato:12,土豆是完全无麸质。
+potato:13,印加对于时间最基本的衡量标准之一是煮土豆所需的时间。
+potato:14,如果马铃薯暴露在光线中生长，它会变绿并且带有毒性。
+potato:15,"“制造2500磅薯片需要10,000磅土豆。”"
+potato:16,如今有4000多种不同的土豆。
+potato:17,“马铃薯属于一个科，茄属植物或茄科。”
+potato:18,“在阿拉斯加克朗代克淘金热期间（1897年至1898年），土豆在重量上和黄金实际上是等值的。”
+potato:19,"“沃尔特·罗利爵士于1589年在科克附近的40,000英亩土地上将土豆引入了爱尔兰。”"
+potato:2,法式薯条由托马斯·杰斐逊在一次白宫晚宴中带到美国。
+potato:20,一年四季都可以收获马铃薯，因为它们每个月都会在某个地方收获。
+potato:21,“原产于非洲和亚洲的洋芋大小不一，从小土豆到创纪录的130磅。”
+potato:22,8月19日和10月27日是美国的国家马铃薯日。
+potato:23,“马铃薯还可以用来酿造酒精饮料，例如伏特加，波奇恩或阿夸维特。”
+potato:24,“马铃薯是最环保的蔬菜之一。它们易于种植，不需要像许多其他蔬菜一样大量依赖肥料和化学添加剂。”
+potato:25,马铃薯起源于南秘鲁地区，最早在公元前8000年至5000年之间被驯化。
+potato:26,马铃薯的英文 potato 源自西班牙语词汇 patata。
+potato:27,马铃薯通常由昆虫授粉，比如黄蜂。
+potato:28,一个土豆由80%的水和20%的固体构成。
+potato:3,2017年，美国的土豆爱好者消费了400万吨不同形状和尺寸的薯条。
+potato:4,土豆是一种强力的催情剂，一名爱尔兰物理学家表示。
+potato:5,美国人每年人均食用140镑土豆。德国人每年人均食用200镑土豆。
+potato:6,根据吉尼斯世界纪录，最大的土豆重18镑4盎司，于1795年在英格兰长成。
+potato:7,马铃薯是世界第四大主食，排在小麦、玉米和大米之后。
+potato:8,马铃薯在超过125个国家种植。
+potato:9,世界每年的马铃薯产量足以覆盖一条4车道马路环绕地球6圈。
+print:anonymous:label,匿名
+print:author:placeholder,你的名字（可选）
+print:author:title,作者
+print:back:title,返回
+print:date:title,日期
+print:keyboard:label,键盘
+print:layer:label,层
+print:layout:label,配列
+print:notes:empty,默认键位
+print:notes:placeholder,该配置的说明
+print:notes:title,说明
+print:print:title,打印
+print:source:title,源码
+printKeymap:label,打印键位
+printKeymap:title,打印键位表
+settingsPanel:darkmode:help,使用 QMK 深色主题
+settingsPanel:darkmode:label,深色模式
+settingsPanel:displaySizes:help,Show keycap sizes in Key Units
+settingsPanel:displaySizes:label,显示按键尺寸
+settingsPanel:displaySizes:title,ctrl + alt + u
+settingsPanel:fastInput:help,不敲击每个位置通过键盘输入按键
+settingsPanel:fastInput:label,快速输入
+settingsPanel:fastInput:title,ctrl + alt + f
+settingsPanel:language:help,更改用户界面语言
+settingsPanel:language:title,语言
+settingsPanel:off:label,关闭
+settingsPanel:on:label,开启
+settingsPanel:snowflakes:label,开启 Snowflakes
+settingsPanel:snowflakes:title,Snowflakes
+settingsPanel:title,配置选项
+settingsPanel:toggleTutorial:help,MechMerlin 的视频教程
+settingsPanel:toggleTutorial:label,视频教程
+testKeys:label,测试键盘
+testKeys:title,测试键盘输入
+tester:back:label,返回
+tester:back:title,回到配置页面
+tester:chatter:detectedAlert,探测到震颤！
+tester:chatter:label,震颤阈值 (ms)
+tester:docs:paragraph,注意：探测到的键位值和键位码可能会因为本地设置有所不同。文档
+tester:keycodeStatus:label,键码已探测
+tester:letters:code:label,键位代码
+tester:letters:key:label,键位值
+tester:letters:keycode:label,键位码
+tester:page:label,重置
+tester:reset:label,重置已测试按键
+tester:reset:title,开启打字机音效
+tester:typewritericon:label,开启打字机音效
+toggleTerminal:label,点击展开
+toggleTerminal:title,开启终端显示

--- a/src/i18n/zh-CN.csv
+++ b/src/i18n/zh-CN.csv
@@ -102,7 +102,7 @@ printKeymap:label,打印键位
 printKeymap:title,打印键位表
 settingsPanel:darkmode:help,使用 QMK 深色主题
 settingsPanel:darkmode:label,深色模式
-settingsPanel:displaySizes:help,Show keycap sizes in Key Units
+settingsPanel:displaySizes:help,以按键单位显示键帽尺寸
 settingsPanel:displaySizes:label,显示按键尺寸
 settingsPanel:displaySizes:title,ctrl + alt + u
 settingsPanel:fastInput:help,不敲击每个位置通过键盘输入按键

--- a/src/i18n/zh-CN.csv
+++ b/src/i18n/zh-CN.csv
@@ -121,8 +121,8 @@ testKeys:label,测试键盘
 testKeys:title,测试键盘输入
 tester:back:label,返回
 tester:back:title,回到配置页面
-tester:chatter:detectedAlert,探测到震颤！
-tester:chatter:label,震颤阈值 (ms)
+tester:chatter:detectedAlert,探测到连击！
+tester:chatter:label,连击阈值 (ms)
 tester:docs:paragraph,注意：探测到的键位值和键位码可能会因为本地设置有所不同。文档
 tester:keycodeStatus:label,键码已探测
 tester:letters:code:label,键位代码

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -68,7 +68,8 @@ const state = {
     { value: 'ru', label: 'Русский' },
     { value: 'pt-BR', label: 'Brasileira' },
     { value: 'pl-PL', label: 'Polski' },
-    { value: 'ms', label: 'Bahasa Malaysia' }
+    { value: 'ms', label: 'Bahasa Malaysia' },
+    { value: 'zh-CN', label: '简体中文' }
   ],
   snowflakes: false
 };


### PR DESCRIPTION
Add Simplified Chinese language translation.

I noticed that you guys has added `zh` support in #520, and as I have commented:
> Chinese is like Portuguese, where there are some variations. And words used in keyboard are especially different.

Here I add only support for Simplified Chinese (`zhCN`), the `zh` one is still there.