### PR TITLE
remove N/A text on unassigned keys when printing

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -534,6 +534,10 @@ button {
   // color: #ccc;
 }
 
+.print-keymap .key:empty:before {
+  content: '';
+}
+
 .key .remove {
   width: 0px;
   height: 0px;


### PR DESCRIPTION
Closes #769. I've updated the CSS to remove the "N/A" text on any unassigned keys only when printing. It will still be visible when assigning keys.