### PR TITLE
New keymap for Sofle rev1 for Flare576

### DIFF
--- a/docs/keymaps/s/sofle_rev1_flare576.json
+++ b/docs/keymaps/s/sofle_rev1_flare576.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "notes": "Instead of up/down, uses layer toggles on ends, incorporates Mouse/Game layers.",
+  "keyboard": "sofle/rev1",
+  "keymap": "Flare576",
+  "commit": "1646c0f26cfa21a7023d404008e4d0aa4917193d",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "LT(3,KC_GRV)", "KC_1",      "KC_2",     "KC_3",    "KC_4",             "KC_5",                   "KC_6",               "KC_7",    "KC_8",          "KC_9",   "KC_0",     "KC_MINS",
+      "LALT_T(KC_TAB)",   "KC_Q",      "KC_W",     "KC_E",    "KC_R",             "KC_T",                   "KC_Y",               "KC_U",    "KC_I",          "KC_O",   "KC_P",     "KC_BSLS",
+      "KC_LSFT",          "KC_A",      "KC_S",     "KC_D",    "KC_F",             "KC_G",                   "KC_H",               "KC_J",    "KC_K",          "KC_L",   "KC_SCLN",  "KC_QUOT",
+      "KC_LCTRL",         "KC_Z",      "KC_X",     "KC_C",    "KC_V",             "KC_B", "KC_MPLY", "KC_HOME", "KC_N",               "KC_M",    "KC_COMM",       "KC_DOT", "KC_SLSH",  "RSFT_T(KC_PLUS)",
+      "TG(5)", "KC_LALT",  "KC_LGUI", "LT(2,KC_ESC)", "KC_SPC",                 "LT(1,KC_ENT)",  "KC_BSPC", "LALT(KC_LSFT)", "KC_DEL", "TG(4)"
+    ],
+    [
+      "KC_F1",    "KC_F2",    "KC_F3",    "KC_F4",    "KC_F5",    "KC_F6",                        "KC_F7",    "KC_F8",    "KC_F9",    "KC_F10",    "KC_F11",   "KC_F12",
+      "_______",  "KC_PSCR",  "XXXXXXX",  "KC_MS_U",  "KC_HOME",  "KC_PGUP",                      "KC_WH_U",  "KC_WH_D",  "KC_WH_L",  "KC_WH_R",   "XXXXXXX",  "ANY(COMP_1)",
+      "_______",  "KC_SLCK",  "KC_MS_L",  "KC_MS_D",  "KC_MS_R",  "XXXXXXX",                      "KC_LEFT",  "KC_DOWN",  "KC_UP",    "KC_RIGHT",  "XXXXXXX",   "ANY(COMP_2)",
+      "_______",  "KC_PAUS",  "XXXXXXX",  "XXXXXXX",  "KC_END",  "KC_PGDOWN", "_______",  "_______", "KC_BTN1",  "KC_BTN2",  "KC_LBRC",  "KC_RBRC",   "XXXXXXX",  "XXXXXXX",
+      "_______",  "_______",  "_______",  "_______",  "XXXXXXX",                      "_______",  "KC_BTN3",  "KC_BTN4",  "KC_BTN5",   "XXXXXXX"
+    ],
+    [
+      "LCTRL(KC_W)",  "LALT(KC_A)",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                          "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "_______",  "KC_EXLM",  "KC_AT",    "KC_HASH",  "KC_DLR",   "KC_PERC",                          "KC_CIRC",  "KC_AMPR",  "KC_ASTR",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "_______",  "ANY(,\\n)",  "ANY(LALT(a)\\n)",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______",    "_______",   "XXXXXXX",  "XXXXXXX",  "KC_LPRN",  "KC_RPRN",  "XXXXXXX",  "XXXXXXX",
+      "_______", "_______", "_______", "_______", "_______",                          "_______", "_______", "_______", "_______", "_______"
+    ],
+    [
+      "_______",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "KC_VOLU",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "KC_MPRV",  "KC_MPLY",  "KC_MNXT",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "_______",  "_______", "KC_VOLD",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX", "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "RESET"
+    ],
+    [
+      "KC_ESC",   "KC_HOME",  "KC_NLCK",  "KC_PSLS",  "KC_PAST",  "KC_PMNS",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
+      "KC_TAB",   "KC_END",   "KC_P7",    "KC_P8",    "KC_P9",    "KC_PPLS",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
+      "KC_LSFT",  "KC_PGUP",  "KC_P4",    "KC_P5",    "KC_P6",    "KC_PCMM",                      "KC_DOWN",  "KC_UP",    "KC_LEFT",  "KC_RIGHT",  "XXXXXXX",  "XXXXXXX",
+      "KC_LCTL",  "KC_PGDN",  "KC_P1",    "KC_P2",    "KC_P3",    "KC_PEQL",  "_______",  "_______",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
+      "_______",  "KC_P0",    "KC_PDOT",  "KC_PENT",  "_______",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______"
+    ],
+    [
+      "KC_ESC",  "KC_1",            "KC_2",    "KC_3",    "KC_4",    "KC_5",                        "KC_6",       "KC_7",       "KC_8",          "KC_9",          "KC_0",          "KC_BSPC",
+      "KC_T",    "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",                        "RCTL(KC_Y)",  "RCTL(KC_U)",  "RCTL(KC_I)",     "RCTL(KC_O)",     "RCTL(KC_P)",     "KC_PGUP",
+      "KC_G",    "KC_LSFT",         "KC_A",    "KC_S",    "KC_D",    "KC_F",                        "RCTL(KC_H)",  "RCTL(KC_J)",  "RCTL(KC_K)",     "RCTL(KC_L)",     "RCTL(KC_SCLN)",  "KC_PGDN",
+      "KC_B",    "KC_LCTRL",        "KC_Z",    "KC_X",    "KC_C",    "KC_V",  "_______",    "_______",  "RCTL(KC_N)",  "RCTL(KC_M)",  "RCTL(KC_COMM)",  "RCTL(KC_DOT)",   "RCTL(KC_SLSH)",  "KC_RIGHT",
+      "_______",         "XXXXXXX", "XXXXXXX", "KC_LALT", "KC_SPC",                      "KC_ENT",     "KC_PSCR",    "XXXXXXX",       "XXXXXXX",       "_______"
+    ]
+  ]
+}

