### PR TITLE
Adding default keymap for afternoonlabs/breeze/rev0

### DIFF
--- a/public/keymaps/a/afternoonlabs_breeze_rev0_default.json
+++ b/public/keymaps/a/afternoonlabs_breeze_rev0_default.json
@@ -1,0 +1,29 @@
+{
+   "keyboard": "afternoonlabs/breeze", 
+   "keymap": "default", 
+   "layout": "LAYOUT", 
+   "commit": "b32b928ff3dea8a3d396ff44d491bb3d4a95a2c8",
+   "layers": [
+      [
+        "KC_ESC", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC", "KC_MINS", "KC_EQL", "KC_GRV", 
+        "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_LBRC", "KC_RBRC", "KC_BSLS", 
+        "KC_LCTL", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_UP", 
+        "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_RSFT", "KC_LEFT", "KC_DOWN", "KC_RIGHT", 
+        "KC_LCTL", "KC_LALT", "KC_LGUI", "KC_SPC", "KC_ENT", "MO(_LOWER)", "MO(_RAISE)", "KC_NO"
+      ], 
+      [
+        "RESET", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", 
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", 
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", 
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MUTE", "KC_VOLD", "KC_VOLU",
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+      ], 
+      [
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PEQL", "KC_PSLS", "KC_PAST", "KC_PMNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", 
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_P7", "KC_P8", "KC_P9", "KC_PPLS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_P4", "KC_P5", "KC_P6", "KC_TRNS", "KC_TRNS", "KC_TRNS", 
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_P1", "KC_P2", "KC_P3", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", 
+        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_P0", "KC_PDOT"
+      ]
+  ]
+}

--- a/public/keymaps/a/afternoonlabs_breeze_rev0_default.json
+++ b/public/keymaps/a/afternoonlabs_breeze_rev0_default.json
@@ -9,7 +9,7 @@
         "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL", "KC_LBRC", "KC_RBRC", "KC_BSLS", 
         "KC_LCTL", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_UP", 
         "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_RSFT", "KC_LEFT", "KC_DOWN", "KC_RIGHT", 
-        "KC_LCTL", "KC_LALT", "KC_LGUI", "KC_SPC", "KC_ENT", "MO(_LOWER)", "MO(_RAISE)", "KC_NO"
+        "KC_LCTL", "KC_LALT", "KC_LGUI", "KC_SPC", "KC_ENT", "MO(2)", "MO(1)", "KC_NO"
       ], 
       [
         "RESET", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", 

--- a/public/keymaps/a/afternoonlabs_breeze_rev0_default.json
+++ b/public/keymaps/a/afternoonlabs_breeze_rev0_default.json
@@ -1,5 +1,5 @@
 {
-   "keyboard": "afternoonlabs/breeze", 
+   "keyboard": "afternoonlabs/breeze/rev0", 
    "keymap": "default", 
    "layout": "LAYOUT", 
    "commit": "b32b928ff3dea8a3d396ff44d491bb3d4a95a2c8",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

As title says, adding a default configurator keymap for Breeze keyboard.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
