### PR TITLE
Adding initial support for Big-Ass Enter.

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -78,6 +78,9 @@ const _getKeySizeClass = (unith, unitw) => {
   if (unith === 2 && unitw == 1.25) {
     return 'kiso';
   }
+  if (unith === 2 && unitw == 2.25) {
+    return 'kbae';
+  }
   return 'custom';
 };
 
@@ -418,4 +421,28 @@ export default {
   box-shadow: rgba(0, 0, 0, 0.1) 0px -2px 0px 2px inset,
     rgba(0, 0, 0, 0.3) 0px 2px 0px 1px;
 }
+.kbae {
+  width: calc(0.5 * var(--default-key-x-spacing) + var(--default-key-width));
+  height: calc(1.1 * var(--default-key-height));
+  padding: 0px;
+  margin-left: calc(var(--default-key-x-spacing) * 0.75);
+  border-radius: 6px 6px 0px 0px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 2px 0px 2px inset,
+    rgba(0, 0, 0, 0.3) 0px 0px 0px 1px;
+}
+.kbae::after {
+  background: inherit;
+  position: absolute;
+  content: '';
+  right: -1px;
+  top: calc(var(--default-key-x-spacing) - 2px);
+  height: var(--default-key-height);
+  width: calc(1.25 * var(--default-key-x-spacing) + 1 * var(--default-key-width) - 2px);
+  border-radius: 6px 0px 6px 6px;
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: rgba(0, 0.1, 0, 0.1) 0px -2px 0px 2px inset,
+    rgba(0, 0, 0, 0.3) 0px 1px 0px 1px;
+}
+
 </style>

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -76,9 +76,9 @@ const _getKeySizeClass = (unith, unitw) => {
     }
   }
   if (unith === 2) {
-    if (unitw == 1.25) {
+    if (unitw === 1.25) {
       return 'kiso';
-    } else if (unitw == 2.25) {
+    } else if (unitw === 2.25) {
       return 'kbae';
     }
   }

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -75,11 +75,12 @@ const _getKeySizeClass = (unith, unitw) => {
         return 'k2uh';
     }
   }
-  if (unith === 2 && unitw == 1.25) {
-    return 'kiso';
-  }
-  if (unith === 2 && unitw == 2.25) {
-    return 'kbae';
+  if (unith === 2) {
+    if (unitw == 1.25) {
+      return 'kiso';
+    } else if (unitw == 2.25) {
+      return 'kbae';
+    }
   }
   return 'custom';
 };

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -438,12 +438,13 @@ export default {
   right: -1px;
   top: calc(var(--default-key-x-spacing) - 1px);
   height: var(--default-key-height);
-  width: calc(1.25 * var(--default-key-x-spacing) + 1 * var(--default-key-width) - 2px);
+  width: calc(
+    1.25 * var(--default-key-x-spacing) + 1 * var(--default-key-width) - 2px
+  );
   border-radius: 6px 0px 6px 6px;
   border-left: 1px solid rgba(0, 0, 0, 0.1);
   border-right: 1px solid rgba(0, 0, 0, 0.1);
   box-shadow: rgba(0, 0.1, 0, 0.1) 0px -2px 0px 2px inset,
     rgba(0, 0, 0, 0.3) 0px 1px 0px 1px;
 }
-
 </style>

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -435,7 +435,7 @@ export default {
   position: absolute;
   content: '';
   right: -1px;
-  top: calc(var(--default-key-x-spacing) - 2px);
+  top: calc(var(--default-key-x-spacing) - 1px);
   height: var(--default-key-height);
   width: calc(1.25 * var(--default-key-x-spacing) + 1 * var(--default-key-width) - 2px);
   border-radius: 6px 0px 6px 6px;


### PR DESCRIPTION
Adding initial support for Big-Ass Enter

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This changed introduces support of the Big-Ass Enter measured as key with height 2 in units and width in 2.25 units.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
