### PR TITLE
add_keymap_chavdai40rev2

### DIFF
--- a/public/keymaps/c/chavdai40_rev1_default.json
+++ b/public/keymaps/c/chavdai40_rev1_default.json
@@ -1,5 +1,5 @@
 {
-  "keyboard": "chavdai40",
+  "keyboard": "chavdai40/rev1",
   "keymap": "default",
   "commit": "245797f6b998fb4f52df61e38151c80b05615740",
   "layout": "LAYOUT_44key",

--- a/public/keymaps/c/chavdai40_rev2_default.json
+++ b/public/keymaps/c/chavdai40_rev2_default.json
@@ -1,0 +1,20 @@
+{
+  "keyboard": "chavdai40/rev2",
+  "keymap": "default",
+  "commit": "245797f6b998fb4f52df61e38151c80b05615740",
+  "layout": "LAYOUT_44key",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_MINS", "KC_BSPC",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN",            "KC_ENT",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_DEL",
+                 "KC_LALT", "KC_LGUI",                       "MO(1)",   "KC_SPC",                        "KC_RGUI", "KC_RALT", "KC_ESC"
+    ],
+    [
+      "KC_GRV",  "KC_EXLM", "KC_AT",   "KC_HASH", "KC_QUOT", "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_LBRC", "KC_RBRC",
+      "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",               "KC_TRNS",
+      "KC_TRNS",            "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_EQL",  "KC_TRNS",
+                 "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}


### PR DESCRIPTION
For production reason, I change Chavdai40% MCU from QFN to QFP.  
So I need add rev2 firmware of qmk.

I want to add chavdai40 rev2 of qmk configurator.
This PR change is below.

change 1 file chavdai40_default.json  
 - rename to chavdai40_rev1_default.json  
 - change keyboard directory chavdai40 => chavdai40/rev1

add 1 file chavdai40_rev2_default.json  
 - keyboard directory is chavdai40/rev2

qmk firmware PR is below.(not merged yet, but will be merged I think)
https://github.com/qmk/qmk_firmware/pull/10210
