### PR TITLE
Add GHS.RAR default keymap

### DIFF
--- a/public/keymaps/g/ghs_rar_default.json
+++ b/public/keymaps/g/ghs_rar_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "ghs/rar",
   "keymap": "default",
-  "commit": "a8904d47b745518e9bbab8f20f05828d77f7f42d",
+  "commit": "8c66c5aa9b08d732329408847dc6cf7645e67ae1",
   "layout": "LAYOUT_ansi",
   "layers": [
     [

--- a/public/keymaps/g/ghs_rar_default.json
+++ b/public/keymaps/g/ghs_rar_default.json
@@ -5,20 +5,20 @@
   "layout": "LAYOUT_ansi",
   "layers": [
     [
-      "KC_ESC",     "KC_F1", "KC_F2", "KC_F3", "KC_F4",     "KC_F5", "KC_F6", "KC_F7", "KC_F8",     "KC_F9", "KC_F10", "KC_F11", "KC_F12",  "KC_DEL",
-      "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL",       "KC_BSPC",         "KC_HOME",
-      "KC_TAB",    "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC",      "KC_BSLS",      "KC_PGUP",
-      "KC_CAPS",    "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",           "KC_ENT",     "KC_PGDN",
-      "KC_LSFT",       "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH",     "KC_RSFT",   "KC_UP",    "KC_END",
-      "KC_LCTL",  "KC_LGUI",  "KC_LALT",                "KC_SPC",            "KC_RALT", "MO(1)",          "KC_LEFT", "KC_DOWN", "KC_RGHT"
+      "KC_ESC",             "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10", "KC_F11",   "KC_F12",  "KC_DEL",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_HOME",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_PGUP",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",  "KC_PGDN",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_END",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "MO(1)",   "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
-      "RGB_TOG",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",  "KC_NO",
-      "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",       "KC_NO",         "RGB_HUI",
-      "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",      "KC_NO",      "RGB_SAI",
-      "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",           "KC_NO",     "RGB_SAD",
-      "KC_NO",       "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO",   "RGB_VAI",    "RGB_HUD",
-      "KC_NO",  "KC_NO",  "KC_NO",                "KC_NO",            "KC_NO", "KC_TRNS",          "RGB_MOD", "RGB_VAD", "RGB_RMOD"
+      "RGB_TOG",            "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RGB_HUI",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RGB_SAI",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",              "KC_NO",   "RGB_SAD",
+      "KC_NO",              "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RGB_VAI", "RGB_HUD",
+      "KC_NO",   "KC_NO",   "KC_NO",                                    "KC_NO",                                    "KC_NO", "KC_TRNS",   "RGB_MOD", "RGB_VAD", "RGB_RMOD"
     ]
   ]
 }

--- a/public/keymaps/g/ghs_rar_default.json
+++ b/public/keymaps/g/ghs_rar_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "ghs/rar",
+  "keymap": "default",
+  "commit": "a8904d47b745518e9bbab8f20f05828d77f7f42d",
+  "layout": "LAYOUT_ansi",
+  "layers": [
+    [
+      "KC_ESC",     "KC_F1", "KC_F2", "KC_F3", "KC_F4",     "KC_F5", "KC_F6", "KC_F7", "KC_F8",     "KC_F9", "KC_F10", "KC_F11", "KC_F12",  "KC_DEL",
+      "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL",       "KC_BSPC",         "KC_HOME",
+      "KC_TAB",    "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC",      "KC_BSLS",      "KC_PGUP",
+      "KC_CAPS",    "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",           "KC_ENT",     "KC_PGDN",
+      "KC_LSFT",       "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH",     "KC_RSFT",   "KC_UP",    "KC_END",
+      "KC_LCTL",  "KC_LGUI",  "KC_LALT",                "KC_SPC",            "KC_RALT", "MO(1)",          "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "RGB_TOG",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO", "KC_NO", "KC_NO", "KC_NO",  "KC_NO",
+      "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",       "KC_NO",         "RGB_HUI",
+      "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",      "KC_NO",      "RGB_SAI",
+      "KC_NO",    "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",           "KC_NO",     "RGB_SAD",
+      "KC_NO",       "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO", "KC_NO",     "KC_NO",   "RGB_VAI",    "RGB_HUD",
+      "KC_NO",  "KC_NO",  "KC_NO",                "KC_NO",            "KC_NO", "KC_TRNS",          "RGB_MOD", "RGB_VAD", "RGB_RMOD"
+    ]
+  ]
+}


### PR DESCRIPTION
Add the default GHS.RAR keymap following https://github.com/qmk/qmk_firmware/pull/9561.