### PR TITLE
Fix print layout for larger keyboards

### DIFF
--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -505,9 +505,6 @@ html[data-theme='dark'] {
       a {
         color: #39c;
       }
-      .layer-output {
-        max-width: 7.2in;
-      }
       .print-keymap {
         background-color: #ffffff;
         border-color: #ffffff;


### PR DESCRIPTION
## Description

Bug was occurring on Windows and macOS in both Firefox and Chrome. The issue was setting parent's max-width to value lower than keyboard layout width. Removing those 3 lines resolves issue.

Fixed #950