### PR TITLE
Issue 746: toggle default clear keycode

### DIFF
--- a/src/components/LayerControl.vue
+++ b/src/components/LayerControl.vue
@@ -25,15 +25,13 @@
 <script>
 import rangeRight from 'lodash/rangeRight';
 import isUndefined from 'lodash/isUndefined';
-import { createNamespacedHelpers } from 'vuex';
-const { mapState, mapGetters, mapMutations } = createNamespacedHelpers(
-  'keymap'
-);
+import { mapState, mapGetters, mapMutations } from 'vuex';
 export default {
   name: 'layer-control',
   computed: {
-    ...mapState(['layer']),
-    ...mapGetters(['getLayer']),
+    ...mapState('keymap', ['layer']),
+    ...mapState('app', ['configuratorSettings']),
+    ...mapGetters('keymap', ['getLayer']),
     layers() {
       let layers = rangeRight(16).map(layer => {
         let clazz = [layer];
@@ -52,19 +50,28 @@ export default {
       });
 
       return layers;
+    },
+    defaultClearLayerCode() {
+      return this.configuratorSettings.clearLayerDefault ? 'KC_TRNS' : 'KC_NO';
     }
   },
   methods: {
-    ...mapMutations(['changeLayer', 'initLayer']),
+    ...mapMutations('keymap', ['changeLayer', 'initLayer']),
     clicked(id) {
       if (isUndefined(this.getLayer(id))) {
-        this.initLayer(id);
+        this.initLayer({
+          layer: id,
+          code: this.defaultClearLayerCode
+        });
       }
       this.changeLayer(id);
     },
     clearLayer() {
       if (confirm(this.$t('layer.confirm'))) {
-        this.initLayer(this.layer);
+        this.initLayer({
+          layer: this.layer,
+          code: this.defaultClearLayerCode
+        });
         this.$store.commit('keymap/setDirty');
       }
     }

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -15,7 +15,7 @@
         <toggle-button
           id="setting-toggle-fast-input"
           :value="continuousInput"
-          :width="75"
+          :width="defaultWidth"
           :sync="true"
           :labels="labels"
           @change="toggleContinuousInput"
@@ -33,7 +33,7 @@
         <toggle-button
           id="setting-toggle-display-size"
           :value="displaySizes"
-          :width="75"
+          :width="defaultWidth"
           :sync="true"
           :labels="labels"
           @change="toggleDisplaySizes"
@@ -51,7 +51,7 @@
         <toggle-button
           id="setting-toggle-tutorial"
           :value="tutorialEnabled"
-          :width="75"
+          :width="defaultWidth"
           :sync="true"
           :labels="labels"
           @change="toggleTutorial"
@@ -70,7 +70,7 @@
         <toggle-button
           id="setting-toggle-darkmode"
           :value="configuratorSettings.darkmodeEnabled"
-          :width="75"
+          :width="defaultWidth"
           :sync="true"
           :labels="labels"
           @change="darkMode"
@@ -91,6 +91,24 @@
           }}</option>
         </select>
       </div>
+      <div>
+        <label
+          class="settings-panel--clear-keymap"
+          @mouseover="help('clearLayer')"
+          :title="$t('settingsPanel.clearLayer.title')"
+          >{{ $t('settingsPanel.clearLayer.title') }}</label
+        >
+        <div>
+          <toggle-button
+            id="settings-panel--clear-keymap"
+            :value="configuratorSettings.clearLayerDefault"
+            :width="defaultWidth"
+            :sync="true"
+            :labels="clearLayerLabels"
+            @change="clearLayerDefault"
+          />
+        </div>
+      </div>
     </div>
     <div v-if="helpText" class="settings-panel--help-text">{{ helpText }}</div>
   </div>
@@ -106,8 +124,13 @@ export default {
         checked: this.$t('settingsPanel.on.label'),
         unchecked: this.$t('settingsPanel.off.label')
       },
+      clearLayerLabels: {
+        checked: this.$t('settingsPanel.kctrns.label'),
+        unchecked: this.$t('settingsPanel.kcno.label')
+      },
       helpText: undefined,
-      clearTextTimer: undefined
+      clearTextTimer: undefined,
+      defaultWidth: 75
     };
   },
   components: { ToggleButton },
