### PR TITLE
Update Keychron default keymaps

### DIFF
--- a/public/keymaps/k/keychron_q1_rev_0100_default.json
+++ b/public/keymaps/k/keychron_q1_rev_0100_default.json
@@ -5,7 +5,7 @@
   "layout": "LAYOUT_ansi_82",
   "layers":[
     [
-      "KC_ESC",             "KC_BRID", "KC_BRIU", "KC_F3",   "KC_F4",   "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_DEL",  "KC_INS",
+      "KC_ESC",             "KC_BRID", "KC_BRIU", "XXXXXXX", "XXXXXXX", "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_DEL",  "KC_INS",
       "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",            "KC_PGUP",
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_PGDN",
       "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",             "KC_HOME",
@@ -13,12 +13,12 @@
       "KC_LCTL", "KC_LALT", "KC_LGUI",                                  "KC_SPC",                                   "KC_RGUI", "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
-      "KC_TRNS",            "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
-      "RGB_TOG", "RGB_MOD", "RGB_VAI", "RGB_HUI", "RGB_SAI", "RGB_SPI", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
-      "KC_TRNS", "RGB_RMOD","RGB_VAD", "RGB_HUD", "RGB_SAD", "RGB_SPD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",            "KC_TRNS",
-      "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+      "KC_TRNS",             "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "RGB_TOG", "RGB_MOD",  "RGB_VAI", "RGB_HUI", "RGB_SAI", "RGB_SPI", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "RGB_RMOD", "RGB_VAD", "RGB_HUD", "RGB_SAD", "RGB_SPD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS",             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS",  "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ],
     [
       "KC_ESC",             "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",  "KC_INS",

--- a/public/keymaps/k/keychron_q1_rev_0102_default.json
+++ b/public/keymaps/k/keychron_q1_rev_0102_default.json
@@ -5,7 +5,7 @@
   "layout": "LAYOUT_iso_83",
   "layers": [
     [
-      "KC_ESC",  "KC_BRID", "KC_BRIU", "KC_F3",   "KC_F4",   "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_DEL",             "KC_INS",
+      "KC_ESC",             "KC_BRID", "KC_BRIU", "XXXXXXX", "XXXXXXX", "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_DEL",  "KC_INS",
       "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",            "KC_PGUP",
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC",                       "KC_PGDN",
       "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUHS", "KC_ENT",             "KC_HOME",
@@ -13,7 +13,7 @@
       "KC_LCTL", "KC_LALT", "KC_LGUI",                                  "KC_SPC",                                   "KC_RGUI", "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
-      "KC_TRNS", "KC_F1",    "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS",             "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS", "KC_TRNS",
       "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
       "RGB_TOG", "RGB_MOD",  "RGB_VAI", "RGB_HUI", "RGB_SAI", "RGB_SPI", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS",
       "KC_TRNS", "RGB_RMOD", "RGB_VAD", "RGB_HUD", "RGB_SAD", "RGB_SPD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
@@ -21,7 +21,7 @@
       "KC_TRNS", "KC_TRNS",  "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ],
     [
-      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",             "KC_INS",
+      "KC_ESC",             "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_DEL",  "KC_INS",
       "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",            "KC_PGUP",
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC",                       "KC_PGDN",
       "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUHS", "KC_ENT",             "KC_HOME",
@@ -29,11 +29,11 @@
       "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "MO(3)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
-      "KC_TRNS", "KC_BRID",  "KC_BRIU", "LGUI(KC_TAB)", "LGUI(KC_E)", "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_TRNS",            "KC_TRNS",
-      "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS",      "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
-      "RGB_TOG", "RGB_MOD",  "RGB_VAI", "RGB_HUI",      "RGB_SAI",    "RGB_SPI", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS",
-      "KC_TRNS", "RGB_RMOD", "RGB_VAD", "RGB_HUD",      "RGB_SAD",    "RGB_SPD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
-      "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS",      "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
+      "KC_TRNS",             "KC_BRID", "KC_BRIU", "LGUI(KC_TAB)", "LGUI(KC_E)", "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "RGB_TOG", "RGB_MOD",  "RGB_VAI", "RGB_HUI", "RGB_SAI",      "RGB_SPI",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "KC_TRNS",
+      "KC_TRNS", "RGB_RMOD", "RGB_VAD", "RGB_HUD", "RGB_SAD",      "RGB_SPD",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS",      "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",
       "KC_TRNS", "KC_TRNS",  "KC_TRNS",                                          "KC_TRNS",                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ]
   ]

--- a/public/keymaps/k/keychron_q2_rev_0110_default.json
+++ b/public/keymaps/k/keychron_q2_rev_0110_default.json
@@ -19,7 +19,7 @@
       "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "MO(3)",   "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
-      "KC_GRV",  "KC_BRID",  "KC_BRIU", "KC_F3",   "KC_F4",   "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_TRNS",            "KC_TRNS",
+      "KC_GRV",  "KC_BRID",  "KC_BRIU", "XXXXXXX", "XXXXXXX", "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_TRNS",            "KC_TRNS",
       "RGB_TOG", "RGB_MOD",  "RGB_VAI", "RGB_HUI", "RGB_SAI", "RGB_SPI", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
       "KC_TRNS", "RGB_RMOD", "RGB_VAD", "RGB_HUD", "RGB_SAD", "RGB_SPD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",            "KC_TRNS",
       "KC_TRNS",             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",

--- a/public/keymaps/k/keychron_q2_rev_0111_default.json
+++ b/public/keymaps/k/keychron_q2_rev_0111_default.json
@@ -19,7 +19,7 @@
       "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                                   "KC_RALT", "MO(3)",   "MO(4)",   "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
-      "KC_GRV",  "KC_BRID",  "KC_BRIU", "KC_F3",   "KC_F4",   "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_TRNS",            "KC_TRNS",
+      "KC_GRV",  "KC_BRID",  "KC_BRIU", "XXXXXXX", "XXXXXXX", "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_TRNS",            "KC_TRNS",
       "RGB_TOG", "RGB_MOD",  "RGB_VAI", "RGB_HUI", "RGB_SAI", "RGB_SPI", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
       "KC_TRNS", "RGB_RMOD", "RGB_VAD", "RGB_HUD", "RGB_SAD", "RGB_SPD", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",            "KC_TRNS",
       "KC_TRNS",             "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",


### PR DESCRIPTION
## Description

Supersedes #1057.

I didn't realize PR1057 had merge conflicts, and they can't be resolved on the web interface.