### PR TITLE
BUG: Don't export keymap with JSON extension

### DIFF
--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -255,7 +255,7 @@ export default {
         notes: this.notes
       });
 
-      this.download(this.exportKeymapName, JSON.stringify(data));
+      this.download(`${this.exportKeymapName}.json`, JSON.stringify(data));
     },
     download(filename, data) {
       this.urlEncodedData = encoding + encodeURIComponent(data);

--- a/src/store/modules/app/getters.js
+++ b/src/store/modules/app/getters.js
@@ -24,7 +24,7 @@ const getters = {
     }
     // issue #331 whitelist what we send to API for keymapName and save to disk
     exportName = exportName.replace(/[^a-z0-9_-]/gi, '');
-    return `${exportName}.json`;
+    return exportName;
   },
   keyCount: state => {
     if (


### PR DESCRIPTION
  - regression - reported by @skulldazed
  - append .json when we export it from browser because that's the
    appropriate time. Don't pollute the JSON