### PR TITLE
Update datyl manuform 6x6 after adding blackpill

### DIFF
--- a/public/keymaps/h/handwired_dactyl_manuform_6x6_blackpill_f411_default.json
+++ b/public/keymaps/h/handwired_dactyl_manuform_6x6_blackpill_f411_default.json
@@ -1,0 +1,41 @@
+{
+  "keyboard": "handwired/dactyl_manuform/6x6/blackpill_f411",
+  "keymap": "default",
+  "commit": "d7eb09949d426af891dd9cf85ad789285422490e",
+  "layout": "LAYOUT_6x6",
+  "layers": [
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",                                               "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_ESC",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                                                "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                                                "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_MINS",
+      "KC_LSFT", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                                                "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LCTL", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",                                                "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_BSLS",
+                            "KC_LBRC", "KC_RBRC",                                                                                         "KC_PLUS", "KC_EQL",
+                                                  "MO(2)",   "KC_SPC",                                              "KC_ENT",  "MO(1)",
+                                                                        "KC_TAB",  "KC_HOME", "KC_END",  "KC_DEL",
+                                                                        "KC_BSPC", "KC_GRV",  "KC_LGUI", "KC_LALT"
+    ],
+    [
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",                                               "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
+      "KC_TILD", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC",                                             "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_DEL",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LBRC",                                             "KC_RBRC", "KC_P7",   "KC_P8",   "KC_P9",   "KC_TRNS", "KC_PLUS",
+      "KC_TRNS", "KC_HOME", "KC_PGUP", "KC_PGDN", "KC_END",  "KC_LPRN",                                             "KC_RPRN", "KC_P4",   "KC_P5",   "KC_P6",   "KC_MINS", "KC_PIPE",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                                             "KC_TRNS", "KC_P1",   "KC_P2",   "KC_P3",   "KC_EQL",  "KC_UNDS",
+                            "KC_TRNS", "KC_PSCR",                                                                                         "KC_TRNS", "KC_P0",
+                                                  "KC_TRNS", "KC_TRNS",                                             "KC_TRNS", "KC_TRNS",
+                                                                        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+                                                                        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_F12",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",                                               "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_LBRC",                                             "KC_RBRC", "KC_TRNS", "KC_NLCK", "KC_INS",  "KC_SLCK", "KC_MUTE",
+      "KC_TRNS", "KC_LEFT", "KC_UP",   "KC_DOWN", "KC_RGHT", "KC_LPRN",                                             "KC_RPRN", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_TRNS", "KC_VOLU",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                                             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_VOLD",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                                             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+                            "KC_TRNS", "KC_TRNS",                                                                                         "KC_EQL",  "KC_TRNS",
+                                                  "KC_TRNS", "KC_TRNS",                                             "KC_TRNS", "KC_TRNS",
+                                                                        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+                                                                        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/h/handwired_dactyl_manuform_6x6_promicro_default.json
+++ b/public/keymaps/h/handwired_dactyl_manuform_6x6_promicro_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "handwired/dactyl_manuform/6x6",
+  "keyboard": "handwired/dactyl_manuform/6x6/promicro",
   "keymap": "default",
-  "commit": "468f7054558153cbf7f7ece3cf8775e1f3d28fe9",
+  "commit": "d7eb09949d426af891dd9cf85ad789285422490e",
   "layout": "LAYOUT_6x6",
   "layers": [
     [


### PR DESCRIPTION
This is simple PR which restore loading default keymaps for dactyl manuform 6x6

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Recently I updated dactyl manuform 6x6. This broke loading default keymap feature in configurator.
I fixed this and also tested this out, buy building img and run configurator locally.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
