### PR TITLE
Color Contrast Updates for Nested Keycodes: DCS Edition

### DIFF
--- a/src/scss/colorways/_sp.scss
+++ b/src/scss/colorways/_sp.scss
@@ -7,11 +7,27 @@
 .dcs-midnight-key {
   background: $color-sp-abs-GB;
   color: $color-sp-abs-VCO;
+  input,
+  .key-contents,
+  .key-contents:empty,
+  .key-contents::before {
+    background: $color-sp-abs-GB;
+    color: lighten($color-sp-abs-VCO, 1%);
+    border-color: mix($color-sp-abs-GB, lighten($color-sp-abs-VCO, 1%));
+  }
 }
 
 .dcs-midnight-mod {
   background: $color-sp-abs-GEW;
   color: $color-sp-abs-VCO;
+  input,
+  .key-contents,
+  .key-contents:empty,
+  .key-contents::before {
+    background: $color-sp-abs-GEW;
+    color: lighten($color-sp-abs-VCO, 14%);
+    border-color: mix($color-sp-abs-GEW, lighten($color-sp-abs-VCO, 14%));
+  }
 }
 
 .dcs-midnight-accent {

--- a/src/scss/colorways/_sp.scss
+++ b/src/scss/colorways/_sp.scss
@@ -42,11 +42,27 @@
 .dcs-midnight-twilight-key {
   background: $color-sp-abs-GB;
   color: $color-sp-abs-VCO;
+  input,
+  .key-contents,
+  .key-contents:empty,
+  .key-contents::before {
+    background: $color-sp-abs-GB;
+    color: lighten($color-sp-abs-VCO, 1%);
+    border-color: mix($color-sp-abs-GB, lighten($color-sp-abs-VCO, 1%));
+  }
 }
 
 .dcs-midnight-twilight-mod {
   background: $color-sp-abs-VCO;
   color: $qmk-black;
+  input,
+  .key-contents,
+  .key-contents:empty,
+  .key-contents::before {
+    background: $color-sp-abs-VCO;
+    color: $qmk-black;
+    border-color: mix($color-sp-abs-VCO, $qmk-black);
+  }
 }
 
 .dsa-galaxy-class-key {


### PR DESCRIPTION
## Description

Along the lines of #454, #286, et. al.

Updates the DCS Midnight and DCS Midnight Twilight keyset colorways so nested keycodes (keycodes which take internal arguments like `LT(1,kc)` and `LCTL(kc)`) are colored similarly to standard keycodes.

## Example Screenshots

Shown on Ergodox EZ. Left half is current `master`, right half is with this PR applied.

### DCS Midnight

![dcs-midnight](https://user-images.githubusercontent.com/18669334/171746954-893e7232-cbeb-4d4d-abdc-5bccaa148138.png)

### DCS Midnight Twilight

![dcs-midnight-twilight](https://user-images.githubusercontent.com/18669334/171746961-7365069e-f964-49c0-af27-4a44c1779488.png)

