### PR TITLE
Mark legacy Menu keycode as "(Legacy)" in Keycodes section

### DIFF
--- a/src/store/modules/keycodes/app-media-mouse.js
+++ b/src/store/modules/keycodes/app-media-mouse.js
@@ -9,7 +9,12 @@ export default [
   { width: 1250 },
   { name: 'Exec', code: 'KC_EXEC', title: 'Execute' },
   { name: 'Help', code: 'KC_HELP', title: 'Help' },
-  { name: 'Menu', code: 'KC_MENU', title: 'Menu (Legacy)' },
+  {
+    name: 'Menu (Legacy)',
+    code: 'KC_MENU',
+    title: 'Menu (Legacy)',
+    width: 1250
+  },
   { name: 'Select', code: 'KC_SLCT', title: 'Select' },
   { name: 'Stop', code: 'KC_STOP', title: 'Stop' },
   { name: 'Again', code: 'KC_AGIN', title: 'Again' },


### PR DESCRIPTION
## Description

Changes the display of the `KC_MENU` key in the keycode selection area to be marked `Menu (Legacy)`, and the same in the keymap display.

Keycode selection:
![image](https://user-images.githubusercontent.com/18669334/175991731-0423e6c7-c3e5-4159-b55c-2ce5a1ee544c.png)

Keymap display:
![image](https://user-images.githubusercontent.com/18669334/176068626-cf5bd4d2-7a7f-4ab3-90c8-aece8a4ee902.png)

Fixes #1143.