--- a/docs/keymaps/s/sofle_rev1_flare576.json
+++ b/docs/keymaps/s/sofle_rev1_flare576.json
@@ -18,14 +18,14 @@
       "_______",  "KC_PSCR",  "XXXXXXX",  "KC_MS_U",  "KC_HOME",  "KC_PGUP",                      "KC_WH_U",  "KC_WH_D",  "KC_WH_L",  "KC_WH_R",   "XXXXXXX",  "ANY(COMP_1)",
       "_______",  "KC_SLCK",  "KC_MS_L",  "KC_MS_D",  "KC_MS_R",  "XXXXXXX",                      "KC_LEFT",  "KC_DOWN",  "KC_UP",    "KC_RIGHT",  "XXXXXXX",   "ANY(COMP_2)",
       "_______",  "KC_PAUS",  "XXXXXXX",  "XXXXXXX",  "KC_END",  "KC_PGDOWN", "_______",  "_______", "KC_BTN1",  "KC_BTN2",  "KC_LBRC",  "KC_RBRC",   "XXXXXXX",  "XXXXXXX",
-      "_______",  "_______",  "_______",  "_______",  "XXXXXXX",                      "_______",  "KC_BTN3",  "KC_BTN4",  "KC_BTN5",   "XXXXXXX"
+      "XXXXXXX",  "_______",  "_______",  "_______",  "XXXXXXX",                      "_______",  "KC_BTN3",  "KC_BTN4",  "KC_BTN5",   "XXXXXXX"
     ],
     [
       "LCTRL(KC_W)",  "LALT(KC_A)",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                          "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
       "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
       "_______",  "KC_EXLM",  "KC_AT",    "KC_HASH",  "KC_DLR",   "KC_PERC",                          "KC_CIRC",  "KC_AMPR",  "KC_ASTR",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
       "_______",  "ANY(,\\n)",  "ANY(LALT(a)\\n)",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______",    "_______",   "XXXXXXX",  "XXXXXXX",  "KC_LPRN",  "KC_RPRN",  "XXXXXXX",  "XXXXXXX",
-      "_______", "_______", "_______", "_______", "_______",                          "_______", "_______", "_______", "_______", "_______"
+      "XXXXXXX", "_______", "_______", "_______", "_______",                          "_______", "_______", "_______", "_______", "XXXXXXX"
     ],
     [
       "_______",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
@@ -39,14 +39,14 @@
       "KC_TAB",   "KC_END",   "KC_P7",    "KC_P8",    "KC_P9",    "KC_PPLS",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
       "KC_LSFT",  "KC_PGUP",  "KC_P4",    "KC_P5",    "KC_P6",    "KC_PCMM",                      "KC_DOWN",  "KC_UP",    "KC_LEFT",  "KC_RIGHT",  "XXXXXXX",  "XXXXXXX",
       "KC_LCTL",  "KC_PGDN",  "KC_P1",    "KC_P2",    "KC_P3",    "KC_PEQL",  "_______",  "_______",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
-      "_______",  "KC_P0",    "KC_PDOT",  "KC_PENT",  "_______",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______"
+      "TO(5)",    "KC_P0",    "KC_PDOT",  "KC_PENT",  "_______",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______"
     ],
     [
       "KC_ESC",  "KC_1",            "KC_2",    "KC_3",    "KC_4",    "KC_5",                        "KC_6",       "KC_7",       "KC_8",          "KC_9",          "KC_0",          "KC_BSPC",
       "KC_T",    "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",                        "RCTL(KC_Y)",  "RCTL(KC_U)",  "RCTL(KC_I)",     "RCTL(KC_O)",     "RCTL(KC_P)",     "KC_PGUP",
       "KC_G",    "KC_LSFT",         "KC_A",    "KC_S",    "KC_D",    "KC_F",                        "RCTL(KC_H)",  "RCTL(KC_J)",  "RCTL(KC_K)",     "RCTL(KC_L)",     "RCTL(KC_SCLN)",  "KC_PGDN",
       "KC_B",    "KC_LCTRL",        "KC_Z",    "KC_X",    "KC_C",    "KC_V",  "_______",    "_______",  "RCTL(KC_N)",  "RCTL(KC_M)",  "RCTL(KC_COMM)",  "RCTL(KC_DOT)",   "RCTL(KC_SLSH)",  "KC_RIGHT",
-      "_______",         "XXXXXXX", "XXXXXXX", "KC_LALT", "KC_SPC",                      "KC_ENT",     "KC_PSCR",    "XXXXXXX",       "XXXXXXX",       "_______"
+      "_______",         "XXXXXXX", "XXXXXXX", "KC_LALT", "KC_SPC",                      "KC_ENT",     "KC_PSCR",    "XXXXXXX",       "XXXXXXX",       "TO(4)"
     ]
   ]
 }

