### PR TITLE
Add some diagnostic messages for unknown layouts

### DIFF
--- a/src/components/VisualKeymap.vue
+++ b/src/components/VisualKeymap.vue
@@ -13,7 +13,7 @@
 </template>
 <script>
 import isUndefined from 'lodash/isUndefined';
-import { mapState, mapGetters, mapMutations } from 'vuex';
+import { mapState, mapGetters, mapMutations, mapActions } from 'vuex';
 import BaseKeymap from '@/components/BaseKeymap';
 import BaseKey from '@/components/BaseKey';
 import AnyKey from '@/components/AnyKey';
@@ -106,6 +106,8 @@ export default {
       'resizeConfig',
       'setLoadingKeymapPromise'
     ]),
+    ...mapMutations('status', ['append']),
+    ...mapActions('status', ['scrollToEnd']),
     /**
      * Due to a quirk in how reactivity works we have to clear the layout
      * name to reset the UI to it's old value.
@@ -161,9 +163,10 @@ export default {
       this.profile && console.time('layout::scale');
       const layout = this.layouts[newLayout];
       if (isUndefined(layout)) {
-        console.log(
-          `WARNING: layout ${newLayout} does not exist on this keyboard`
-        );
+        const msg = `\n\nWARNING: layout ${newLayout} does not exist on this keyboard\n\n`;
+        console.log(msg);
+        this.append(msg);
+        this.scrollToEnd();
         return;
       }
       const max = layout.reduce(

--- a/src/components/VisualKeymap.vue
+++ b/src/components/VisualKeymap.vue
@@ -160,6 +160,12 @@ export default {
       // eslint-disable-next-line no-console
       this.profile && console.time('layout::scale');
       const layout = this.layouts[newLayout];
+      if (isUndefined(layout)) {
+        console.log(
+          `WARNING: layout ${newLayout} does not exist on this keyboard`
+        );
+        return;
+      }
       const max = layout.reduce(
         (acc, pos) => {
           let _pos = Object.assign({ w: 1, h: 1 }, pos);


### PR DESCRIPTION
This prevents an all out crash which isn't helpful, and gives you a diagnostic about bad defaults that reference layouts that no longer exist. Ideally this should have been remapped.