### PR TITLE
Add a default keymap for yoichiro/lunakey_mini keyboard

### DIFF
--- a/public/keymaps/y/yoichiro_lunakey_mini_default.json
+++ b/public/keymaps/y/yoichiro_lunakey_mini_default.json
@@ -1,0 +1,30 @@
+{
+  "keyboard":"yoichiro/lunakey_mini",
+  "keymap":"default",
+  "commit": "c84650a147a5bf26322b583be85774121f5464e2",
+  "layout":"LAYOUT_split_3x6_4",
+  "layers":[
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+      "KC_LGUI", "KC_LALT", "MO(1)",   "KC_SPC",  "KC_ENT",  "MO(2)",   "KC_RALT", "KC_RGUI"
+    ],
+    [
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_LCTL", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_TRNS", "KC_TRNS",
+      "KC_LSFT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_LGUI", "KC_LALT", "KC_TRNS", "KC_SPC",  "KC_ENT",  "MO(3)",   "KC_RALT", "KC_RGUI"
+    ],[
+      "KC_ESC",  "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_BSPC",
+      "KC_LCTL", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MINS", "KC_EQL",  "KC_LCBR", "KC_RCBR", "KC_PIPE", "KC_GRV",
+      "KC_LSFT", "KC_TILD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_UNDS", "KC_PLUS", "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_TILD",
+      "KC_LGUI", "KC_LALT", "MO(3)",   "KC_SPC",  "KC_ENT",  "KC_TRNS", "KC_RALT", "KC_RGUI"
+    ],[
+      "RESET",   "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",
+      "RGB_TOG", "RGB_HUI", "RGB_SAI", "RGB_VAI", "KC_TRNS", "KC_TRNS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "RGB_MOD", "RGB_HUD", "RGB_SAD", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_LGUI", "KC_LALT", "KC_TRNS", "KC_SPC",  "KC_ENT",  "KC_TRNS", "KC_RALT", "KC_RGUI"
+    ]
+  ]
+}


### PR DESCRIPTION
# What is This

This pull request adds a new default keymap for the `yoichiro/lunakey_mini` keyboard to the QMK Configurator.

# References

* The last commit of the `keymaps/default/keymap.c` is [here](https://github.com/qmk/qmk_firmware/commit/c84650a147a5bf26322b583be85774121f5464e2).