### PR TITLE
Add playlist to QMK Tutorial wizard

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -59,7 +59,7 @@
       class="embedded-tutorial"
       width="560"
       height="315"
-      src="https://www.youtube.com/embed/-imgglzDMdY"
+      src="https://www.youtube.com/embed/-imgglzDMdY?list=PLZlceRZZjRugJFL-vnenYnDrbMc6wu_e_"
       frameborder="0"
       sandbox="allow-scripts allow-same-origin"
       allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
## Description
Currently, when you enable the wizard, it brings up a single video. While this is useful, I think it might be useful for users to see that there's a playlist of other related tutorials as well, so I have edited the embed link to include the playlist.