### PR TITLE
Add default keymap for MechBrewery MB-65H

### DIFF
--- a/public/keymaps/m/mechbrewery_mb65h_default.json
+++ b/public/keymaps/m/mechbrewery_mb65h_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "mechbrewery/mb65h",
+  "keymap": "default",
+  "commit": "e1759cd638e87366036df2f322c96c1e2e06026a",
+  "layout": "LAYOUT_65_ansi_blocker",
+  "layers": [
+    [
+        "KC_ESC",  "KC_1",    "KC_2",   "KC_3", "KC_4", "KC_5", "KC_6",   "KC_7", "KC_8", "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",             "KC_BSPC", "KC_HOME",
+        "KC_TAB",             "KC_Q",   "KC_W", "KC_E", "KC_R", "KC_T",   "KC_Y", "KC_U", "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_PGUP",
+        "KC_CAPS",            "KC_A",   "KC_S", "KC_D", "KC_F", "KC_G",   "KC_H", "KC_J", "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",  "KC_PGDN",
+        "KC_LSFT",            "KC_Z",   "KC_X", "KC_C", "KC_V", "KC_B",   "KC_N", "KC_M", "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT", "KC_UP",   "KC_END",
+        "KC_LCTL", "KC_LGUI", "KC_LALT",                        "KC_SPC",                            "KC_RALT", "MO(1)",              "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+        "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",           "KC_DEL",  "_______",
+        "_______",            "_______", "KC_UP",   "_______", "_______", "_______", "_______", "KC_INS",  "_______", "KC_PSCR", "KC_SLCK", "KC_PAUS", "_______", "_______", "_______",
+        "_______",            "KC_LEFT", "KC_DOWN", "KC_RGHT", "_______", "_______", "_______", "_______", "_______", "KC_HOME", "KC_PGUP", "_______",          "_______", "_______",
+        "_______",            "_______", "_______", "_______", "_______", "_______", "KC_VOLD", "KC_VOLU", "KC_MUTE", "KC_END",  "KC_PGDN",          "_______", "_______", "_______",
+        "_______", "_______", "_______",                                  "_______",                                  "_______", "_______",          "_______", "_______", "_______"
+    ]
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Default keymap for MechBrewery MB-65H.
MechBrewery MB-65H is a layout 65 ANSI blocker hot-swappable PCB.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
