### PR TITLE
fix: potato fact is not loaded with correct language after launch

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -99,16 +99,16 @@ export default {
   },
   async beforeMount() {
     await this.appLoad();
+    this.randomPotatoFact();
+    this.interval = setInterval(() => {
+      this.randomPotatoFact();
+    }, this.interval);
   },
   created() {
     // will trigger function before closing/refreshing tab
     window.addEventListener('beforeunload', this.showConfirmationPrompt);
   },
   mounted() {
-    this.randomPotatoFact();
-    this.interval = setInterval(() => {
-      this.randomPotatoFact();
-    }, this.interval);
     this.destroyWatcher = this.$store.watch(
       state => state.app.settingsPanelVisible,
       this.toggleSettingsPanel


### PR DESCRIPTION
Potato fact is not correctly shown in language user selected and always starts with English. After the first interval (which is literally `120000`), it will be back normal.

Because potato fact is shown at `mounted`, `vue-i18n` is not actually initialized and the language is fallback to `en` and the interval is somehow huge.

At `beforeMount` hooks, it works fine.