### PR TITLE
Add s_ol/0xc_pad default layout

### DIFF
--- a/public/keymaps/s/s_ol_0xc_pad_default.json
+++ b/public/keymaps/s/s_ol_0xc_pad_default.json
@@ -1,0 +1,9 @@
+{
+  "keyboard": "s_ol/0xc_pad",
+  "keymap": "default",
+  "commit": "8cc86490aac59a93ece62229cc93097a17420fa5",
+  "layout": "LAYOUT",
+  "layers": [
+    [ "RGB_RMOD", "RGB_MOD", "KC_CUT" , "KC_COPY", "KC_PSTE", "KC_PGUP", "KC_PGDN", "KC_VOLU", "KC_VOLD", "KC_1" , "KC_2" , "KC_3" ]
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is the default layout for the 0xC.pad macropad.
See also the keyboard PR qmk/qmk_firmware#16057.


<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
