### PR TITLE
Add default keymap for Runes Vaengr

### DIFF
--- a/public/keymaps/r/runes_vaengr_default.json
+++ b/public/keymaps/r/runes_vaengr_default.json
@@ -1,0 +1,36 @@
+{
+    "keyboard": "runes/vaengr",
+    "keymap": "default",
+    "commit": "02ac0f89c4665f5fc6e57559a8c49d363117fbc0",
+    "layout": "LAYOUT",
+    "layers": [
+        [
+            "KC_ESC", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_BSPC",
+            "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_DEL",
+            "KC_CAPS", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",
+            "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_UP", "KC_ENT",
+            "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_GRV", "MO(1)", "KC_SPC", "MO(2)", "KC_SLSH", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+        ],
+        [
+            "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12",
+            "KC_TRNS", "KC_PGUP", "KC_HOME", "KC_DEL", "KC_BSPC", "KC_TRNS", "KC_TRNS", "KC_UNDS", "KC_PLUS", "KC_MINS", "KC_EQL", "KC_BSLS",
+            "KC_TRNS", "KC_PGDN", "KC_END", "KC_ENT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LCBR", "KC_RCBR", "KC_LBRC", "KC_RBRC", "KC_PIPE",
+            "KC_TRNS", "KC_PSCR", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_MPLY", "KC_MSTP", "KC_MPRV", "KC_MNXT", "KC_SLCK", "KC_PAUS", "KC_TRNS",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(3)", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+        ],
+        [
+            "KC_TRNS", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_TRNS", "KC_NLCK", "KC_P7", "KC_P8", "KC_P9", "KC_TRNS",
+            "KC_TRNS", "KC_F6", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_TRNS", "KC_PMNS", "KC_P4", "KC_P5", "KC_P6", "KC_TRNS",
+            "KC_TRNS", "KC_F11", "KC_F12", "KC_F13", "KC_F14", "KC_F15", "KC_TRNS", "KC_PAST", "KC_P1", "KC_P2", "KC_P3", "KC_PPLS",
+            "KC_TRNS", "KC_F16", "KC_F17", "KC_F18", "KC_F19", "KC_F20", "KC_TRNS", "KC_PSLS", "KC_P0", "KC_PDOT", "KC_PEQL", "KC_PENT",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(3)", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+        ],
+        [
+            "KC_SLEP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RESET",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "RGB_MODE_FORWARD", "RGB_TOG", "RGB_HUI", "RGB_SAI", "RGB_VAI", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+        ]
+    ]
+}


### PR DESCRIPTION
Add default keymap for Runes Vaengr

## Description

Add default keymap for Runes Vaengr keyboard that added with this PR: https://github.com/qmk/qmk_firmware/pull/13945/