### PR TITLE
Add default keymaps for CozyKeys Bloomer v2 and v3

### DIFF
--- a/public/keymaps/c/cozykeys_bloomer_v2_default.json
+++ b/public/keymaps/c/cozykeys_bloomer_v2_default.json
@@ -13,12 +13,12 @@
       "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_GRV",  "MO(1)",   "KC_BSPC", "KC_DEL",   "KC_DOWN", "KC_ENT",  "KC_SPC",  "KC_LBRC", "KC_RBRC", "KC_RALT", "KC_RGUI", "KC_RCTL"
     ],
     [
-      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",    "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RESET",
-      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RGB_HUI",  "RGB_SAI", "RGB_VAI", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
-      "KC_NO",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NO",   "RGB_HUD",  "RGB_SAD", "RGB_VAD", "KC_NO",   "KC_GRV",  "KC_LBRC", "KC_RBRC", "KC_NO",   "KC_NO",
-      "KC_NO",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_NO",                                     "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_NO",   "KC_NO",
-      "KC_NO",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_NO",   "RGB_RMOD", "RGB_TOG", "RGB_MOD", "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END",  "KC_NO",   "KC_NO",
-      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_TRNS", "KC_NO",   "KC_NO",    "RGB_M_P", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO"
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RGB_HUI",  "RGB_SAI", "RGB_VAI", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "RGB_HUD",  "RGB_SAD", "RGB_VAD", "KC_TRNS", "KC_GRV",  "KC_LBRC", "KC_RBRC", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_TRNS",                                   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_TRNS", "RGB_RMOD", "RGB_TOG", "RGB_MOD", "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END",  "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "RGB_M_P", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ]
   ]
 }

--- a/public/keymaps/c/cozykeys_bloomer_v2_default.json
+++ b/public/keymaps/c/cozykeys_bloomer_v2_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "cozykeys/bloomer/v2",
+  "keymap": "default",
+  "commit": "TODO",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_PSCR",  "KC_SLCK", "KC_PAUS", "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_EQL",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_INS",   "KC_HOME", "KC_PGUP", "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_CAPS",  "KC_END",  "KC_PGDN", "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSLS",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                                      "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_LEFT",  "KC_UP",   "KC_RGHT", "KC_LGUI", "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_GRV",  "MO(1)",   "KC_BSPC", "KC_DEL",   "KC_DOWN", "KC_ENT",  "KC_SPC",  "KC_LBRC", "KC_RBRC", "KC_RALT", "KC_RGUI", "KC_RCTL"
+    ],
+    [
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",    "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RESET",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RGB_HUI",  "RGB_SAI", "RGB_VAI", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NO",   "RGB_HUD",  "RGB_SAD", "RGB_VAD", "KC_NO",   "KC_GRV",  "KC_LBRC", "KC_RBRC", "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_NO",                                     "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_NO",   "RGB_RMOD", "RGB_TOG", "RGB_MOD", "KC_HOME", "KC_LGUI", "KC_PGUP", "KC_END",  "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_TRNS", "KC_NO",   "KC_NO",    "RGB_M_P", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO"
+    ]
+  ]
+}

--- a/public/keymaps/c/cozykeys_bloomer_v2_default.json
+++ b/public/keymaps/c/cozykeys_bloomer_v2_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "cozykeys/bloomer/v2",
   "keymap": "default",
-  "commit": "TODO",
+  "commit": "d3963a61cb9209efce1d8f052d5d8e7aaa2be48b",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/c/cozykeys_bloomer_v2_default.json
+++ b/public/keymaps/c/cozykeys_bloomer_v2_default.json
@@ -9,7 +9,7 @@
       "KC_EQL",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_INS",   "KC_HOME", "KC_PGUP", "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS",
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_CAPS",  "KC_END",  "KC_PGDN", "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSLS",
       "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                                      "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
-      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_LEFT",  "KC_UP",   "KC_RGHT", "KC_LGUI", "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_LEFT",  "KC_UP",   "KC_RGHT", "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
       "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_GRV",  "MO(1)",   "KC_BSPC", "KC_DEL",   "KC_DOWN", "KC_ENT",  "KC_SPC",  "KC_LBRC", "KC_RBRC", "KC_RALT", "KC_RGUI", "KC_RCTL"
     ],
     [
@@ -17,7 +17,7 @@
       "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RGB_HUI",  "RGB_SAI", "RGB_VAI", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
       "KC_NO",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_NO",   "RGB_HUD",  "RGB_SAD", "RGB_VAD", "KC_NO",   "KC_GRV",  "KC_LBRC", "KC_RBRC", "KC_NO",   "KC_NO",
       "KC_NO",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_NO",                                     "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_NO",   "KC_NO",
-      "KC_NO",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_NO",   "RGB_RMOD", "RGB_TOG", "RGB_MOD", "KC_HOME", "KC_LGUI", "KC_PGUP", "KC_END",  "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_NO",   "RGB_RMOD", "RGB_TOG", "RGB_MOD", "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END",  "KC_NO",   "KC_NO",
       "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_TRNS", "KC_NO",   "KC_NO",    "RGB_M_P", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO"
     ]
   ]

--- a/public/keymaps/c/cozykeys_bloomer_v3_default.json
+++ b/public/keymaps/c/cozykeys_bloomer_v3_default.json
@@ -10,7 +10,7 @@
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_LBRC",      "KC_PSCR",  "KC_PAUS",      "KC_RBRC", "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSLS",
       "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_PGUP",      "KC_SLCK",  "KC_NLCK",      "KC_HOME", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
       "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_PGDN", "KC_CAPS", "KC_UP",   "KC_INS",  "KC_END",  "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
