### PR TITLE
Issue 895: layout aliases

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"],
+      "@/*": ["./*"],
+      "~~/*": ["./*"],
+      "@@/*": ["./*"]
+    }
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -379,17 +379,16 @@ export default {
     },
     opened() {
       this.stopListening();
+      const select = this.$refs.select;
       Vue.nextTick(() => {
-        const active = this.$refs.select.$el.querySelector(
+        const active = select.$el.querySelector(
           '.vs__dropdown-menu .vs__dropdown-option--selected'
         );
         if (active) {
           // subtract height so we can see the previous value as well
           var offsetTop = active.offsetTop - active.offsetHeight;
-          this.$refs.select.typeAheadPointer = this.keyboards.indexOf(
-            this.keyboard
-          );
-          this.$refs.select.scrollTo(offsetTop > 0 ? offsetTop : 0, 0);
+          select.typeAheadPointer = this.keyboards.indexOf(this.keyboard);
+          select.$el.scrollTo(offsetTop > 0 ? offsetTop : 0, 0);
         }
       });
     },

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -108,8 +108,8 @@ const actions = {
           keyboards: {}
         };
         fake.keyboards[state.keyboard] = preview;
-        commit('processLayouts', fake);
         commit('setKeyboardMeta', {});
+        commit('processLayouts', fake);
         resolve(preview);
       });
       return p;

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -109,6 +109,7 @@ const actions = {
         };
         fake.keyboards[state.keyboard] = preview;
         commit('processLayouts', fake);
+        commit('setKeyboardMeta', {});
         resolve(preview);
       });
       return p;
@@ -116,6 +117,7 @@ const actions = {
     return axios
       .get(backend_keyboards_url + '/' + state.keyboard)
       .then(resp => {
+        commit('setKeyboardMeta', resp);
         commit('processLayouts', resp);
         return resp;
       });

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -45,6 +45,17 @@ const mutations = {
     state._keyboards = _keyboards; // make a 2nd copy
   },
   setLayout(state, _layout) {
+    if (
+      state.keyboardMeta &&
+      state.keyboard &&
+      state.keyboardMeta[state.keyboard]
+    ) {
+      const { layout_aliases } = state.keyboardMeta[state.keyboard];
+      if (layout_aliases && layout_aliases[_layout]) {
+        state.layout = layout_aliases[_layout];
+        return;
+      }
+    }
     state.layout = _layout;
   },
   setKeymapName(state, _keymapName) {
@@ -94,7 +105,9 @@ const mutations = {
       if (state.isPreview) {
         layouts = resp.keyboards[PREVIEW_LABEL].layouts;
       } else {
-        layouts = resp.data.keyboards[state.keyboard].layouts;
+        if (resp.data && resp.data.keyboards) {
+          layouts = resp.data.keyboards[state.keyboard].layouts;
+        }
       }
       if (size(layouts) === 0) {
         // API return empty layout object
@@ -173,6 +186,12 @@ const mutations = {
   },
   toggleSnowflakes(state) {
     state.snowflakes = !state.snowflakes;
+  },
+  setKeyboardMeta(state, value) {
+    if (value.status === 200) {
+      state.keyboardMeta =
+        value.data && value.data.keyboards ? value.data.keyboards : {};
+    }
   }
 };
 

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -34,6 +34,7 @@ function loadSettings() {
 
 const state = {
   keyboard: '',
+  keyboardMeta: {},
   configuratorSettings: loadSettings(),
   keyboards: [],
   appInitialized: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Provides an implementation to use metadata in API to remap layouts dynamically in old keymap files.
Fixes some other misc bugs.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

 - load alias layout data into app/keyboardMeta
 - fix reference issues with scrollTo implementation
 - add more object guards when state is indeterminate
 - look at layout_alias if it exists and use it to remap a keyboard
   layout when it's being set
 - keep vetur happy by adding config file

Fixes #895 
<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
