### PR TITLE
Add handwired/macroboard default keymap

### DIFF
--- a/public/keymaps/h/handwired_macroboard_layout_ortho_5x6_default.json
+++ b/public/keymaps/h/handwired_macroboard_layout_ortho_5x6_default.json
@@ -1,0 +1,14 @@
+{
+  "keyboard": "handwired/macroboard",
+  "keymap": "handwired_macroboard_layout_ortho_5x6_mine",
+  "layout": "LAYOUT_ortho_5x6",
+  "layers": [
+    [
+      "KC_GRV", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5",
+      "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T",
+      "KC_ESC", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G",
+      "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B",
+      "KC_LCTL", "KC_LGUI", "RGB_TOG", "KC_LALT", "RESET", "KC_SPC"
+    ]
+  ]
+}


### PR DESCRIPTION
Adding default keymap for [newly added](https://github.com/qmk/qmk_firmware/pull/16219#event-6013877843) handwired/macroboard keyboard.
