### PR TITLE
fixed incorrect display while pressing F13

### DIFF
--- a/src/store/modules/tester/codeToPos.js
+++ b/src/store/modules/tester/codeToPos.js
@@ -12,7 +12,7 @@ const ROW1 = [
   'F10',
   'F11',
   'F12',
-  'F13',
+  'PrintScreen',
   'ScrollLock',
   'Pause'
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
The displayed result was not correct while pressed F13 under keyboard tester mode.

![(C0K5PP3VFWM1`0J1_ZS%LT](https://user-images.githubusercontent.com/720475/135197260-f313ac49-422c-4d8c-a750-426b68c5ad40.png)


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
it should be:

![U8K` 8`3T8_HE$9J{GDWURW](https://user-images.githubusercontent.com/720475/135197439-38936529-8ed1-4e50-9101-af2d1e5aee22.png)

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
