### PR TITLE
Update Kyria keymap according to qmk/qmk_firmware#13511

### DIFF
--- a/public/keymaps/s/splitkb_kyria_rev1_default.json
+++ b/public/keymaps/s/splitkb_kyria_rev1_default.json
@@ -5,28 +5,46 @@
   "layout": "LAYOUT",
   "layers": [
     [
-      "LT(2,KC_ESC)",         "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                                                                                "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_PIPE",
-      "MT(MOD_LCTL,KC_BSPC)", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                                                                                "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
-      "KC_LSFT",              "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",                "KC_LSFT",      "KC_LSFT",      "KC_LSFT",      "KC_LSFT",      "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_MINS",
-                                                    "KC_LGUI", "KC_DEL",  "MT(MOD_LALT,KC_ENT)", "LT(1,KC_SPC)", "LT(2,KC_ESC)", "LT(1,KC_ENT)", "LT(2,KC_SPC)", "KC_TAB",  "KC_BSPC", "KC_RALT"
+     "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_E"  ,   "KC_R" ,   "KC_T" ,                                        "KC_Y",   "KC_U" ,  "KC_I" ,   "KC_O" ,  "KC_P" , "KC_BSPC",
+     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","MT(MOD_RCTL, KC_QUOTE)",
+     "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_V" ,   "KC_B" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_N",   "KC_M" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
+                                      "MO(6)" , "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
-      "KC_TRNS", "KC_EXLM", "KC_AT",   "KC_LCBR", "KC_RCBR", "KC_PIPE",                                             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_BSLS",
-      "KC_TRNS", "KC_HASH", "KC_DLR",  "KC_LPRN", "KC_RPRN", "KC_GRV",                                              "KC_PLUS", "KC_MINS", "KC_SLSH", "KC_ASTR", "KC_PERC", "KC_QUOT",
-      "KC_TRNS", "KC_PERC", "KC_CIRC", "KC_LBRC", "KC_RBRC", "KC_TILD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_AMPR", "KC_EQL",  "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_MINS",
-                                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_SCLN", "KC_EQL",  "KC_EQL",  "KC_SCLN", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+     "KC_TAB"  ,"KC_QUOTE","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
+     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "MT(MOD_RCTL, KC_MINUS)",
+     "KC_LSFT" ,"KC_SCLN", "KC_Q"   ,  "KC_J"  ,   "KC_K" ,   "KC_X" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_B",   "KC_M" ,  "KC_W" ,   "KC_V" ,  "KC_Z" , "KC_RSFT",
+                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
-      "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                                                "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_VOLU",                                             "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "KC_TRNS", "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MUTE", "KC_VOLD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MS_L", "KC_MS_D", "KC_MS_U", "KC_MS_R", "KC_TRNS", "KC_TRNS",
-                                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+     "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_F"  ,   "KC_P" ,   "KC_B" ,                                        "KC_J",   "KC_L" ,  "KC_U" ,   "KC_Y" ,"KC_SCLN", "KC_BSPC",
+     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "MT(MOD_RCTL, KC_QUOTE)",
+     "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_D" ,   "KC_V" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_K",   "KC_H" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
+                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
-      "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",                                                "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_TRNS",
-      "KC_TRNS", "RGB_TOG", "RGB_SAI", "RGB_HUI", "RGB_VAI", "RGB_MOD",                                              "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_F11",  "KC_F12",  "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "RGB_SAD", "RGB_HUD", "RGB_VAD", "RGB_RMOD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
-                                       "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+      "_______", "_______", "_______", "_______", "_______", "_______",                                     "KC_PGUP", "KC_HOME", "KC_UP",   "KC_END",  "KC_VOLU", "KC_DEL",
+      "_______", "KC_LGUI", "KC_LALT", "KC_LCTL", "KC_LSFT", "_______",                                     "KC_PGDN", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_VOLD", "KC_INS",
+      "_______", "_______", "_______", "_______", "_______", "_______", "_______", "KC_SLCK", "_______", "_______","KC_PAUSE", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_PSCR",
+                                 "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______"
+    ],
+    [
+     "KC_GRV" ,   "KC_1" ,   "KC_2" ,   "KC_3" ,   "KC_4" ,   "KC_5" ,                                       "KC_6" ,   "KC_7" ,   "KC_8" ,   "KC_9" ,   "KC_0" , "KC_EQL" ,
+     "KC_TILD" , "KC_EXLM",  "KC_AT" , "KC_HASH",  "KC_DLR", "KC_PERC",                                     "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_PLUS",
+     "KC_PIPE" , "KC_BSLS", "KC_COLN", "KC_SCLN", "KC_MINS", "KC_LBRC", "KC_LCBR", "_______", "_______", "KC_RCBR", "KC_RBRC", "KC_UNDS", "KC_COMM",  "KC_DOT", "KC_SLSH", "KC_QUES",
+                                 "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______"
+    ],
+    [
+      "_______",  "KC_F9" ,  "KC_F10",  "KC_F11",  "KC_F12", "_______",                                     "_______", "_______", "_______", "_______", "_______", "_______",
+      "_______",  "KC_F5" ,  "KC_F6" ,  "KC_F7" ,  "KC_F8" , "_______",                                     "_______", "KC_RSFT", "KC_RCTL", "KC_LALT", "KC_RGUI", "_______",
+      "_______",  "KC_F1" ,  "KC_F2" ,  "KC_F3" ,  "KC_F4" , "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______",
+                                 "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______"
+    ],
+    [
+      "_______", "_______", "_______", "DF(0)" , "_______", "_______",                                    "_______", "_______", "_______", "_______",  "_______", "_______",
+      "_______", "_______", "_______", "DF(1)" , "_______", "_______",                                    "RGB_TOG", "RGB_SAI", "RGB_HUI", "RGB_VAI",  "RGB_MOD", "_______",
+      "_______", "_______", "_______", "DF(2)" , "_______", "_______","_______", "_______", "_______", "_______", "_______", "RGB_SAD", "RGB_HUD", "RGB_VAD", "RGB_RMOD", "_______",
+                                 "_______", "_______", "_______","_______", "_______", "_______", "_______", "_______", "_______", "_______"
     ]
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

The default keymap for the splitkb/kyria keyboard has been changed in https://github.com/qmk/qmk_firmware/pull/13511 and in https://github.com/qmk/qmk_firmware/pull/14080. This PR brings the configurator keymap in sync with the keymap files in the core QMK firmware repository.

The commit points to the develop merge commit which is correct so I left it as is.

I hope that the very long mod taps breaking the pretty alignment of the keymap isn't a problem.
