### PR TITLE
Unnecessary quoting & escaping of keymap JSON

### DIFF
--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -127,7 +127,6 @@ import Vue from 'vue';
 import { mapMutations, mapActions, mapState, mapGetters } from 'vuex';
 import first from 'lodash/first';
 import isUndefined from 'lodash/isUndefined';
-import escape from 'lodash/escape';
 import { clearKeymapTemplate } from '@/common.js';
 import { PREVIEW_LABEL } from '@/store/modules/constants';
 import {
@@ -350,8 +349,8 @@ export default {
 
       if (!isUndefined(data.author)) {
         const { author, notes } = data;
-        this.setAuthor(escape(author));
-        this.setNotes(escape(notes));
+        this.setAuthor(author);
+        this.setNotes(notes);
       }
 
       // remap old json files to new mappings if they need it

--- a/src/store/modules/keymap.js
+++ b/src/store/modules/keymap.js
@@ -30,7 +30,7 @@ const state = {
     keymap: {
       version: 1,
       documentation:
-        '"This file is a QMK Configurator export. You can import this at <https://config.qmk.fm>. It can also be used directly with QMK\'s source code.\n\nTo setup your QMK environment check out the tutorial: <https://docs.qmk.fm/#/newbs>\n\nYou can convert this file to a keymap.c using this command: `qmk json2c {keymap}`\n\nYou can compile this keymap using this command: `qmk compile {keymap}`"\n'
+        "This file is a QMK Configurator export. You can import this at <https://config.qmk.fm>. It can also be used directly with QMK's source code.\n\nTo setup your QMK environment check out the tutorial: <https://docs.qmk.fm/#/newbs>\n\nYou can convert this file to a keymap.c using this command: `qmk json2c {keymap}`\n\nYou can compile this keymap using this command: `qmk compile {keymap}`\n"
     }
   }
 };


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Upon every keymap JSON upload/edit/download cycle, my email address in the
`author` field gains another pair of `&amp;`. Likewise for `notes`.

We shouldn't HTML-entity `encode` here, as (1) it's not appropriate for
JSON, and (2) JSON serialisation will already escape anything that needs it.

FWIW, when I upload a pristeen keymap JSON and click ‘Print Keymap’, the `author` and `notes` textarea/input shows escaped HTML entities, so it's not necessary to escape for those either.

Bonus removal of extraneous `"`s in the `documentation` field of the keymap template.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
