### PR TITLE
Improve key size calculations

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -350,52 +350,52 @@ export default {
       (var(--default-key-y-spacing) - var(--default-key-height))
   );
 }
-.key.k125u {
+.k125u {
   --unit-width: 1.25;
 }
-.key.k15u {
+.k15u {
   --unit-width: 1.5;
 }
-.key.k175u {
+.k175u {
   --unit-width: 1.75;
 }
-.key.k2u {
+.k2u {
   --unit-width: 2;
 }
-.key.k225u {
+.k225u {
   --unit-width: 2.25;
 }
-.key.k275u {
+.k275u {
   --unit-width: 2.75;
 }
-.key.k3u {
+.k3u {
   --unit-width: 3;
 }
-.key.k4u {
+.k4u {
   --unit-width: 4;
 }
-.key.k6u {
+.k6u {
   --unit-width: 6;
 }
-.key.k625u {
+.k625u {
   --unit-width: 6.25;
 }
-.key.k7u {
+.k7u {
   --unit-width: 7;
 }
-.key.k125uh {
+.k125uh {
   --unit-height: 1.25;
 }
-.key.k15uh {
+.k15uh {
   --unit-height: 1.5;
 }
-.key.k175uh {
+.k175uh {
   --unit-height: 1.75;
 }
-.key.k2uh {
+.k2uh {
   --unit-height: 2;
 }
-.key.kiso {
+.kiso {
   width: calc(0.5 * var(--default-key-x-spacing) + var(--default-key-width));
   height: var(--default-key-height);
   padding: 0px;

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -34,11 +34,64 @@ let substitute = Object.assign(
   colorways.platformIcons(window.navigator.platform)
 );
 
-const getKeyClass = (unitheight, unitwidth) => {
-  if (unitheight === 2 && unitwidth == 1.25) {
+const _getKeyClass = (unith, unitw) => {
+  if (unith === 2 && unitw == 1.25) {
     return 'kiso';
   }
-  return '';
+  if (unith == 1) {
+    switch (unitw) {
+      case 1:
+        return 'k1u';
+      case 1.25:
+        return 'k125u';
+      case 1.5:
+        return 'k15u';
+      case 1.75:
+        return 'k175u';
+      case 2:
+        return 'k2u';
+      case 2.25:
+        return 'k225u';
+      case 2.75:
+        return 'k275u';
+      case 3:
+        return 'k3u';
+      case 4:
+        return 'k4u';
+      case 6:
+        return 'k6u';
+      case 6.25:
+        return 'k625u';
+      case 7:
+        return 'k7u';
+    }
+  }
+  if (unitw == 1) {
+    switch (unith) {
+      case 1.25:
+        return 'k125uh';
+      case 1.5:
+        return 'k15uh';
+      case 1.75:
+        return 'k175uh';
+      case 2:
+        return 'k2uh';
+    }
+  }
+  return 'custom';
+};
+
+const cache = new Map();
+
+const getKeyClass = (unitheight, unitwidth) => {
+  const key = `${unitheight}-${unitwidth}`;
+  let hit = cache.has(key);
+  if (hit) {
+    return cache.get(key);
+  }
+  const value = _getKeyClass(unitheight, unitwidth);
+  cache.set(key, value);
+  return value;
 };
 
 export default {
@@ -154,17 +207,20 @@ export default {
     },
     mystyles() {
       let styles = [];
-      if (this.uw !== 1) {
-        styles.push(`--unit-width: ${this.uw};`);
-      }
-      if (this.uh !== 1) {
-        styles.push(`--unit-height: ${this.uh};`);
-      }
       if (this.y > 0) {
         styles.push(`top: ${this.y}px;`);
       }
       if (this.x > 0) {
         styles.push(`left: ${this.x}px;`);
+      }
+      if (getKeyClass(this.uh, this.uw) === 'custom') {
+        // explicitly override the height and width calculations for the keymap and provide custom values
+        if (this.uw !== 1) {
+          styles.push(`--unit-width: ${this.uw};`);
+        }
+        if (this.uh !== 1) {
+          styles.push(`--unit-height: ${this.uh};`);
+        }
       }
 
       return styles.join('');
@@ -295,6 +351,51 @@ export default {
     var(--unit-height) * var(--default-key-y-spacing) -
       (var(--default-key-y-spacing) - var(--default-key-height))
   );
+}
+.key.k125u {
+  --unit-width: 1.25;
+}
+.key.k15u {
+  --unit-width: 1.5;
+}
+.key.k175u {
+  --unit-width: 1.75;
+}
+.key.k2u {
+  --unit-width: 2;
+}
+.key.k225u {
+  --unit-width: 2.25;
+}
+.key.k275u {
+  --unit-width: 2.75;
+}
+.key.k3u {
+  --unit-width: 3;
+}
+.key.k4u {
+  --unit-width: 4;
+}
+.key.k6u {
+  --unit-width: 6;
+}
+.key.k625u {
+  --unit-width: 6.25;
+}
+.key.k7u {
+  --unit-width: 7;
+}
+.key.k125uh {
+  --unit-height: 1.25;
+}
+.key.k15uh {
+  --unit-height: 1.5;
+}
+.key.k175uh {
+  --unit-height: 1.75;
+}
+.key.k2uh {
+  --unit-height: 2;
 }
 .key.kiso {
   width: calc(0.5 * var(--default-key-x-spacing) + var(--default-key-width));

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -34,7 +34,7 @@ let substitute = Object.assign(
   colorways.platformIcons(window.navigator.platform)
 );
 
-const _getKeyClass = (unith, unitw) => {
+const _getKeySizeClass = (unith, unitw) => {
   if (unith == 1) {
     switch (unitw) {
       case 1:
@@ -83,13 +83,13 @@ const _getKeyClass = (unith, unitw) => {
 
 const cache = new Map();
 
-const getKeyClass = (unitheight, unitwidth) => {
+const getKeySizeClass = (unitheight, unitwidth) => {
   const key = `${unitheight}-${unitwidth}`;
   let hit = cache.has(key);
   if (hit) {
     return cache.get(key);
   }
-  const value = _getKeyClass(unitheight, unitwidth);
+  const value = _getKeySizeClass(unitheight, unitwidth);
   cache.set(key, value);
   return value;
 };
@@ -178,7 +178,7 @@ export default {
         classes.push('smaller');
       }
       const { KEY_WIDTH, KEY_HEIGHT } = this.config;
-      classes.push(getKeyClass(this.uh, this.uw));
+      classes.push(getKeySizeClass(this.uh, this.uw));
       if (!isUndefined(this.meta) && !this.printable) {
         if (this.colorwayOverride && this.colorwayOverride[this.meta.code]) {
           // Colorway specific overrides by keycode
@@ -213,7 +213,7 @@ export default {
       if (this.x > 0) {
         styles.push(`left: ${this.x}px;`);
       }
-      if (getKeyClass(this.uh, this.uw) === 'custom') {
+      if (getKeySizeClass(this.uh, this.uw) === 'custom') {
         // explicitly override the height and width calculations for the keymap and provide custom values
         if (this.uw !== 1) {
           styles.push(`--unit-width: ${this.uw};`);

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -35,9 +35,6 @@ let substitute = Object.assign(
 );
 
 const _getKeyClass = (unith, unitw) => {
-  if (unith === 2 && unitw == 1.25) {
-    return 'kiso';
-  }
   if (unith == 1) {
     switch (unitw) {
       case 1:
@@ -77,6 +74,9 @@ const _getKeyClass = (unith, unitw) => {
       case 2:
         return 'k2uh';
     }
+  }
+  if (unith === 2 && unitw == 1.25) {
+    return 'kiso';
   }
   return 'custom';
 };

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -341,8 +341,6 @@ export default {
     0px 0px 0px 1px rgba(0, 0, 0, 0.3);
   border-left: 1px solid rgba(0, 0, 0, 0.1);
   border-right: 1px solid rgba(0, 0, 0, 0.1);
-  --unit-width: 1;
-  --unit-height: 1;
   width: calc(
     var(--unit-width) * var(--default-key-x-spacing) -
       (var(--default-key-x-spacing) - var(--default-key-width))

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -34,69 +34,11 @@ let substitute = Object.assign(
   colorways.platformIcons(window.navigator.platform)
 );
 
-const _getUnitClass = (unith, unitw) => {
-  if (unith == unitw && unith > 1) {
-    return 'custom';
+const getKeyClass = (unitheight, unitwidth) => {
+  if (unitheight === 2 && unitwidth == 1.25) {
+    return 'kiso';
   }
-  if (unith > unitw || unith < 1) {
-    if (unith === 2 && unitw == 1.25) {
-      return 'kiso';
-    }
-    switch (unith) {
-      case 2:
-        return 'k2uh';
-      case 1.25:
-        'k125uh';
-        return 'k125uh';
-      case 1.5:
-        return 'k15uh';
-      case 1.75:
-        return 'k175uh';
-      default:
-        return 'custom';
-    }
-  }
-  switch (unitw) {
-    case 1:
-      return 'k1u';
-    case 1.25:
-      return 'k125u';
-    case 1.5:
-      return 'k15u';
-    case 1.75:
-      return 'k175u';
-    case 2:
-      return 'k2u';
-    case 2.25:
-      return 'k225u';
-    case 2.75:
-      return 'k275u';
-    case 3:
-      return 'k3u';
-    case 4:
-      return 'k4u';
-    case 6:
-      return 'k6u';
-    case 6.25:
-      return 'k625u';
-    case 7:
-      return 'k7u';
-    default:
-      return 'custom';
-  }
-};
-
-const cache = new Map();
-
-const getUnitClass = (unitheight, unitwidth) => {
-  const key = `${unitheight}-${unitwidth}`;
-  let hit = cache.has(key);
-  if (hit) {
-    return cache.get(key);
-  }
-  const value = _getUnitClass(unitheight, unitwidth);
-  cache.set(key, value);
-  return value;
+  return '';
 };
 
 export default {
@@ -183,7 +125,7 @@ export default {
         classes.push('smaller');
       }
       const { KEY_WIDTH, KEY_HEIGHT } = this.config;
-      classes.push(getUnitClass(this.uh, this.uw));
+      classes.push(getKeyClass(this.uh, this.uw));
       if (!isUndefined(this.meta) && !this.printable) {
         if (this.colorwayOverride && this.colorwayOverride[this.meta.code]) {
           // Colorway specific overrides by keycode
@@ -212,20 +154,17 @@ export default {
     },
     mystyles() {
       let styles = [];
+      if (this.uw !== 1) {
+        styles.push(`--unit-width: ${this.uw};`);
+      }
+      if (this.uh !== 1) {
+        styles.push(`--unit-height: ${this.uh};`);
+      }
       if (this.y > 0) {
         styles.push(`top: ${this.y}px;`);
       }
       if (this.x > 0) {
         styles.push(`left: ${this.x}px;`);
-      }
-      if (getUnitClass(this.uh, this.uw) === 'custom') {
-        // explicitly override the height and width calculations for the keymap and provide custom values
-        styles = styles.concat([
-          `--default-key-height: ${this.uh * this.config.KEY_Y_SPACING -
-            (this.config.KEY_Y_SPACING - this.config.KEY_HEIGHT)}px;`,
-          `--default-key-width: ${this.uw * this.config.KEY_X_SPACING -
-            (this.config.KEY_X_SPACING - this.config.KEY_WIDTH)}px;`
-        ]);
       }
 
       return styles.join('');
@@ -346,104 +285,15 @@ export default {
     0px 0px 0px 1px rgba(0, 0, 0, 0.3);
   border-left: 1px solid rgba(0, 0, 0, 0.1);
   border-right: 1px solid rgba(0, 0, 0, 0.1);
-}
-.k1u {
-  width: calc(var(--default-key-width));
-  height: calc(var(--default-key-height));
-}
-//(w - 1) * this.config.KEY_X_SPACING + this.config.KEY_WIDTH
-.k125u {
+  --unit-width: 1;
+  --unit-height: 1;
   width: calc(
-    calc(0.25 * var(--default-key-x-spacing)) + var(--default-key-width)
+    var(--unit-width) * var(--default-key-x-spacing) -
+      (var(--default-key-x-spacing) - var(--default-key-width))
   );
-  height: var(--default-key-height);
-}
-.k15u {
-  width: calc(
-    calc(0.5 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k175u {
-  width: calc(
-    calc(0.75 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k2u {
-  width: calc(
-    calc(1 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k225u {
-  width: calc(
-    calc(1.25 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k275u {
-  width: calc(
-    calc(1.75 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k3u {
-  width: calc(
-    calc(2 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k4u {
-  width: calc(
-    calc(3 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k6u {
-  width: calc(
-    calc(5 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k625u {
-  width: calc(
-    calc(5.25 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k7u {
-  width: calc(
-    calc(6 * var(--default-key-x-spacing)) + var(--default-key-width)
-  );
-  height: var(--default-key-height);
-}
-.k2uh {
-  width: var(--default-key-width);
   height: calc(
-    calc(1 * var(--default-key-y-spacing)) + var(--default-key-height)
-  );
-}
-.custom {
-  width: var(--default-key-width);
-  height: var(--default-key-height);
-}
-.k125uh {
-  width: var(--default-key-width);
-  height: calc(
-    calc(0.25 * var(--default-key-y-spacing)) + var(--default-key-height)
-  );
-}
-.k15uh {
-  width: var(--default-key-width);
-  height: calc(
-    calc(0.5 * var(--default-key-y-spacing)) + var(--default-key-height)
-  );
-}
-.k175uh {
-  width: var(--default-key-width);
-  height: calc(
-    calc(0.75 * var(--default-key-y-spacing)) + var(--default-key-height)
+    var(--unit-height) * var(--default-key-y-spacing) -
+      (var(--default-key-y-spacing) - var(--default-key-height))
   );
 }
 .key.kiso {

--- a/src/components/BaseKeymap.vue
+++ b/src/components/BaseKeymap.vue
@@ -10,6 +10,8 @@ export default {
         smolKeySize *= (1 + this.config.SCALE) / 2;
       }
       return {
+        '--unit-width: 1',
+        '--unit-height: 1',
         '--default-smaller-key-font-size': `${smolKeySize}rem`,
         '--default-key-font-size': `${keySize}rem`,
         '--default-key-height': `${this.config.KEY_HEIGHT}px`,

--- a/src/components/BaseKeymap.vue
+++ b/src/components/BaseKeymap.vue
@@ -10,8 +10,8 @@ export default {
         smolKeySize *= (1 + this.config.SCALE) / 2;
       }
       return {
-        '--unit-width: 1',
-        '--unit-height: 1',
+        '--unit-width': '1',
+        '--unit-height': '1',
         '--default-smaller-key-font-size': `${smolKeySize}rem`,
         '--default-key-font-size': `${keySize}rem`,
         '--default-key-height': `${this.config.KEY_HEIGHT}px`,


### PR DESCRIPTION
This seems like a cleaner approach to the problem in #759. Instead of having multiple classes for each common keysize and falling back on `custom`, we move the calculation completely to the `.key` class by exposing the units as variables (I couldn't get `attr()` to work inside `calc()` 😢). Now we just need to determine whether the key is an ISO enter, and add the `kiso` class if so.