### PR TITLE
Fix printing keymaps with empty layer - Issue 852

### DIFF
--- a/src/components/PrintKey.vue
+++ b/src/components/PrintKey.vue
@@ -5,14 +5,15 @@
     :class="myclasses"
     :style="mystyles"
     :title="displayName"
-  >{{ displayName }}
+  >
+    {{ displayName }}
   </div>
 </template>
 <script>
-import BaseKey from "./BaseKey";
+import BaseKey from './BaseKey';
 
 export default {
-  name: "print-key",
+  name: 'print-key',
   props: {
     layer: Number
   },
@@ -22,18 +23,18 @@ export default {
       return `key-${this.layer}-${this.id}`;
     },
     displayName() {
-      if (this.meta.type === "layer") {
-        return this.meta.code.replace("layer", this.meta.layer);
+      if (this.meta.type === 'layer') {
+        return this.meta.code.replace('layer', this.meta.layer);
       }
-      if (this.meta.type === "text") {
+      if (this.meta.type === 'text') {
         return this.formatName(this.breakLines(this.meta.text));
       }
-      if (this.meta.type === "layer-container") {
+      if (this.meta.type === 'layer-container') {
         return `${this.meta.name.toUpperCase()},\n${this.formatName(
           this.meta.contents.code
         )}`;
       }
-      if (this.meta.type === "container") {
+      if (this.meta.type === 'container') {
         return `${this.meta.name.toUpperCase()}\n(${this.formatName(
           this.meta.contents.code
         )})`;
@@ -44,7 +45,7 @@ export default {
   methods: {
     breakLines(name) {
       if (this.uw < 1.75) {
-        name = name.replace(" ", "\n").replace("_", "_\n");
+        name = name.replace(' ', '\n').replace('_', '_\n');
       }
       return name;
     }

--- a/src/components/PrintKey.vue
+++ b/src/components/PrintKey.vue
@@ -1,17 +1,18 @@
 <template>
-  <!-- prettier-ignore -->
   <div
     :id="myid"
     class="key"
     :class="myclasses"
     :style="mystyles"
     :title="displayName"
-  >{{ displayName }}</div>
+  >{{ displayName }}
+  </div>
 </template>
 <script>
-import BaseKey from './BaseKey';
+import BaseKey from "./BaseKey";
+
 export default {
-  name: 'print-key',
+  name: "print-key",
   props: {
     layer: Number
   },
@@ -21,18 +22,18 @@ export default {
       return `key-${this.layer}-${this.id}`;
     },
     displayName() {
-      if (this.meta.type === 'layer') {
-        return this.meta.code.replace('layer', this.meta.layer);
+      if (this.meta.type === "layer") {
+        return this.meta.code.replace("layer", this.meta.layer);
       }
-      if (this.meta.type === 'text') {
+      if (this.meta.type === "text") {
         return this.formatName(this.breakLines(this.meta.text));
       }
-      if (this.meta.type === 'layer-container') {
+      if (this.meta.type === "layer-container") {
         return `${this.meta.name.toUpperCase()},\n${this.formatName(
           this.meta.contents.code
         )}`;
       }
-      if (this.meta.type === 'container') {
+      if (this.meta.type === "container") {
         return `${this.meta.name.toUpperCase()}\n(${this.formatName(
           this.meta.contents.code
         )})`;
@@ -43,7 +44,7 @@ export default {
   methods: {
     breakLines(name) {
       if (this.uw < 1.75) {
-        name = name.replace(' ', '\n').replace('_', '_\n');
+        name = name.replace(" ", "\n").replace("_", "_\n");
       }
       return name;
     }

--- a/src/components/PrintKeymap.vue
+++ b/src/components/PrintKeymap.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="print-keymap" :style="styles">
     <template v-for="meta in currentLayer(layer)">
-      <component
+      <PrintKey
         :layer="layer"
-        v-bind:is="getComponent(meta)"
         v-bind="meta"
         :key="meta.id"
         :printable="true"

--- a/src/components/PrintKeymap.vue
+++ b/src/components/PrintKeymap.vue
@@ -39,9 +39,9 @@ export default {
   },
   methods: {
     ...mapMutations('keymap', ['resizeConfig']),
-    currentLayer(layerIDX) {
+    currentLayer(layerIndex) {
       const layout = this.layouts[this.layout];
-      const keymap = this.getLayer(layerIDX);
+      const keymap = this.getLayer(layerIndex);
       if (isUndefined(layout) || isUndefined(keymap)) {
         return [];
       }

--- a/src/components/PrintKeymap.vue
+++ b/src/components/PrintKeymap.vue
@@ -1,12 +1,7 @@
 <template>
   <div class="print-keymap" :style="styles">
     <template v-for="meta in currentLayer(layer)">
-      <PrintKey
-        :layer="layer"
-        v-bind="meta"
-        :key="meta.id"
-        :printable="true"
-      />
+      <PrintKey :layer="layer" v-bind="meta" :key="meta.id" :printable="true" />
     </template>
   </div>
 </template>

--- a/src/views/Print.vue
+++ b/src/views/Print.vue
@@ -57,12 +57,12 @@
       </table>
     </div>
     <div>
-      <template v-for="idx in activeLayers">
-        <div class="layer-output" :class="firefoxOnly(idx)" :key="idx">
+      <template v-for="index in activeLayers">
+        <div class="layer-output" :class="firefoxOnly(index)" :key="index">
           <h3 class="layer-output-title">
-            {{ i18n('layer.label') }} {{ idx }}
+            {{ i18n('layer.label') }} {{ index }}
           </h3>
-          <PrintKeymap :layer="idx"></PrintKeymap>
+          <PrintKeymap :layer="index"></PrintKeymap>
         </div>
       </template>
     </div>
@@ -137,9 +137,9 @@ export default {
         window.print();
       });
     },
-    firefoxOnly(idx) {
+    firefoxOnly(index) {
       if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-        if ((idx / 3) % 3 == 0) {
+        if ((index / 3) % 3 == 0) {
           return 'layout-output-firefox';
         }
       }


### PR DESCRIPTION
## Description

Turns out the PrintKeymap component was being rendered incorrectly with an incorrect dynamic binding. There is only one component to render so directly referencing both solves the issue and reduces complexity.

Removes a prettier ignore in PrintKey.

Clarifies a variable name in Print.
 
Fixed #852 
