### PR TITLE
Update a_dux with missing quote keycode

### DIFF
--- a/public/keymaps/a/a_dux_default.json
+++ b/public/keymaps/a/a_dux_default.json
@@ -6,7 +6,7 @@
   "layers": [
     [
       "KC_Q",    "KC_W",    "KC_E",    "KC_R",         "KC_T",       "KC_Y",    "KC_U",         "KC_I",    "KC_O",    "KC_P",
-      "KC_A",    "KC_S",    "KC_D",    "KC_F",         "KC_G",       "KC_H",    "KC_J",         "KC_K",    "KC_L",    "KC_SCLN",
+      "KC_A",    "KC_S",    "KC_D",    "KC_F",         "KC_G",       "KC_H",    "KC_J",         "KC_K",    "KC_L",    "KC_QUOT",
       "KC_Z",    "KC_X",    "KC_C",    "KC_V",         "KC_B",       "KC_N",    "KC_M",         "KC_COMM", "KC_DOT",  "KC_SLSH",
                                        "LT(3,KC_TAB)", "KC_LSFT",    "KC_SPC",  "LT(1,KC_ENT)"
     ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add missing `KC_QUOT` to a_dux keymap.
