### PR TITLE
add default keymap: mntre

### DIFF
--- a/public/keymaps/m/mntre_default.json
+++ b/public/keymaps/m/mntre_default.json
@@ -1,0 +1,24 @@
+{
+  "keyboard": "mntre",
+  "keymap": "default",
+  "commit": "51be57c28709f60ce8c196de48d302d67abe6a4d",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",  "KC_F4",   "KC_F5",   "KC_F6",  "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "MO(1)",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",   "KC_4",    "KC_5",    "KC_6",   "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",   "KC_R",    "KC_T",    "KC_Y",   "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
+      "KC_LCTL", "KC_APP",  "KC_A",    "KC_S",   "KC_D",    "KC_F",    "KC_G",   "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",
+      "KC_LSFT", "KC_DEL",  "KC_Z",    "KC_X",   "KC_C",    "KC_V",    "KC_B",   "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_UP",   "KC_RSFT",
+      "KC_RGUI", "KC_LGUI", "KC_RCTL", "KC_SPC", "KC_LALT", "KC_RALT", "KC_SPC", "KC_PGUP", "KC_PGDN", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_NO",   "BL_DEC",  "BL_INC",  "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_TRNS",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RESET",  "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO"
+    ]
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add default layout for MNT Reform USB standalone keyboard ("mntre" in QMK)

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
