### PR TITLE
add GMK Vaporwave

### DIFF
--- a/src/components/colorways/gmk/index.js
+++ b/src/components/colorways/gmk/index.js
@@ -34,6 +34,7 @@ import gmk_space_cadet from './space_cadet';
 import gmk_striker from './striker';
 import gmk_terminal from './terminal';
 import gmk_ta_royal_alpha from './ta_royal_alpha';
+import gmk_vaporwave from './vaporwave';
 import gmk_wob from './wob';
 import gmk_yuri from './yuri';
 
@@ -74,6 +75,7 @@ export default [
   gmk_striker,
   gmk_ta_royal_alpha,
   gmk_terminal,
+  gmk_vaporwave,
   gmk_wob,
   gmk_yuri
 ];

--- a/src/components/colorways/gmk/vaporwave.js
+++ b/src/components/colorways/gmk/vaporwave.js
@@ -1,0 +1,7 @@
+export default {
+  name: 'gmk-vaporwave',
+  override: {
+    KC_ENT: 'accent',
+    KC_ESC: 'accent'
+  }
+};

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -1146,15 +1146,23 @@
 }
 
 .gmk-vaporwave-key {
-  $color-vaporwave-lighter-pink: scale-color(#ff3eb5, $lightness: 40%);
-  background-color: #9595d2;
+  $color-vaporwave-lighter-pink: scale-color(
+    #ff3eb5,
+    $lightness: 60%,
+    $saturation: -20%
+  );
+  $color-vaporwave-lighter-lilac: scale-color(#9595d2, $lightness: 5%);
+  background-color: $color-vaporwave-lighter-lilac;
   color: $color-vaporwave-lighter-pink;
   font-weight: bold;
   input,
   .key-contents {
-    background: lighten(#9595d2, 5%);
+    background: lighten($color-vaporwave-lighter-lilac, 5%);
     color: $color-vaporwave-lighter-pink;
-    border-color: mix(#9595d2, $color-vaporwave-lighter-pink);
+    border-color: mix(
+      $color-vaporwave-lighter-lilac,
+      $color-vaporwave-lighter-pink
+    );
   }
 }
 

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -1145,6 +1145,35 @@
   color: $color-gmk-abs-N9;
 }
 
+.gmk-vaporwave-key {
+  $color-vaporwave-lighter-pink: scale-color(#ff3eb5, $lightness: 40%);
+  background-color: #9595d2;
+  color: $color-vaporwave-lighter-pink;
+  font-weight: bold;
+  input,
+  .key-contents {
+    background: lighten(#9595d2, 5%);
+    color: $color-vaporwave-lighter-pink;
+    border-color: mix(#9595d2, $color-vaporwave-lighter-pink);
+  }
+}
+
+.gmk-vaporwave-mod {
+  background-color: #6244bb;
+  color: #00bce3;
+  input,
+  .key-contents {
+    background: lighten(#6244bb, 10%);
+    color: #00bce3;
+    border-color: mix(#6244bb, #00bce3);
+  }
+}
+
+.gmk-vaporwave-accent {
+  background-color: #00bce3;
+  color: #6244bb;
+}
+
 .gmk-wob-key {
   background: $color-gmk-abs-CR;
   color: $color-gmk-abs-WS1;

--- a/src/scss/colorways.scss
+++ b/src/scss/colorways.scss
@@ -1171,7 +1171,7 @@
   color: #00bce3;
   input,
   .key-contents {
-    background: lighten(#6244bb, 10%);
+    background: darken(#6244bb, 10%);
     color: #00bce3;
     border-color: mix(#6244bb, #00bce3);
   }


### PR DESCRIPTION
Adds vaporwave colorway. Uses colors from this [GH thread](https://geekhack.org/index.php?topic=99875.0).
Had to lighten the original pink color and change the font weight to bold as the contrast was very bad (see screenshots below). Coincidentally it looks more like the real thing 😄 

![orig-pink](https://user-images.githubusercontent.com/2387645/100737259-988aff80-33dc-11eb-927d-474d00dbbcc9.png)
![lighter-pink](https://user-images.githubusercontent.com/2387645/100737279-9de84a00-33dc-11eb-8d19-5c9351efdd9d.png)
