### PR TITLE
Add Configurator Keyset Theme "GMK Fro.Yo" 

### DIFF
--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -120,7 +120,8 @@ export default {
           .replace(/Kat/, 'KAT')
           .replace(/Wob/, 'WOB')
           .replace(/Ta/, 'TA')
-          .replace(/ ?Plus/g, '+');
+          .replace(/ ?Plus/g, '+')
+          .replace(/ ?Dot/g, '.');
       });
     },
     redditPost() {

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -121,7 +121,7 @@ export default {
           .replace(/Wob/, 'WOB')
           .replace(/Ta/, 'TA')
           .replace(/ ?Plus/g, '+')
-          .replace(/ ?Dot/g, '.');
+          .replace(/ ?Dot ?/g, '\.');
       });
     },
     redditPost() {

--- a/src/components/colorways/gmk/fro_dot_yo.js
+++ b/src/components/colorways/gmk/fro_dot_yo.js
@@ -4,7 +4,7 @@ export default {
     KC_TAB: 'blu',
     KC_BSPC: 'rdp',
     KC_LGUI: 'blu',
-    KC_RGUI: 'blue',
+    KC_RGUI: 'blu',
     KC_CAPS: 'ppl',
     KC_ENT: 'grn',
     KC_PENT: 'grn',

--- a/src/components/colorways/gmk/fro_dot_yo.js
+++ b/src/components/colorways/gmk/fro_dot_yo.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'gmk-fro_dot_yo',
+  name: 'gmk-fro-dot-yo',
   override: {
     KC_TAB: 'blu',
     KC_BSPC: 'rdp',

--- a/src/components/colorways/gmk/fro_dot_yo.js
+++ b/src/components/colorways/gmk/fro_dot_yo.js
@@ -1,0 +1,23 @@
+export default {
+  name: 'gmk-fro_dot_yo',
+  override: {
+    KC_TAB: 'blu',
+    KC_BSPC: 'rdp',
+    KC_LGUI: 'blu',
+    KC_RGUI: 'blue',
+    KC_CAPS: 'ppl',
+    KC_ENT: 'grn',
+    KC_PENT: 'grn',
+    KC_LALT: 'grn',
+    KC_RALT: 'grn',
+    KC_LSFT: 'ylw',
+    KC_RSFT: 'ylw',
+    KC_LCTL: 'rdp',
+    KC_RCTL: 'rdp',
+    KC_APP: 'ppl',
+    KC_INS: 'rdp',
+    'MO(layer)': 'ppl',
+    KC_ESC: 'rdp',
+    KC_GESC: 'rdp'
+  }
+};

--- a/src/components/colorways/gmk/index.js
+++ b/src/components/colorways/gmk/index.js
@@ -11,6 +11,7 @@ import gmk_deku from './deku';
 import gmk_dolch from './dolch';
 import gmk_dracula from './dracula';
 import gmk_dualshot from './dualshot';
+import gmk_fro_dot_yo from './fro_dot_yo';
 import gmk_hammerhead_dark from './hammerhead_dark';
 import gmk_hammerhead_light from './hammerhead_light';
 import gmk_handarbeit_plus from './handarbeit_plus';
@@ -49,6 +50,7 @@ export default [
   gmk_dolch,
   gmk_dracula,
   gmk_dualshot,
+  gmk_fro_dot_yo,
   gmk_hammerhead_dark,
   gmk_hammerhead_light,
   gmk_handarbeit_plus,

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -575,7 +575,8 @@
   // placeholder
 }
 
-.gmk-fro-dot-yo-key, .gmk-fro-dot-yo-mod {
+.gmk-fro-dot-yo-key,
+.gmk-fro-dot-yo-mod {
   background: $color-gmk-abs-L9;
   color: $color-gmk-abs-2B;
 }

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -575,7 +575,7 @@
   // placeholder
 }
 
-.gmk-fro-dot-yo-key {
+.gmk-fro-dot-yo-key, .gmk-fro-dot-yo-mod {
   background: $color-gmk-abs-L9;
   color: $color-gmk-abs-2B;
 }

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -575,6 +575,34 @@
   // placeholder
 }
 
+.gmk-fro-dot-yo-key {
+  background: $color-gmk-abs-L9;
+  color: $color-gmk-abs-2B;
+}
+.gmk-fro-dot-yo-rdp {
+  background: $color-gmk-abs-L9;
+  color: $color-pantone-2345C;
+}
+.gmk-fro-dot-yo-grn {
+  background: $color-gmk-abs-L9;
+  color: $color-pantone-3395C;
+}
+.gmk-fro-dot-yo-blu {
+  background: $color-gmk-abs-L9;
+  color: $color-pantone-312C;
+}
+.gmk-fro-dot-yo-ppl {
+  background: $color-gmk-abs-L9;
+  color: $color-pantone-2088C;
+}
+.gmk-fro-dot-yo-ylw {
+  background: $color-gmk-abs-L9;
+  color: $color-gmk-abs-N6;
+}
+.gmk-fro-dot-yo-kb {
+  // placeholder
+}
+
 .gmk-hammerhead-dark-key {
   background: $color-pantone-533C;
   color: $color-pantone-3258C;

--- a/src/scss/pantone.scss
+++ b/src/scss/pantone.scss
@@ -20,3 +20,7 @@ $color-pantone-142C: rgb(241, 190, 72);
 $color-pantone-179C: rgb(224, 60, 49);
 $color-pantone-11C: rgb(83, 86, 90);
 $color-pantone-311C: rgb(5, 195, 221);
+$color-pantone-2345C: rgb(255, 109, 106);
+$color-pantone-2088C: rgb(130, 93, 199);
+$color-pantone-3395C: rgb(0, 195, 137);
+$color-pantone-312C: rgb(0, 169, 206);


### PR DESCRIPTION
# [Fro.Yo Theme](https://i.imgur.com/jMP5zCs.jpg)

## New Files:

- [x] (1)`src/components/colorways/gmk/fro_dot_yo.js`
   - Add key color overrides

## Modified Files:

- [x] (1) `src/components/colorways/gmk/index.js`
   - New file path reference

- [x] (1) `src/scss/colorways.scss`
   - Define key colors

- [x] (1) `src/scss/pantone.scss`
   - Add x4 new PANTONE swatches

- [ ] (1) `src/components/Main.vue`
   - Add filter to insert "." for menu item ***(No idea if this works)***