-      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_GRV",  "MO(1)",   "KC_BSPC", "KC_DEL",  "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_LGUI", "KC_LGUI", "KC_LBRC", "KC_RBRC", "KC_RALT", "KC_RGUI", "KC_RCTL"
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_GRV",  "MO(1)",   "KC_BSPC", "KC_DEL",  "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_ENT",  "KC_SPC",  "KC_LBRC", "KC_RBRC", "KC_RALT", "KC_RGUI", "KC_RCTL"
     ],
     [
       "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",    "KC_NO",                                                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RESET",

--- a/public/keymaps/c/cozykeys_bloomer_v3_default.json
+++ b/public/keymaps/c/cozykeys_bloomer_v3_default.json
@@ -13,12 +13,12 @@
       "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_GRV",  "MO(1)",   "KC_BSPC", "KC_DEL",  "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_ENT",  "KC_SPC",  "KC_LBRC", "KC_RBRC", "KC_RALT", "KC_RGUI", "KC_RCTL"
     ],
     [
-      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",    "KC_NO",                                                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RESET",
-      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",    "KC_NO",                                                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
-      "KC_NO",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",   "KC_NO",  "KC_NO",        "RGB_TOG",  "RGB_M_P",      "KC_NO",   "KC_NO",   "KC_GRV",  "KC_LBRC", "KC_RBRC", "KC_NO",   "KC_NO",
-      "KC_NO",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",    "KC_NO",  "KC_NO",        "RGB_RMOD", "RGB_MOD",      "KC_NO",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_NO",   "KC_NO",
-      "KC_NO",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",    "KC_NO",  "KC_NO",   "RGB_HUI", "RGB_SAI", "RGB_VAI", "KC_NO",   "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END",  "KC_NO",   "KC_NO",
-      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_TRNS",  "KC_NO",  "KC_NO",   "RGB_HUD", "RGB_SAD", "RGB_VAD", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO"
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS",                                                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS",                                                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",   "KC_TRNS","KC_TRNS",      "RGB_TOG",  "RGB_M_P",      "KC_TRNS", "KC_TRNS", "KC_GRV",  "KC_LBRC", "KC_RBRC", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",    "KC_TRNS","KC_TRNS",      "RGB_RMOD", "RGB_MOD",      "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",    "KC_TRNS","KC_TRNS", "RGB_HUI", "RGB_SAI", "RGB_VAI", "KC_TRNS", "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END",  "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS","KC_TRNS", "RGB_HUD", "RGB_SAD", "RGB_VAD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ]
   ]
 }

--- a/public/keymaps/c/cozykeys_bloomer_v3_default.json
+++ b/public/keymaps/c/cozykeys_bloomer_v3_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "cozykeys/bloomer/v3",
   "keymap": "default",
-  "commit": "TODO",
+  "commit": "d3963a61cb9209efce1d8f052d5d8e7aaa2be48b",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/c/cozykeys_bloomer_v3_default.json
+++ b/public/keymaps/c/cozykeys_bloomer_v3_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "cozykeys/bloomer/v3",
+  "keymap": "default",
+  "commit": "TODO",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",                                                          "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_EQL",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                                                           "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_LBRC",      "KC_PSCR",  "KC_PAUS",      "KC_RBRC", "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSLS",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_PGUP",      "KC_SLCK",  "KC_NLCK",      "KC_HOME", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_PGDN", "KC_CAPS", "KC_UP",   "KC_INS",  "KC_END",  "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_GRV",  "MO(1)",   "KC_BSPC", "KC_DEL",  "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_LGUI", "KC_LGUI", "KC_LBRC", "KC_RBRC", "KC_RALT", "KC_RGUI", "KC_RCTL"
+    ],
+    [
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",    "KC_NO",                                                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RESET",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",    "KC_NO",                                                         "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",   "KC_NO",  "KC_NO",        "RGB_TOG",  "RGB_M_P",      "KC_NO",   "KC_NO",   "KC_GRV",  "KC_LBRC", "KC_RBRC", "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",    "KC_NO",  "KC_NO",        "RGB_RMOD", "RGB_MOD",      "KC_NO",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",    "KC_NO",  "KC_NO",   "RGB_HUI", "RGB_SAI", "RGB_VAI", "KC_NO",   "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END",  "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_TRNS",  "KC_NO",  "KC_NO",   "RGB_HUD", "RGB_SAD", "RGB_VAD", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO"
+    ]
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I am in the process of adding the CozyKeys Bloomer keyboard to QMK and this PR is to add the default keymaps to the configurator.

The corresponding PR in the QMK repository is:
https://github.com/qmk/qmk_firmware/pull/12639

**Do not merge yet.** This is intentionally set up as a draft PR for two reasons:
- The commit hash for the keyboard doesn't exist until the corresponding PR in the QMK repository is merged, at which point I will update the `"commit"` fields here
- I have not been able to test importing of these files
    - I was able to load my local `info.json` into the configurator, set up the keymap, and export it; however, it looks like importing a keymap doesn't work when a local `info.json` file is being used
    - My understanding is that the configurator parses for `info.json` files in the `master` branch of QMK, so I will test this as soon as the corresponding PR is merged in the QMK repo