### PR TITLE
`the_uni`: remove steno keycodes from default keymap

### DIFF
--- a/public/keymaps/t/the_uni_pro_micro_default.json
+++ b/public/keymaps/t/the_uni_pro_micro_default.json
@@ -5,9 +5,9 @@
   "layout": "LAYOUT",
   "layers": [
     [
-      "STN_S1",  "STN_TL",  "STN_PL",  "STN_HL",  "STN_ST1", "STN_ST3", "STN_FR",  "STN_PR",  "STN_LR",  "STN_TR",  "STN_DR",
-      "STN_S2",  "STN_KL",  "STN_WL",  "STN_RL",  "STN_ST2", "STN_ST4", "STN_RR",  "STN_BR",  "STN_GR",  "STN_SR",  "STN_ZR",
-                            "STN_N1",  "STN_A",   "STN_O",   "STN_E",   "STN_U",   "STN_N2"
+      "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T",             "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P",    "KC_LBRC",
+      "KC_A", "KC_S", "KC_D", "KC_F", "KC_G",             "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",
+                      "KC_1", "KC_C", "KC_V",             "KC_N", "KC_M", "KC_2"
     ]
   ]
 }

--- a/public/keymaps/t/the_uni_usb_c_default.json
+++ b/public/keymaps/t/the_uni_usb_c_default.json
@@ -5,9 +5,9 @@
   "layout": "LAYOUT",
   "layers": [
     [
-      "STN_S1",  "STN_TL",  "STN_PL",  "STN_HL",  "STN_ST1", "STN_ST3", "STN_FR",  "STN_PR",  "STN_LR",  "STN_TR",  "STN_DR",
-      "STN_S2",  "STN_KL",  "STN_WL",  "STN_RL",  "STN_ST2", "STN_ST4", "STN_RR",  "STN_BR",  "STN_GR",  "STN_SR",  "STN_ZR",
-                            "STN_N1",  "STN_A",   "STN_O",   "STN_E",   "STN_U",   "STN_N2"
+      "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T",             "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P",    "KC_LBRC",
+      "KC_A", "KC_S", "KC_D", "KC_F", "KC_G",             "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT",
+                      "KC_1", "KC_C", "KC_V",             "KC_N", "KC_M", "KC_2"
     ]
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

![image](https://user-images.githubusercontent.com/4781841/154333992-bade1064-f774-4424-9a33-709a76b37efe.png)
etc.
