### PR TITLE
rebound rev4 default keymap config json

### DIFF
--- a/public/keymaps/m/montsinger_rebound_rev4_default.json
+++ b/public/keymaps/m/montsinger_rebound_rev4_default.json
@@ -1,0 +1,45 @@
+{
+  "keyboard": "montsinger/rebound/rev4",
+  "keymap": "default",
+  "commit": "bbd17def21cbf6df94305da4dd3d3fe51414a94e",
+  "layout": "LAYOUT_all",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",               "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_PGUP", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_PGDN", "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "KC_ENT",  "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",               "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",    "_______", "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "_______", "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "_______", "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TAB",  "KC_QUOT", "KC_COMM", "KC_DOT",  "KC_P",    "KC_Y",               "KC_F",    "KC_G",    "KC_C",    "KC_R",    "KC_L",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_O",    "KC_E",    "KC_U",    "KC_I",    "_______", "KC_D",    "KC_H",    "KC_T",    "KC_N",    "KC_S",    "KC_SLSH",
+      "KC_LSFT", "KC_SCLN", "KC_Q",    "KC_J",    "KC_K",    "KC_X",    "_______", "KC_B",    "KC_M",    "KC_W",    "KC_V",    "KC_Z",    "KC_ENT",
+      "MO(5)",   "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(3)",   "KC_SPC",  "_______", "KC_SPC",  "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC",            "KC_CIRC", "KC_AMPR",    "KC_ASTR",    "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "_______", "KC_F6",   "KC_UNDS",    "KC_PLUS",    "KC_LCBR", "KC_RCBR", "KC_PIPE",
+      "_______", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "_______", "KC_F12",  "S(KC_NUHS)", "S(KC_NUBS)", "_______", "_______", "_______",
+      "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "MO(5)",      "KC_MNXT",    "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",               "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_DEL",
+      "KC_DEL",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "_______", "KC_F6",   "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "_______", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "_______", "KC_F12",  "KC_NUHS", "KC_NUBS", "_______", "_______", "_______",
+      "_______", "_______", "_______", "_______", "MO(5)",   "_______", "_______", "_______", "_______", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "_______", "RESET",   "_______", "_______", "_______", "_______",            "_______", "_______", "_______", "_______", "_______", "KC_DEL",
+      "_______", "_______", "_______", "AU_ON",   "AU_OFF",  "AG_NORM", "_______", "AG_SWAP", "TO(0)",   "TO(1)",   "TO(2)",   "_______", "_______",
+      "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______",
+      "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______"
+    ]
+  ]
+}
+

--- a/public/keymaps/m/montsinger_rebound_rev4_default.json
+++ b/public/keymaps/m/montsinger_rebound_rev4_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "montsinger/rebound/rev4",
   "keymap": "default",
-  "commit": "e56f4e8e752db58ef88be4e03ab35709c1e7eb1d",
+  "commit": "b43bdc1c69bb5a57976a159bfc00c4ac1c7c7f8f",
   "layout": "LAYOUT_all",
   "layers": [
     [

--- a/public/keymaps/m/montsinger_rebound_rev4_default.json
+++ b/public/keymaps/m/montsinger_rebound_rev4_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "montsinger/rebound/rev4",
   "keymap": "default",
-  "commit": "bbd17def21cbf6df94305da4dd3d3fe51414a94e",
+  "commit": "e56f4e8e752db58ef88be4e03ab35709c1e7eb1d",
   "layout": "LAYOUT_all",
   "layers": [
     [


### PR DESCRIPTION
default keymap for montsinger/rebound rev 4, same as rev 3