### PR TITLE
Update Default Keymaps and Redirect Table: QMK 0.17.0

### DIFF
--- a/public/keymaps/a/amjkeyboard_amj40_default.json
+++ b/public/keymaps/a/amjkeyboard_amj40_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "amj40",
+  "keyboard": "amjkeyboard/amj40",
   "keymap": "default",
-  "commit": "fa740f81298dc0965970a4dc7b0b67285bd1985c",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/a/amjkeyboard_amj60_default.json
+++ b/public/keymaps/a/amjkeyboard_amj60_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "amj60",
+  "keyboard": "amjkeyboard/amj60",
   "keymap": "default",
-  "commit": "bf70db479c6b027c670bb0e261f4202864525970",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_all",
   "layers": [
     [

--- a/public/keymaps/a/amjkeyboard_amj96_default.json
+++ b/public/keymaps/a/amjkeyboard_amj96_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "amj96",
+  "keyboard": "amjkeyboard/amj96",
   "keymap": "default",
-  "commit": "29f199f456e4ef364926d0d5babd96b708393955",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_all",
   "layers": [
     [

--- a/public/keymaps/a/amjkeyboard_amjpad_default.json
+++ b/public/keymaps/a/amjkeyboard_amjpad_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "amjpad",
+  "keyboard": "amjkeyboard/amjpad",
   "keymap": "default",
-  "commit": "99b35940bc4166eae3853c9e2fa94bd2be72742e",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_numpad_6x4",
   "layers": [
     [

--- a/public/keymaps/g/gmmk_pro_rev1_ansi_default.json
+++ b/public/keymaps/g/gmmk_pro_rev1_ansi_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "gmmk/pro/ansi",
+  "keyboard": "gmmk/pro/rev1/ansi",
   "keymap": "default",
-  "commit": "e13ad14cb788d8995d19df1de281039693906c42",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/g/gmmk_pro_rev1_iso_default.json
+++ b/public/keymaps/g/gmmk_pro_rev1_iso_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "gmmk/pro/iso",
+  "keyboard": "gmmk/pro/rev1/iso",
   "keymap": "default",
-  "commit": "e13ad14cb788d8995d19df1de281039693906c42",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_absinthe_default.json
+++ b/public/keymaps/k/keyhive_absinthe_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "absinthe",
+  "keyboard": "keyhive/absinthe",
   "keymap": "default",
-  "commit": "1646c0f26cfa21a7023d404008e4d0aa4917193d",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_default",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_ergosaurus_default.json
+++ b/public/keymaps/k/keyhive_ergosaurus_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "ergosaurus",
+  "keyboard": "keyhive/ergosaurus",
   "keymap": "default",
-  "commit": "138c3e7042a3fb9e94a784c3b8f6b0815e71cf3b",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_alice_split_bs",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_honeycomb_default.json
+++ b/public/keymaps/k/keyhive_honeycomb_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "honeycomb",
+  "keyboard": "keyhive/honeycomb",
   "keymap": "default",
-  "commit": "d4e1e712f68567dfed6ff19cf762d01f6bb3d60c",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_lattice60_default.json
+++ b/public/keymaps/k/keyhive_lattice60_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "lattice60",
+  "keyboard": "keyhive/lattice60",
   "keymap": "default",
-  "commit": "6e8876be39f829b0327f567d673b23be0f4f28c6",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_all",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_navi10_rev0_default.json
+++ b/public/keymaps/k/keyhive_navi10_rev0_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "navi10/rev2",
+  "keyboard": "keyhive/navi10/rev0",
   "keymap": "default",
-  "commit": "6c834dea7b506db480ae7a96f3b35f955824d4ec",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_navi10_rev2_default.json
+++ b/public/keymaps/k/keyhive_navi10_rev2_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "navi10/rev0",
+  "keyboard": "keyhive/navi10/rev2",
   "keymap": "default",
-  "commit": "6c834dea7b506db480ae7a96f3b35f955824d4ec",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_navi10_rev3_default.json
+++ b/public/keymaps/k/keyhive_navi10_rev3_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "navi10/rev3",
+  "keyboard": "keyhive/navi10/rev3",
   "keymap": "default",
-  "commit": "6c834dea7b506db480ae7a96f3b35f955824d4ec",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_opus_default.json
+++ b/public/keymaps/k/keyhive_opus_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "opus",
+  "keyboard": "keyhive/opus",
   "keymap": "default",
-  "commit": "f90688e55060c3b4ebe797c42c483fd2d0412321",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_smallice_default.json
+++ b/public/keymaps/k/keyhive_smallice_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "smallice",
+  "keyboard": "keyhive/smallice",
   "keymap": "default",
-  "commit": "5195f97d356ee76a7206112ae0cb62c4d3c532d8",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_southpole_default.json
+++ b/public/keymaps/k/keyhive_southpole_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "southpole",
+  "keyboard": "keyhive/southpole",
   "keymap": "default",
-  "commit": "99b35940bc4166eae3853c9e2fa94bd2be72742e",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/k/keyhive_uno_rev1_default.json
+++ b/public/keymaps/k/keyhive_uno_rev1_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "uno/rev2",
+  "keyboard": "keyhive/uno/rev1",
   "keymap": "default",
-  "commit": "8fe3864fe7601a7e6572e7db680775edeff771ac",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "macros": [
     [

--- a/public/keymaps/k/keyhive_uno_rev2_default.json
+++ b/public/keymaps/k/keyhive_uno_rev2_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "uno/rev1",
+  "keyboard": "keyhive/uno/rev2",
   "keymap": "default",
-  "commit": "8fe3864fe7601a7e6572e7db680775edeff771ac",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "macros": [
     [

--- a/public/keymaps/k/keyhive_ut472_default.json
+++ b/public/keymaps/k/keyhive_ut472_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "ut472",
+  "keyboard": "keyhive/ut472",
   "keymap": "default",
-  "commit": "3307a8e057bcd2590f6943d954647c520a823458",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/m/mt_blocked65_default.json
+++ b/public/keymaps/m/mt_blocked65_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "wheatfield/blocked65",
+  "keyboard": "mt/blocked65",
   "keymap": "default",
-  "commit": "fe3e5cba6915b49a9a20ca4b0a43b308d1512d53",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_65_ansi_blocker",
   "layers": [
     [

--- a/public/keymaps/m/mt_mt40_default.json
+++ b/public/keymaps/m/mt_mt40_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "mt40",
+  "keyboard": "mt/mt40",
   "keymap": "default",
-  "commit": "99b35940bc4166eae3853c9e2fa94bd2be72742e",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_planck_mit",
   "layers": [
     [

--- a/public/keymaps/m/mt_mt64rgb_default.json
+++ b/public/keymaps/m/mt_mt64rgb_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "mt64rgb",
+  "keyboard": "mt/mt64rgb",
   "keymap": "default",
-  "commit": "1646c0f26cfa21a7023d404008e4d0aa4917193d",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_64_ansi",
   "layers": [
     [

--- a/public/keymaps/m/mt_mt84_default.json
+++ b/public/keymaps/m/mt_mt84_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "mt84",
+  "keyboard": "mt/mt84",
   "keymap": "default",
-  "commit": "1646c0f26cfa21a7023d404008e4d0aa4917193d",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_75_ansi",
   "layers": [
     [

--- a/public/keymaps/m/mt_mt980_default.json
+++ b/public/keymaps/m/mt_mt980_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "mt980",
+  "keyboard": "mt/mt980",
   "keymap": "default",
-  "commit": "0072fdd799ffe61bf64f12c23335da3adeb083e5",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/m/mt_split75_default.json
+++ b/public/keymaps/m/mt_split75_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "wheatfield/split75",
+  "keyboard": "mt/split75",
   "keymap": "default",
-  "commit": "3f6de1ef546f5c8e355ce111f3602ca70bb60fc0",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/v/viktus_at101_bh_default.json
+++ b/public/keymaps/v/viktus_at101_bh_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "at101_bh",
+  "keyboard": "viktus/at101_bh",
   "keymap": "default",
-  "commit": "fe6d6cf76dc827adb2f46d55217dc189eae21b02",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/v/viktus_omnikey_bh_default.json
+++ b/public/keymaps/v/viktus_omnikey_bh_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "omnikey_bh",
+  "keyboard": "viktus/omnikey_bh",
   "keymap": "default",
-  "commit": "99b35940bc4166eae3853c9e2fa94bd2be72742e",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/v/viktus_z150_bh_default.json
+++ b/public/keymaps/v/viktus_z150_bh_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "z150_bh",
+  "keyboard": "viktus/z150_bh",
   "keymap": "default",
-  "commit": "fe6d6cf76dc827adb2f46d55217dc189eae21b02",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT",
   "layers": [
     [

--- a/public/keymaps/y/ymdk_melody96_default.json
+++ b/public/keymaps/y/ymdk_melody96_default.json
@@ -1,7 +1,7 @@
 {
-  "keyboard": "melody96",
+  "keyboard": "ymdk/melody96",
   "keymap": "default",
-  "commit": "aab2ac22c5217afcbbbaff8b5444b02765f6de66",
+  "commit": "b835171008eaeaa992a1b8e390af8bce6f5f0b8f",
   "layout": "LAYOUT_all",
   "layers": [
     [

--- a/src/remap.js
+++ b/src/remap.js
@@ -2,6 +2,9 @@ const lookup = {
   '2_milk': {
     target: 'spaceman/2_milk'
   },
+  absinthe: {
+    target: 'keyhive/absinthe'
+  },
   'aeboards/ext65': {
     target: 'aeboards/ext65/rev1'
   },
@@ -14,6 +17,18 @@ const lookup = {
   alice: {
     target: 'tgr/alice'
   },
+  amj40: {
+    target: 'amjkeyboard/amj40'
+  },
+  amj60: {
+    target: 'amjkeyboard/amj60'
+  },
+  amj96: {
+    target: 'amjkeyboard/amj96'
+  },
+  amjpad: {
+    target: 'amjkeyboard/amjpad'
+  },
   angel17: {
     target: 'angel17/alpha'
   },
@@ -22,6 +37,9 @@ const lookup = {
   },
   aplx6: {
     target: 'aplyard/aplx6/rev1'
+  },
+  at101_bh: {
+    target: 'viktus/at101_bh'
   },
   at101_blackheart: {
     target: 'at101_bh'
@@ -149,6 +167,9 @@ const lookup = {
   ergoinu: {
     target: 'dm9records/ergoinu'
   },
+  ergosaurus: {
+    target: 'keyhive/ergosaurus'
+  },
   'exclusive/e85': {
     target: 'exclusive/e85/hotswap'
   },
@@ -160,6 +181,12 @@ const lookup = {
   },
   'gmmk/pro': {
     target: 'gmmk/pro/ansi'
+  },
+  'gmmk/pro/ansi': {
+    target: 'gmmk/pro/rev1/ansi'
+  },
+  'gmmk/pro/iso': {
+    target: 'gmmk/pro/rev1/iso'
   },
   'handwired/ferris': {
     target: 'ferris/0_1'
@@ -208,6 +235,9 @@ const lookup = {
   },
   'helix/rev2/under/oled': {
     target: 'helix/rev2/under'
+  },
+  honeycomb: {
+    target: 'keyhive/honeycomb'
   },
   id80: {
     target: 'id80/ansi'
@@ -274,6 +304,9 @@ const lookup = {
   },
   'kyria/rev1': {
     target: 'splitkb/kyria/rev1'
+  },
+  lattice60: {
+    target: 'keyhive/lattice60'
   },
   'lfkeyboards/lfk78': {
     target: 'lfkeyboards/lfk78/revj'
@@ -368,6 +401,9 @@ const lookup = {
   'mechlovin/hannah65': {
     target: 'mechlovin/hannah65/rev1'
   },
+  melody96: {
+    target: 'ymdk/melody96'
+  },
   model01: {
     target: 'keyboardio/model01'
   },
@@ -376,6 +412,27 @@ const lookup = {
   },
   'montsinger/rebound': {
     target: 'montsinger/rebound/rev1'
+  },
+  mt40: {
+    target: 'mt/mt40'
+  },
+  mt64rgb: {
+    target: 'mt/mt64rgb'
+  },
+  mt84: {
+    target: 'mt/mt84'
+  },
+  mt980: {
+    target: 'mt/mt980'
+  },
+  'navi10/rev0': {
+    target: 'keyhive/navi10/rev0'
+  },
+  'navi10/rev2': {
+    target: 'keyhive/navi10/rev2'
+  },
+  'navi10/rev3': {
+    target: 'keyhive/navi10/rev3'
   },
   'nckiibs/flatbread60': {
     target: 'delikeeb/flatbread60'
@@ -412,8 +469,14 @@ const lookup = {
   oddball: {
     target: 'oddball/v1'
   },
+  omnikey_bh: {
+    target: 'viktus/omnikey_bh'
+  },
   omnikey_blackheart: {
     target: 'omnikey_bh'
+  },
+  opus: {
+    target: 'keyhive/opus'
   },
   'pabile/p20': {
     target: 'pabile/p20/ver1'
@@ -513,8 +576,14 @@ const lookup = {
   skog: {
     target: 'percent/skog'
   },
+  smallice: {
+    target: 'keyhive/smallice'
+  },
   southpaw75: {
     target: 'fr4/southpaw75'
+  },
+  southpole: {
+    target: 'keyhive/southpole'
   },
   speedo: {
     target: 'cozykeys/speedo/v2'
@@ -546,6 +615,12 @@ const lookup = {
   underscore33: {
     target: 'underscore33/rev1'
   },
+  uno: {
+    target: 'keyhive/uno'
+  },
+  ut472: {
+    target: 'keyhive/ut472'
+  },
   vinta: {
     target: 'coarse/vinta',
     layouts: {
@@ -560,6 +635,12 @@ const lookup = {
   },
   'whale/sk': {
     target: 'whale/sk/v3'
+  },
+  'wheatfield/blocked65': {
+    target: 'mt/blocked65'
+  },
+  'wheatfield/split75': {
+    target: 'mt/split75'
   },
   xd002: {
     target: 'xiudi/xd002'
@@ -602,6 +683,9 @@ const lookup = {
   },
   ymd75: {
     target: 'ymd75/rev1'
+  },
+  z150_bh: {
+    target: 'viktus/z150_bh'
   },
   z150_blackheart: {
     target: 'z150_bh'


### PR DESCRIPTION
Updates the keymaps for keyboards that have moved in QMK with the release of 0.17.0.

Fixes #1124.
