### PR TITLE
Update commit hashes for Herringbone and GHS.RAR

### DIFF
--- a/public/keymaps/g/ghs_rar_default.json
+++ b/public/keymaps/g/ghs_rar_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "ghs/rar",
   "keymap": "default",
-  "commit": "8c66c5aa9b08d732329408847dc6cf7645e67ae1",
+  "commit": "60ee8bddfcd2889c8ae040c06ae639ac6113e795",
   "layout": "LAYOUT_ansi",
   "layers": [
     [

--- a/public/keymaps/r/ramonimbao_herringbone_default.json
+++ b/public/keymaps/r/ramonimbao_herringbone_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "ramonimbao/herringbone",
   "keymap": "default",
-  "commit": "48db3ad6ef1e7c98bce592791972c7beaa2315ef",
+  "commit": "76b21a4b90a490c69175bef2dffc6eb6759ac26d",
   "layout": "LAYOUT_ansi",
   "layers": [
     [


### PR DESCRIPTION
After some changes (https://github.com/qmk/qmk_firmware/pull/9671, https://github.com/qmk/qmk_firmware/pull/9679), this updates the commit hash of the Herringbone and GHS.RAR keyboards.