### PR TITLE
Add Ctrl+Shift modifier key

### DIFF
--- a/src/store/modules/keycodes/quantum.js
+++ b/src/store/modules/keycodes/quantum.js
@@ -282,6 +282,12 @@ export default [
     type: 'container',
     title: 'LCTL + LALT'
   },
+  {
+    name: 'RCS',
+    code: 'RCS(kc)',
+    type: 'container',
+    title: 'RCTL + RSFT'
+  },
 
   { width: 0 },
 


### PR DESCRIPTION
I didn't see a way to create a [<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd>](https://help.gnome.org/users/gnome-help/stable/tips-specialchars.html.en#ctrlshiftu) key using the configurator. [`RCS(kc)`](https://docs.qmk.fm/#/feature_advanced_keycodes?id=modifier-keys) would work for me. Can we add that?