--- a/public/keymaps/s/sofle_rev1_flare576.json
+++ b/public/keymaps/s/sofle_rev1_flare576.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "notes": "Instead of up/down, uses layer toggles on ends, incorporates Mouse/Game layers.",
+  "keyboard": "sofle/rev1",
+  "keymap": "Flare576",
+  "commit": "1646c0f26cfa21a7023d404008e4d0aa4917193d",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "LT(3,KC_GRV)", "KC_1",      "KC_2",     "KC_3",    "KC_4",             "KC_5",                   "KC_6",               "KC_7",    "KC_8",          "KC_9",   "KC_0",     "KC_MINS",
+      "LALT_T(KC_TAB)",   "KC_Q",      "KC_W",     "KC_E",    "KC_R",             "KC_T",                   "KC_Y",               "KC_U",    "KC_I",          "KC_O",   "KC_P",     "KC_BSLS",
+      "KC_LSFT",          "KC_A",      "KC_S",     "KC_D",    "KC_F",             "KC_G",                   "KC_H",               "KC_J",    "KC_K",          "KC_L",   "KC_SCLN",  "KC_QUOT",
+      "KC_LCTRL",         "KC_Z",      "KC_X",     "KC_C",    "KC_V",             "KC_B", "KC_MPLY", "KC_HOME", "KC_N",               "KC_M",    "KC_COMM",       "KC_DOT", "KC_SLSH",  "RSFT_T(KC_PLUS)",
+      "TG(5)", "KC_LALT",  "KC_LGUI", "LT(2,KC_ESC)", "KC_SPC",                 "LT(1,KC_ENT)",  "KC_BSPC", "LALT(KC_LSFT)", "KC_DEL", "TG(4)"
+    ],
+    [
+      "KC_F1",    "KC_F2",    "KC_F3",    "KC_F4",    "KC_F5",    "KC_F6",                        "KC_F7",    "KC_F8",    "KC_F9",    "KC_F10",    "KC_F11",   "KC_F12",
+      "_______",  "KC_PSCR",  "XXXXXXX",  "KC_MS_U",  "KC_HOME",  "KC_PGUP",                      "KC_WH_U",  "KC_WH_D",  "KC_WH_L",  "KC_WH_R",   "XXXXXXX",  "ANY(COMP_1)",
+      "_______",  "KC_SLCK",  "KC_MS_L",  "KC_MS_D",  "KC_MS_R",  "XXXXXXX",                      "KC_LEFT",  "KC_DOWN",  "KC_UP",    "KC_RIGHT",  "XXXXXXX",   "ANY(COMP_2)",
+      "_______",  "KC_PAUS",  "XXXXXXX",  "XXXXXXX",  "KC_END",  "KC_PGDOWN", "_______",  "_______", "KC_BTN1",  "KC_BTN2",  "KC_LBRC",  "KC_RBRC",   "XXXXXXX",  "XXXXXXX",
+      "_______",  "_______",  "_______",  "_______",  "XXXXXXX",                      "_______",  "KC_BTN3",  "KC_BTN4",  "KC_BTN5",   "XXXXXXX"
+    ],
+    [
+      "LCTRL(KC_W)",  "LALT(KC_A)",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                          "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "_______",  "KC_EXLM",  "KC_AT",    "KC_HASH",  "KC_DLR",   "KC_PERC",                          "KC_CIRC",  "KC_AMPR",  "KC_ASTR",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "_______",  "ANY(,\\n)",  "ANY(LALT(a)\\n)",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______",    "_______",   "XXXXXXX",  "XXXXXXX",  "KC_LPRN",  "KC_RPRN",  "XXXXXXX",  "XXXXXXX",
+      "_______", "_______", "_______", "_______", "_______",                          "_______", "_______", "_______", "_______", "_______"
+    ],
+    [
+      "_______",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "KC_VOLU",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "KC_MPRV",  "KC_MPLY",  "KC_MNXT",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "_______",  "_______", "KC_VOLD",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
+      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX", "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "RESET"
+    ],
+    [
+      "KC_ESC",   "KC_HOME",  "KC_NLCK",  "KC_PSLS",  "KC_PAST",  "KC_PMNS",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
+      "KC_TAB",   "KC_END",   "KC_P7",    "KC_P8",    "KC_P9",    "KC_PPLS",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
+      "KC_LSFT",  "KC_PGUP",  "KC_P4",    "KC_P5",    "KC_P6",    "KC_PCMM",                      "KC_DOWN",  "KC_UP",    "KC_LEFT",  "KC_RIGHT",  "XXXXXXX",  "XXXXXXX",
+      "KC_LCTL",  "KC_PGDN",  "KC_P1",    "KC_P2",    "KC_P3",    "KC_PEQL",  "_______",  "_______",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
+      "_______",  "KC_P0",    "KC_PDOT",  "KC_PENT",  "_______",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______"
+    ],
+    [
+      "KC_ESC",  "KC_1",            "KC_2",    "KC_3",    "KC_4",    "KC_5",                        "KC_6",       "KC_7",       "KC_8",          "KC_9",          "KC_0",          "KC_BSPC",
+      "KC_T",    "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",                        "RCTL(KC_Y)",  "RCTL(KC_U)",  "RCTL(KC_I)",     "RCTL(KC_O)",     "RCTL(KC_P)",     "KC_PGUP",
+      "KC_G",    "KC_LSFT",         "KC_A",    "KC_S",    "KC_D",    "KC_F",                        "RCTL(KC_H)",  "RCTL(KC_J)",  "RCTL(KC_K)",     "RCTL(KC_L)",     "RCTL(KC_SCLN)",  "KC_PGDN",
+      "KC_B",    "KC_LCTRL",        "KC_Z",    "KC_X",    "KC_C",    "KC_V",  "_______",    "_______",  "RCTL(KC_N)",  "RCTL(KC_M)",  "RCTL(KC_COMM)",  "RCTL(KC_DOT)",   "RCTL(KC_SLSH)",  "KC_RIGHT",
+      "_______",         "XXXXXXX", "XXXXXXX", "KC_LALT", "KC_SPC",                      "KC_ENT",     "KC_PSCR",    "XXXXXXX",       "XXXXXXX",       "_______"
+    ]
+  ]
+}

