### PR TITLE
Removed space; seems like qmk configurator doesn't like it

### DIFF
--- a/public/keymaps/h/handwired_dactyl_rah_default.json
+++ b/public/keymaps/h/handwired_dactyl_rah_default.json
@@ -7,7 +7,7 @@
     [
       "KC_GRV",          "KC_1",    "KC_2",   "KC_3",    "KC_4",    "KC_5",                                                          "KC_6",   "KC_7",    "KC_8",    "KC_9",   "KC_0",           "KC_HOME",
       "KC_TAB",          "KC_Q",    "KC_W",   "KC_E",    "KC_R",    "KC_T",                                                          "KC_Y",   "KC_U",    "KC_I",    "KC_O",   "KC_P",           "KC_BSLS",
-      "LCTL_T(KC_CAPS)", "KC_A",    "KC_S",   "KC_D",    "KC_F",    "KC_G",                                                          "KC_H",   "KC_J",    "KC_K",    "KC_L",   "LT(1, KC_SCLN)", "KC_QUOT",
+      "LCTL_T(KC_CAPS)", "KC_A",    "KC_S",   "KC_D",    "KC_F",    "KC_G",                                                          "KC_H",   "KC_J",    "KC_K",    "KC_L",   "LT(1,KC_SCLN)", "KC_QUOT",
       "KC_LSFT",         "KC_Z",    "KC_X",   "KC_C",    "KC_V",    "KC_B",                                                          "KC_N",   "KC_M",    "KC_COMM", "KC_DOT", "KC_SLSH",        "KC_RSFT",
       "LCTL_T(KC_ESC)",  "KC_MINS", "KC_EQL", "KC_LBRC", "KC_RBRC",                                                                            "KC_LEFT", "KC_DOWN", "KC_UP",  "KC_RGHT",        "KC_END",
                                                                                "TT(1)",          "KC_DEL",     "KC_PGUP", "KC_RCTL",


### PR DESCRIPTION
Seems like the space causes qmk configurator to fail in reading `KC_SCLN`