### PR TITLE
Fix custom key sizes

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -35,7 +35,10 @@ let substitute = Object.assign(
 );
 
 const _getUnitClass = (unith, unitw) => {
-  if (unith >= unitw && unith !== 1) {
+  if (unith == unitw && unith > 1) {
+    return 'custom';
+  }
+  if (unith > unitw || unith < 1) {
     if (unith === 2 && unitw == 1.25) {
       return 'kiso';
     }

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -35,7 +35,7 @@ let substitute = Object.assign(
 );
 
 const _getUnitClass = (unith, unitw) => {
-  if (unith > unitw || unith < 1) {
+  if (unith >= unitw && unith !== 1) {
     if (unith === 2 && unitw == 1.25) {
       return 'kiso';
     }
@@ -218,8 +218,10 @@ export default {
       if (getUnitClass(this.uh, this.uw) === 'custom') {
         // explicitly override the height and width calculations for the keymap and provide custom values
         styles = styles.concat([
-          `--default-key-height: ${this.config.KEY_HEIGHT * this.uh}px;`,
-          `--default-key-width: ${this.config.KEY_WIDTH * this.uw}px;`
+          `--default-key-height: ${this.uh * this.config.KEY_Y_SPACING -
+            (this.config.KEY_Y_SPACING - this.config.KEY_HEIGHT)}px;`,
+          `--default-key-width: ${this.uw * this.config.KEY_X_SPACING -
+            (this.config.KEY_X_SPACING - this.config.KEY_WIDTH)}px;`
         ]);
       }
 


### PR DESCRIPTION
The keys on the `bigseries` keyboards were being given the class `k4u`, but they are actually 4x4u. Additionally, the sizing calculations for custom sized keys needed to take the key spacing into account.

![image](https://user-images.githubusercontent.com/4781841/85292954-018e5300-b4e0-11ea-8bfc-660d99f9c707.png)
