### PR TITLE
Add "choc_taro" default keymap

### DIFF
--- a/public/keymaps/c/choc_taro_default.json
+++ b/public/keymaps/c/choc_taro_default.json
@@ -1,0 +1,15 @@
+{
+    "keyboard": "choc_taro",
+    "keymap": "default",
+    "commit": "8b9e3e9979ffddaa91e022e8ab953be5c7c5283e",
+    "layout": "LAYOUT_all",
+    "layers":[
+        [
+            "KC_ESC",  "KC_GRV",  "KC_1",    "KC_2",  "KC_3",  "KC_4",  "KC_5",  "KC_6",  "KC_7",  "KC_8",     "KC_9",    "KC_0",     "KC_MINS",  "KC_EQL",  "KC_BSPC",
+            "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",  "KC_R",  "KC_T",  "KC_Y",  "KC_U",  "KC_I",  "KC_O",     "KC_P",    "KC_LBRC",  "KC_RBRC",  "KC_BSLS",
+            "KC_CAPS", "KC_A",    "KC_S",    "KC_D",  "KC_F",  "KC_G",  "KC_H",  "KC_J",  "KC_K",  "KC_L",     "KC_SCLN", "KC_QUOT",              "KC_ENT",
+            "KC_LSFT",            "KC_Z",    "KC_X",  "KC_C",  "KC_V",  "KC_B",  "KC_N",  "KC_M",  "KC_COMM",  "KC_DOT",  "KC_SLSH",  "KC_RSFT",  "KC_DEL",
+            "KC_LCTL", "KC_LGUI", "KC_LALT",                            "KC_SPC",                              "KC_RALT", "KC_RGUI",  "KC_APP",   "KC_RCTL"
+        ]
+    ]
+}

--- a/public/keymaps/c/choc_taro_default.json
+++ b/public/keymaps/c/choc_taro_default.json
@@ -7,7 +7,7 @@
         [
             "KC_ESC",  "KC_GRV",  "KC_1",    "KC_2",  "KC_3",  "KC_4",  "KC_5",  "KC_6",  "KC_7",  "KC_8",     "KC_9",    "KC_0",     "KC_MINS",  "KC_EQL",  "KC_BSPC",
             "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",  "KC_R",  "KC_T",  "KC_Y",  "KC_U",  "KC_I",  "KC_O",     "KC_P",    "KC_LBRC",  "KC_RBRC",  "KC_BSLS",
-            "KC_CAPS", "KC_A",    "KC_S",    "KC_D",  "KC_F",  "KC_G",  "KC_H",  "KC_J",  "KC_K",  "KC_L",     "KC_SCLN", "KC_QUOT",              "KC_ENT",
+            "KC_LCAP", "KC_A",    "KC_S",    "KC_D",  "KC_F",  "KC_G",  "KC_H",  "KC_J",  "KC_K",  "KC_L",     "KC_SCLN", "KC_QUOT",              "KC_ENT",
             "KC_LSFT",            "KC_Z",    "KC_X",  "KC_C",  "KC_V",  "KC_B",  "KC_N",  "KC_M",  "KC_COMM",  "KC_DOT",  "KC_SLSH",  "KC_RSFT",  "KC_DEL",
             "KC_LCTL", "KC_LGUI", "KC_LALT",                            "KC_SPC",                              "KC_RALT", "KC_RGUI",  "KC_APP",   "KC_RCTL"
         ]


### PR DESCRIPTION
Added `keymap/c/choc_taro_default.json`.

Firmware PR is https://github.com/qmk/qmk_firmware/pull/9556