### PR TITLE
Stop service fonts via Google Fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "test:cypress:ci": "start-server-and-test serve http://localhost:8080 test:cypress"
   },
   "dependencies": {
+    "@fontsource/montserrat": "^4.5.1",
+    "@fontsource/roboto": "^4.5.1",
+    "@fontsource/roboto-mono": "^4.5.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.12",
     "@fortawesome/free-brands-svg-icons": "^5.6.3",
     "@fortawesome/free-solid-svg-icons": "^5.6.3",
@@ -60,8 +63,8 @@
     "sass-loader": "8",
     "serialize-javascript": "^3.1.0",
     "start-server-and-test": "^1.10.0",
-    "vue-loader": "^15.7.0",
     "tar": "^6.1.9",
+    "vue-loader": "^15.7.0",
     "vue-template-compiler": "^2.6.11"
   },
   "resolutions": {

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -317,7 +317,7 @@ export default {
 };
 </script>
 <style lang="scss">
-@import url('https://fonts.googleapis.com/css?family=Montserrat');
+@import '~@fontsource/montserrat/400.css';
 @import '../scss/gmk-abs';
 @import '../scss/sp-abs';
 @import '../scss/sp-pbt';

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -8,8 +8,9 @@ TO REFACTOR: import of style.css
 */
 
 /* prevent draggable elements from being selected */
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono');
-@import url('https://fonts.googleapis.com/css?family=Roboto');
+@import '~@fontsource/roboto-mono/400.css';
+@import '~@fontsource/roboto/400.css';
+@import '~@fontsource/roboto/700.css';
 
 [draggable] {
   -moz-user-select: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,6 +1096,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fontsource/montserrat@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@fontsource/montserrat/-/montserrat-4.5.1.tgz#64a33ffdb77bbc63484c0321710bed272cc5b16f"
+  integrity sha512-xdMkzsnFlzDt5Vj9+AWuUp4Vd9F3hYN2I0GTZZYscWN/bQ20wVOGtdWLO8Okfv7SZ9t/z39/EayAAt+f/8tAvw==
+
+"@fontsource/roboto-mono@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto-mono/-/roboto-mono-4.5.0.tgz#27e44fbb1d86a9ef14501493a37eef1d73e60d02"
+  integrity sha512-/6Gm6fJjBHZiFNyvzIKGJkVuyifoc1aoTel+pkzdhxNh7yNhFyokCoChdbbqZEpGKpqs5uld74G5TJthUVFyjw==
+
+"@fontsource/roboto@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.5.1.tgz#63f7b783f755d8f6727eb60198627e7e1be3ac20"
+  integrity sha512-3mhfL+eNPG/woMNqwD/OHaW5qMpeGEBsDwzmhFmjB1yUV+M+M9P0NhP/AyHvnGz3DrqkvZ7CPzNMa+UkVLeELg==
+
 "@fortawesome/fontawesome-common-types@^0.2.32", "@fortawesome/fontawesome-common-types@^0.2.36":
   version "0.2.36"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"


### PR DESCRIPTION
Switch from serving fonts from Google Fonts to bundling them with the
app at build time.

This has a few consequences:

- Improved privacy for users: no leaking to Google details about people
  visiting configurator.
- Google Fonts are not versioned and may be updated at any time, which
  can result in breakage for users.
- Google Fonts vary at any time, so improved security like SRI or
  cross-domain hardening are not possible without breakage.
- This makes configurator load properly offline once built, which is
  super handy for those with spotty or metered connections.