@@ -130,9 +153,16 @@ export default {
   methods: {
     ...mapMutations('keymap', ['toggleDisplaySizes', 'toggleContinuousInput']),
     ...mapMutations('app', ['toggleTutorial', 'toggleSnowflakes']),
-    ...mapActions('app', ['toggleDarkMode', 'changeLanguage']),
+    ...mapActions('app', [
+      'toggleDarkMode',
+      'changeLanguage',
+      'toggleClearLayerDefault'
+    ]),
     darkMode() {
       this.toggleDarkMode();
+    },
+    clearLayerDefault() {
+      this.toggleClearLayerDefault();
     },
     help(key) {
       switch (key) {
@@ -150,6 +180,9 @@ export default {
           break;
         case 'language':
           this.helpText = this.$t('settingsPanel.language.help');
+          break;
+        case 'clearLayer':
+          this.helpText = this.$t('settingsPanel.clearLayer.help');
           break;
       }
 

--- a/src/i18n/en.csv
+++ b/src/i18n/en.csv
@@ -112,6 +112,10 @@ settingsPanel:language:help,Change the language of the user interface
 settingsPanel:language:title,Language
 settingsPanel:off:label,Off
 settingsPanel:on:label,On
+settingsPanel:clearLayer:title,Clear Layer Default
+settingsPanel:clearLayer:help,Change the default keycode for clear layer
+settingsPanel:kcno:label,KC_NO
+settingsPanel:kctrns:label,KC_TRNS
 settingsPanel:snowflakes:label,Toggle Snowflakes
 settingsPanel:snowflakes:title,Snowflakes
 settingsPanel:title,Configurator Settings

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -281,7 +281,7 @@ function load_converted_keymap(converted_keymap) {
   const acc = converted_keymap.reduce(
     (acc, layerData, _layer) => {
       //Add layer object for every layer that exists
-      store.commit('keymap/initLayer', _layer);
+      store.commit('keymap/initLayer', { layer: _layer });
       //Loop over each keycode in the layer
       acc.layers.push(
         layerData.map(keycode => {

--- a/src/store/localStorage.js
+++ b/src/store/localStorage.js
@@ -1,6 +1,6 @@
 const CONSTS = {
   configuratorSettings: 'configuratorSettings',
-  configuratorSettingsVersion: 1
+  configuratorSettingsVersion: 2
 };
 
 function localStorageLoad(key) {

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -25,7 +25,7 @@ const actions = {
   /**
    * load the default keymap for the currently selected keyboard
    */
-  loadDefaultKeymap({ state }) {
+  async loadDefaultKeymap({ state }) {
     const keyboardPath = state.keyboard.slice(0, 1);
     // eslint-disable-next-line
     const keyboardName = state.keyboard.replace(/\//g, '_');
@@ -40,7 +40,7 @@ const actions = {
   /**
    * load keymap from the selected URL
    */
-  loadKeymapFromUrl(_, url) {
+  async loadKeymapFromUrl(_, url) {
     return axios.get(url).then(r => {
       return r.data;
     });
@@ -145,6 +145,12 @@ const actions = {
       document.getElementsByTagName('html')[0].dataset.theme = '';
     }
     commit('setDarkmode', darkStatus);
+    await dispatch('saveConfiguratorSettings');
+  },
+  async toggleClearLayerDefault({ commit, state, dispatch }) {
+    let status = state.configuratorSettings.clearLayerDefault;
+    status = !status;
+    commit('setClearLayerDefault', status);
     await dispatch('saveConfiguratorSettings');
   },
   async setFavoriteKeyboard({ commit, dispatch }, keyboard) {

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -165,8 +165,11 @@ const mutations = {
   toggleTutorial(state) {
     state.tutorialEnabled = !state.tutorialEnabled;
   },
-  setDarkmode(state, enabled) {
-    state.configuratorSettings.darkmodeEnabled = enabled;
+  setDarkmode(state, value) {
+    state.configuratorSettings.darkmodeEnabled = value;
+  },
+  setClearLayerDefault(state, value) {
+    state.configuratorSettings.clearLayerDefault = value;
   },
   toggleSnowflakes(state) {
     state.snowflakes = !state.snowflakes;

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -13,7 +13,8 @@ function setDefaultConfiguratorSettings() {
     version: CONSTS.configuratorSettingsVersion,
     darkmodeEnabled: osDarkMode,
     favoriteKeyboard: '',
-    favoriteColor: ''
+    favoriteColor: '',
+    clearLayerDefault: false
   };
   localStorageSet(CONSTS.configuratorSettings, JSON.stringify(initialConfig));
   return initialConfig;


### PR DESCRIPTION
A little more involved that I expected but this allows toggling of
the default behavior for clearing a layer. There's one downside,
you have to toggle it back to actually remove a layer if you are
in KC_TRNS mode, but this is an expert mode thing...