--- a/public/keymaps/s/sofle_rev1_flare576.json
+++ b/public/keymaps/s/sofle_rev1_flare576.json
@@ -18,14 +18,14 @@
       "_______",  "KC_PSCR",  "XXXXXXX",  "KC_MS_U",  "KC_HOME",  "KC_PGUP",                      "KC_WH_U",  "KC_WH_D",  "KC_WH_L",  "KC_WH_R",   "XXXXXXX",  "ANY(COMP_1)",
       "_______",  "KC_SLCK",  "KC_MS_L",  "KC_MS_D",  "KC_MS_R",  "XXXXXXX",                      "KC_LEFT",  "KC_DOWN",  "KC_UP",    "KC_RIGHT",  "XXXXXXX",   "ANY(COMP_2)",
       "_______",  "KC_PAUS",  "XXXXXXX",  "XXXXXXX",  "KC_END",  "KC_PGDOWN", "_______",  "_______", "KC_BTN1",  "KC_BTN2",  "KC_LBRC",  "KC_RBRC",   "XXXXXXX",  "XXXXXXX",
-      "_______",  "_______",  "_______",  "_______",  "XXXXXXX",                      "_______",  "KC_BTN3",  "KC_BTN4",  "KC_BTN5",   "XXXXXXX"
+      "XXXXXXX",  "_______",  "_______",  "_______",  "XXXXXXX",                      "_______",  "KC_BTN3",  "KC_BTN4",  "KC_BTN5",   "XXXXXXX"
     ],
     [
       "LCTRL(KC_W)",  "LALT(KC_A)",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                          "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
       "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
       "_______",  "KC_EXLM",  "KC_AT",    "KC_HASH",  "KC_DLR",   "KC_PERC",                          "KC_CIRC",  "KC_AMPR",  "KC_ASTR",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
       "_______",  "ANY(,\\n)",  "ANY(LALT(a)\\n)",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______",    "_______",   "XXXXXXX",  "XXXXXXX",  "KC_LPRN",  "KC_RPRN",  "XXXXXXX",  "XXXXXXX",
-      "_______", "_______", "_______", "_______", "_______",                          "_______", "_______", "_______", "_______", "_______"
+      "XXXXXXX", "_______", "_______", "_______", "_______",                          "_______", "_______", "_______", "_______", "XXXXXXX"
     ],
     [
       "_______",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",                     "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",
@@ -39,14 +39,14 @@
       "KC_TAB",   "KC_END",   "KC_P7",    "KC_P8",    "KC_P9",    "KC_PPLS",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
       "KC_LSFT",  "KC_PGUP",  "KC_P4",    "KC_P5",    "KC_P6",    "KC_PCMM",                      "KC_DOWN",  "KC_UP",    "KC_LEFT",  "KC_RIGHT",  "XXXXXXX",  "XXXXXXX",
       "KC_LCTL",  "KC_PGDN",  "KC_P1",    "KC_P2",    "KC_P3",    "KC_PEQL",  "_______",  "_______",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "XXXXXXX",  "XXXXXXX",
-      "_______",  "KC_P0",    "KC_PDOT",  "KC_PENT",  "_______",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______"
+      "TO(5)",    "KC_P0",    "KC_PDOT",  "KC_PENT",  "_______",                      "XXXXXXX",  "XXXXXXX",  "XXXXXXX",  "XXXXXXX",   "_______"
     ],
     [
       "KC_ESC",  "KC_1",            "KC_2",    "KC_3",    "KC_4",    "KC_5",                        "KC_6",       "KC_7",       "KC_8",          "KC_9",          "KC_0",          "KC_BSPC",
       "KC_T",    "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",                        "RCTL(KC_Y)",  "RCTL(KC_U)",  "RCTL(KC_I)",     "RCTL(KC_O)",     "RCTL(KC_P)",     "KC_PGUP",
       "KC_G",    "KC_LSFT",         "KC_A",    "KC_S",    "KC_D",    "KC_F",                        "RCTL(KC_H)",  "RCTL(KC_J)",  "RCTL(KC_K)",     "RCTL(KC_L)",     "RCTL(KC_SCLN)",  "KC_PGDN",
       "KC_B",    "KC_LCTRL",        "KC_Z",    "KC_X",    "KC_C",    "KC_V",  "_______",    "_______",  "RCTL(KC_N)",  "RCTL(KC_M)",  "RCTL(KC_COMM)",  "RCTL(KC_DOT)",   "RCTL(KC_SLSH)",  "KC_RIGHT",
-      "_______",         "XXXXXXX", "XXXXXXX", "KC_LALT", "KC_SPC",                      "KC_ENT",     "KC_PSCR",    "XXXXXXX",       "XXXXXXX",       "_______"
+      "_______",         "XXXXXXX", "XXXXXXX", "KC_LALT", "KC_SPC",                      "KC_ENT",     "KC_PSCR",    "XXXXXXX",       "XXXXXXX",       "TO(4)"
     ]
   ]
 }


### PR DESCRIPTION
## Description

Uses outside bottom buttons for swapping between "Num Pad" and "Game" layouts, and various LT keys for quick access to mouse and symbols. Also focuses on the `,` and `.` keys for brace characters:

| Combo | `,`/`.` |
|-------|-----|
| Shift | `<`/`>` |
| Mouse | `[`/`]` |
| Shift + Mouse | `{`/`}` |
| Esc | `(`/`)` |

Feel free to visit https://github.com/Flare576/sofle for more information

Ties to https://github.com/qmk/qmk_firmware/pull/13723