### PR TITLE
Fix two buttons using same leavePrint ID

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -260,7 +260,6 @@ a img {
 #settings,
 #printkeymaps,
 #testkeys,
-#leavePrint,
 #leaveTest,
 #resetTest,
 #load-default,

--- a/src/views/Print.vue
+++ b/src/views/Print.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="print-layout">
     <div class="print-controls">
-      <button id="leavePrint" @click="gohome">
+      <button class="ui-button" @click="gohome">
         <font-awesome-icon icon="chevron-left" size="lg" fixed-width />
         {{ i18n('back.title') }}
       </button>
-      <button id="leavePrint" @click="print()">
+      <button class="ui-button" @click="print()">
         <font-awesome-icon icon="print" size="lg" fixed-width />
         {{ i18n('print.title') }}
       </button>


### PR DESCRIPTION
## Description

An ID can only be applied to one element at a time. The buttons within Print.vue both had the same ID. Further, it looks like they were just using it for styling. This styling is already achieved with the `ui-button` class so I have removed the IDs and applied the class instead.