### PR TITLE
Use keyboards.qmk.fm to fetch metadata

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VUE_APP_API_URL=https://api.qmk.fm
+VUE_APP_KEYBOARDS_URL=https://keyboards.qmk.fm

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VUE_APP_API_URL=https://api.qmk.fm
+VUE_APP_KEYBOARDS_URL=https://keyboards.qmk.fm

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import isUndefined from 'lodash/isUndefined';
 import { backend_keyboards_url } from '@/store/modules/constants';
+import { backend_keyboard_list_url } from '@/store/modules/constants';
 import { getPreferredLayout, getExclusionList } from '@/jquery';
 import { localStorageSet, CONSTS } from '@/store/localStorage';
 
@@ -11,10 +12,10 @@ const actions = {
    * fetchKeyboards - fetch keyboard list from API
    */
   async fetchKeyboards({ commit }) {
-    const r = await axios.get(backend_keyboards_url);
+    const r = await axios.get(backend_keyboard_list_url);
     if (r.status === 200) {
       const exclude = getExclusionList();
-      const results = r.data.filter(keeb => {
+      const results = r.data.keyboards.filter(keeb => {
         return isUndefined(exclude[keeb]);
       });
       commit('setKeyboards', results);
@@ -115,7 +116,7 @@ const actions = {
       return p;
     }
     return axios
-      .get(backend_keyboards_url + '/' + state.keyboard)
+      .get(backend_keyboards_url + '/' + state.keyboard + '/info.json')
       .then(resp => {
         commit('setKeyboardMeta', resp);
         commit('processLayouts', resp);

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -1,6 +1,9 @@
 import axios from 'axios';
 import isUndefined from 'lodash/isUndefined';
-import { backend_keyboards_url, backend_keyboard_list_url } from '@/store/modules/constants';
+import {
+  backend_keyboards_url,
+  backend_keyboard_list_url
+} from '@/store/modules/constants';
 import { getPreferredLayout, getExclusionList } from '@/jquery';
 import { localStorageSet, CONSTS } from '@/store/localStorage';
 

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import isUndefined from 'lodash/isUndefined';
-import { backend_keyboards_url } from '@/store/modules/constants';
-import { backend_keyboard_list_url } from '@/store/modules/constants';
+import { backend_keyboards_url, backend_keyboard_list_url } from '@/store/modules/constants';
 import { getPreferredLayout, getExclusionList } from '@/jquery';
 import { localStorageSet, CONSTS } from '@/store/localStorage';
 
@@ -116,7 +115,7 @@ const actions = {
       return p;
     }
     return axios
-      .get(backend_keyboards_url + '/' + state.keyboard + '/info.json')
+      .get(`${backend_keyboards_url}/${state.keyboard}/info.json`)
       .then(resp => {
         commit('setKeyboardMeta', resp);
         commit('processLayouts', resp);

--- a/src/store/modules/constants.js
+++ b/src/store/modules/constants.js
@@ -1,11 +1,11 @@
 import template from 'lodash/template';
 
 export const backend_baseurl = process.env.VUE_APP_API_URL;
-if (isUndefined(backend_baseurl)) {
+if (typeof backend_baseurl === 'undefined') {
   throw 'Backend URL has not been specified';
 }
 export const keyboards_baseurl = process.env.VUE_APP_KEYBOARDS_URL;
-if (isUndefined(keyboards_baseurl)) {
+if (typeof keyboards_baseurl === 'undefined') {
   throw 'Keyboard Metadata URL has not been specified';
 }
 export const backend_keyboards_url = `${keyboards_baseurl}/v1/keyboards`;

--- a/src/store/modules/constants.js
+++ b/src/store/modules/constants.js
@@ -1,11 +1,11 @@
 import template from 'lodash/template';
 
 export const backend_baseurl = process.env.VUE_APP_API_URL;
-if (!backend_baseurl) {
+if (isUndefined(backend_baseurl)) {
   throw 'Backend URL has not been specified';
 }
 export const keyboards_baseurl = process.env.VUE_APP_KEYBOARDS_URL;
-if (!keyboards_baseurl) {
+if (isUndefined(keyboards_baseurl)) {
   throw 'Keyboard Metadata URL has not been specified';
 }
 export const backend_keyboards_url = `${keyboards_baseurl}/v1/keyboards`;

--- a/src/store/modules/constants.js
+++ b/src/store/modules/constants.js
@@ -4,11 +4,16 @@ export const backend_baseurl = process.env.VUE_APP_API_URL;
 if (!backend_baseurl) {
   throw 'Backend URL has not been specified';
 }
-export const backend_keyboards_url = `${backend_baseurl}/v1/keyboards`;
+export const keyboards_baseurl = process.env.VUE_APP_KEYBOARDS_URL;
+if (!keyboards_baseurl) {
+  throw 'Keyboard Metadata URL has not been specified';
+}
+export const backend_keyboards_url = `${keyboards_baseurl}/v1/keyboards`;
+export const backend_keyboard_list_url = `${keyboards_baseurl}/v1/keyboard_list.json`;
 export const backend_compile_url = `${backend_baseurl}/v1/compile`;
 export const backend_status_url = `${backend_baseurl}/v1`;
 export const backend_readme_url_template = template(
-  `${backend_keyboards_url}/<%= keyboard %>/readme`
+  `${backend_keyboards_url}/<%= keyboard %>/readme.md`
 );
 export const backend_skeletons_url = `${backend_baseurl}/v1/skeletons`;
 export const PREVIEW_LABEL = 'Preview info.json';

--- a/src/store/modules/constants.js
+++ b/src/store/modules/constants.js
@@ -1,11 +1,12 @@
 import template from 'lodash/template';
+import isUndefined from 'lodash/isUndefined';
 
 export const backend_baseurl = process.env.VUE_APP_API_URL;
-if (typeof backend_baseurl === 'undefined') {
+if (isUndefined(backend_baseurl)) {
   throw 'Backend URL has not been specified';
 }
 export const keyboards_baseurl = process.env.VUE_APP_KEYBOARDS_URL;
-if (typeof keyboards_baseurl === 'undefined') {
+if (isUndefined(keyboards_baseurl)) {
   throw 'Keyboard Metadata URL has not been specified';
 }
 export const backend_keyboards_url = `${keyboards_baseurl}/v1/keyboards`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
Now that we have `keyboards.qmk.fm` updating regularly using github actions we should use that so we can stop generating duplicate metadata in the API. This PR adds support for doing that. This should help to improve the responsiveness of the UI when the API is under load.

I don't know if this is the best approach, I just sorta changed things around until I stopped getting errors. Happy to change anything about this PR.