### PR TITLE
Update handwired_split89_default.json

### DIFF
--- a/public/keymaps/h/handwired_split89_default.json
+++ b/public/keymaps/h/handwired_split89_default.json
@@ -9,7 +9,7 @@
       	   "KC_TAB",      "KC_Q",      "KC_W",      "KC_E",      "KC_R",     "KC_T",      "KC_Y",      "KC_U",      "KC_I",      "KC_O",      "KC_P",      "KC_LBRC",     "KC_RBRC",     "KC_BSLS",      "KC_DEL",      "KC_END",     "KC_PGDN",
            "KC_CAPS",     "KC_A",      "KC_S",      "KC_D",      "KC_F",     "KC_G",      "KC_H",      "KC_J",      "KC_K",      "KC_L",      "KC_SCLN",   "KC_QUOT",     "KC_ENT",
            "KC_LSFT",     "KC_Z",      "KC_X",      "KC_C",      "KC_V",     "KC_B",      "KC_N",      "KC_M",      "KC_COMM",   "KC_DOT",    "KC_SLSH",          "KC_RSFT",                                            "KC_UP",
-	   "KC_LSFT",     "MO(1)",     "KC_LGUI",   "KC_LALT",               "KC_SPC",    "KC_SPC",                              "KC_RALT",   "KC_RGUI",   "KC_APP",    "KC_RCTL",                          "KC_LEFT",  "KC_DOWN",     "KC_RGHT"
+	   "KC_LCTL",     "MO(1)",     "KC_LGUI",   "KC_LALT",               "KC_SPC",    "KC_SPC",                              "KC_RALT",   "KC_RGUI",   "KC_APP",    "KC_RCTL",                          "KC_LEFT",  "KC_DOWN",     "KC_RGHT"
     ],
     [
            "KC_NO",      "KC_NO",      "KC_NO",     "KC_NO",     "KC_NO",    "KC_NO",     "KC_NO",     "KC_NO",     "KC_NO",     "KC_NO",     "KC_NO",                    "KC_NO",        "KC_NO",       "KC_NO",       "KC_NO",       "KC_NO",


### PR DESCRIPTION
Left control key map updated to use control instead of shift.   (DOH!)

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->


<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
