### PR TITLE
Add Splitography to the steno keyboards

### DIFF
--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -9,7 +9,7 @@ import {
 import { getPreferredLayout, getExclusionList } from '@/util';
 import { localStorageSet, CONSTS } from '@/store/localStorage';
 
-const steno_keyboards = ['gergo', 'georgi'];
+const steno_keyboards = ['gergo', 'georgi', 'splitography'];
 
 const actions = {
   /**


### PR DESCRIPTION
## Description

The [Splitography steno keyboard](https://softhruf.love/products/soft-hruf-erl) was [recently added to QMK](https://github.com/qmk/qmk_firmware/pull/15133).
This PR simply adds it to the list of steno keyboards.