### PR TITLE
Add deng/djam default keymap

### DIFF
--- a/public/keymaps/d/deng_djam_default.json
+++ b/public/keymaps/d/deng_djam_default.json
@@ -1,0 +1,13 @@
+{
+    "keyboard": "deng/djam",
+    "keymap": "default",
+    "commit": "ddae04bca129772d74bb87a29ef65dba94fb47e9",
+    "layout": "LAYOUT",
+    "layers": [
+        [
+                       "KC_S",    "KC_D",    "KC_F",                                     "KC_J",    "KC_K",    "KC_L",
+            "KC_A",    "KC_Z",    "KC_X",    "KC_C",                                     "KC_N",    "KC_M",    "KC_COMM", "KC_SCLN",
+            "KC_LEFT", "KC_RGHT",                       "BL_TOGG", "KC_SPC",  "BL_STEP",                       "KC_UP",   "KC_DOWN"
+        ]
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Add [deng/djam](https://config.qmk.fm/#/deng/djam/LAYOUT) default keymap

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
