### PR TITLE
Color Contrast Updates for Nested Keycodes: DSA Edition

### DIFF
--- a/src/scss/colorways/_keyreative.scss
+++ b/src/scss/colorways/_keyreative.scss
@@ -21,21 +21,34 @@
 .dsa-milkshake-mod {
   background: white;
   color: #232d43;
+  input,
+  .key-contents,
+  .key-contents:empty,
+  .key-contents::before {
+    background: darken(white, 4%);
+    color: #232d43;
+    border-color: mix(darken(white, 4%), #232d43);
+  }
 }
 .dsa-milkshake-esc {
   background: #f0849e;
+  color: #232d43;
 }
 .dsa-milkshake-backspace {
   background: #f1ed8a;
+  color: #232d43;
 }
 .dsa-milkshake-enter {
   background: #8ce1ce;
+  color: #232d43;
 }
 .dsa-milkshake-alt {
   background: #75cde8;
+  color: #232d43;
 }
 .dsa-milkshake-os {
   background: #c091ed;
+  color: #232d43;
 }
 
 .kat-hyperfuse-key {

--- a/src/scss/colorways/_sp.scss
+++ b/src/scss/colorways/_sp.scss
@@ -69,10 +69,12 @@
   background: $color-sp-pbt-BFE;
   color: $color-sp-pbt-BLACK;
   input,
-  .key-contents {
-    background: lighten($color-sp-pbt-BFE, 10%);
+  .key-contents,
+  .key-contents:empty,
+  .key-contents::before {
+    background: lighten($color-sp-pbt-BFE, 4%);
     color: $color-sp-pbt-BLACK;
-    border-color: mix($color-sp-pbt-BFE, $color-sp-pbt-BLACK);
+    border-color: mix(lighten($color-sp-pbt-BFE, 4%), $color-sp-pbt-BLACK);
   }
 }
 .dsa-galaxy-class-mod {
@@ -80,10 +82,12 @@
   background: $color-pantone-141C;
   color: $color-sp-pbt-BLACK;
   input,
-  .key-contents {
-    background: lighten($color-pantone-141C, 10%);
+  .key-contents,
+  .key-contents:empty,
+  .key-contents::before {
+    background: lighten($color-pantone-141C, 4%);
     color: $color-sp-pbt-BLACK;
-    border-color: mix(lighten($color-pantone-141C, 10%), $color-sp-pbt-BLACK);
+    border-color: mix(lighten($color-pantone-141C, 4%), $color-sp-pbt-BLACK);
   }
 }
 .dsa-galaxy-class-purple {


### PR DESCRIPTION
## Description

Updates the DSA Galaxy Class and DSA Milkshake keyset colorways so nested keycodes (keycodes which take internal arguments like `LT(1,kc)` and `LCTL(kc)`) are colored similarly to standard keycodes.

## Example Screenshots

Shown on Ergodox EZ.

### DSA Galaxy Class

Left half is current `master`, right half is with this PR applied. This PR is actually a reduction in contrast, because I found the existing colors a bit jarring.

![dsa-galaxy-class](https://user-images.githubusercontent.com/18669334/171790829-75abf1f2-3ef9-4819-9320-611b42ad7bc0.png)

### DSA Milkshake (animated GIF)

![dsa-milkshake](https://user-images.githubusercontent.com/18669334/171790814-457b1ae2-ca28-49dc-bd3e-7cfb8071b2a9.gif)

