### PR TITLE
Add default layout for Durgod K320

### DIFF
--- a/public/keymaps/d/durgod_k320_default.json
+++ b/public/keymaps/d/durgod_k320_default.json
@@ -1,6 +1,6 @@
 {
-  "keyboard": "Durgod K320",
-  "keymap": "default_537b761",
+  "keyboard": "durgod/k320",
+  "keymap": "default",
   "commit": "537b7614b9be39025379291880b549e4fa4d826d",
   "layout": "LAYOUT_tkl_ansi",
   "layers": [

--- a/public/keymaps/d/durgod_k320_default.json
+++ b/public/keymaps/d/durgod_k320_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "Durgod K320",
+  "keymap": "default_537b761",
+  "commit": "537b7614b9be39025379291880b549e4fa4d826d",
+  "layout": "LAYOUT_tkl_ansi",
+  "layers": [
+    [
+        "KC_ESC",   "KC_F1",    "KC_F2",    "KC_F3",    "KC_F4",    "KC_F5",    "KC_F6",    "KC_F7",    "KC_F8",    "KC_F9",    "KC_F10",   "KC_F11",   "KC_F12",               "KC_PSCR",  "KC_SLCK",  "KC_PAUS",
+        "KC_GRV",   "KC_1",     "KC_2",     "KC_3",     "KC_4",     "KC_5",     "KC_6",     "KC_7",     "KC_8",     "KC_9",     "KC_0",     "KC_MINS",  "KC_EQL",   "KC_BSPC",  "KC_INS",   "KC_HOME",  "KC_PGUP",
+        "KC_TAB",   "KC_Q",     "KC_W",     "KC_E",     "KC_R",     "KC_T",     "KC_Y",     "KC_U",     "KC_I",     "KC_O",     "KC_P",     "KC_LBRC",  "KC_RBRC",  "KC_BSLS",  "KC_DEL",   "KC_END",   "KC_PGDN",
+        "KC_CAPS",  "KC_A",     "KC_S",     "KC_D",     "KC_F",     "KC_G",     "KC_H",     "KC_J",     "KC_K",     "KC_L",     "KC_SCLN",  "KC_QUOT",  "KC_ENT",
+        "KC_LSFT",  "KC_Z",     "KC_X",     "KC_C",     "KC_V",     "KC_B",     "KC_N",     "KC_M",     "KC_COMM",  "KC_DOT",   "KC_SLSH",  "KC_RSFT",                          "KC_UP",
+        "KC_LCTL",  "KC_LGUI",  "KC_LALT",                                "KC_SPC",                                 "KC_RALT",  "MO(1)",    "KC_APP",   "KC_RCTL",  "KC_LEFT",  "KC_DOWN",  "KC_RGHT"
+    ],
+    [
+      "KC_TRNS",  "KC_MPLY",  "KC_MSTP",  "KC_MRWD",  "KC_MFFD",  "KC_MUTE",  "KC_VOLD",  "KC_VOLU",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",                "KC_TRNS",  "KC_TRNS",  "KC_TRNS",
+      "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",    "KC_TRNS",  "KC_TRNS",  "KC_TRNS",
+      "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",    "KC_TRNS",  "KC_TRNS",  "KC_TRNS",
+      "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",
+      "KC_TRNS",            "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",                              "KC_TRNS",
+      "KC_TRNS",  "KC_TRNS",  "KC_TRNS",                                "KC_TRNS",                                "KC_TRNS",  "KC_TRNS",  "KC_TRNS",  "KC_TRNS",                "KC_TRNS",  "KC_TRNS",   "KC_TRNS"
+    ]
+  ]
+}


### PR DESCRIPTION
Add a default layout for the Durgod K320.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The Durgod K320 is a recent addition to QMK and I successfully used the QMK Configurator to make a layout for it but it was a bit tedious initially since there was no default layout. This PR comes to rectify that and simplify the work for future users of this keyboard.