### PR TITLE
Update GHS.RAR commit hash

### DIFF
--- a/public/keymaps/g/ghs_rar_default.json
+++ b/public/keymaps/g/ghs_rar_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "ghs/rar",
   "keymap": "default",
-  "commit": "8c66c5aa9b08d732329408847dc6cf7645e67ae1",
+  "commit": "c02666c4cbdae772698f2cb252a2a791225f81a9",
   "layout": "LAYOUT_ansi",
   "layers": [
     [


### PR DESCRIPTION
This updates the commit hash following the latest commit: https://github.com/qmk/qmk_firmware/pull/10028

Thanks!