### PR TITLE
Replace MT(<mod>, <kc>) by <mod>_T(<kc>) for prettier keys

### DIFF
--- a/public/keymaps/4/40percentclub_tomato_default.json
+++ b/public/keymaps/4/40percentclub_tomato_default.json
@@ -7,7 +7,7 @@
     [
       "KC_Q",              "KC_W",              "KC_E",       "KC_R",       "KC_T",          "KC_Y",         "KC_U",       "KC_I",              "KC_O",              "KC_P",
       "KC_A",              "KC_S",              "KC_D",       "KC_F",       "KC_G",          "KC_H",         "KC_J",       "KC_K",              "KC_L",              "KC_ESC",
-      "MT(MOD_LCTL,KC_Z)", "MT(MOD_LALT,KC_X)", "LT(3,KC_C)", "LT(4,KC_V)", "LT(2,KC_BSPC)", "LT(1,KC_SPC)", "LT(5,KC_B)", "MT(MOD_RALT,KC_N)", "MT(MOD_RCTL,KC_M)", "MT(MOD_RSFT,KC_ENT)"
+      "LCTL_T(KC_Z)", "LALT_T(KC_X)", "LT(3,KC_C)", "LT(4,KC_V)", "LT(2,KC_BSPC)", "LT(1,KC_SPC)", "LT(5,KC_B)", "RALT_T(KC_N)", "RCTL_T(KC_M)", "RSFT_T(KC_ENT)"
     ],
     [
       "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",

--- a/public/keymaps/4/40percentclub_ut47_default.json
+++ b/public/keymaps/4/40percentclub_ut47_default.json
@@ -7,7 +7,7 @@
     [
       "KC_ESC",       "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
       "LT(3,KC_TAB)", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
-      "KC_LSFT",      "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "MT(MOD_RSFT,KC_ENT)",
+      "KC_LSFT",      "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "RSFT_T(KC_ENT)",
       "KC_LCTL",      "KC_LALT", "KC_LGUI", "KC_APP",  "MO(2)",        "KC_SPC",        "MO(1)",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
     ],
 

--- a/public/keymaps/a/alpha_default.json
+++ b/public/keymaps/a/alpha_default.json
@@ -7,12 +7,12 @@
     [
       "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",
       "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                "KC_H",    "KC_J",    "KC_K",    "KC_L",    "TO(1)",
-      "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "MT(MOD_LSFT,KC_SPC)",            "KC_B",    "KC_N",    "KC_M"
+      "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "LSFT_T(KC_SPC)",            "KC_B",    "KC_N",    "KC_M"
     ],
     [
       "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",
       "KC_BSPC", "KC_ESC",  "KC_TAB",  "KC_SCLN", "KC_QUOT",             "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT", "TO(2)",
-      "KC_LCTL", "KC_LGUI", "KC_LALT", "TO(0)",   "MT(MOD_LSFT,KC_ENT)",            "KC_COMM", "KC_DOT",  "KC_SLSH"
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "TO(0)",   "LSFT_T(KC_ENT)",            "KC_COMM", "KC_DOT",  "KC_SLSH"
     ],
     [
       "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",

--- a/public/keymaps/b/buzzard_rev1_default.json
+++ b/public/keymaps/b/buzzard_rev1_default.json
@@ -7,7 +7,7 @@
     [
                              "KC_Q",         "KC_W",         "KC_E",         "KC_R",          "KC_T",                                                                        "KC_Y",    "KC_U",         "KC_I",         "KC_O",           "KC_P",
       "OSM(MOD_LSFT)",       "LGUI_T(KC_A)", "LALT_T(KC_S)", "LCTL_T(KC_D)", "LSFT_T(KC_F)",  "KC_G",                                                                        "KC_H",    "RSFT_T(KC_J)", "RCTL_T(KC_K)", "LALT_T(KC_L)",   "RGUI_T(KC_SCLN)", "KC_DEL",
-      "MT(MOD_LCTL,KC_ESC)", "KC_Z",         "RALT_T(KC_X)", "KC_C",         "KC_V",          "KC_B",                                                                        "KC_N",    "KC_M",         "KC_COMM",      "RALT_T(KC_DOT)", "KC_SLSH",         "MO(5)",
+      "LCTL_T(KC_ESC)", "KC_Z",         "RALT_T(KC_X)", "KC_C",         "KC_V",          "KC_B",                                                                        "KC_N",    "KC_M",         "KC_COMM",      "RALT_T(KC_DOT)", "KC_SLSH",         "MO(5)",
                                                                                               "KC_BTN1", "LT(1,KC_SPC)", "LT(3,KC_TAB)",    "LT(4,KC_BSPC)", "LT(2,KC_ENT)", "KC_BTN2"
     ],
     [

--- a/public/keymaps/g/gboards_gergo_default.json
+++ b/public/keymaps/g/gboards_gergo_default.json
@@ -6,9 +6,9 @@
   "layers": [
     [
       "LT(2,KC_ESC)",        "KC_Q",    "KC_W",    "KC_E",    "KC_R",                "KC_T",                                                                                           "KC_Y",    "KC_U",    "KC_I",    "KC_O",     "KC_P",    "KC_PIPE",
-      "MT(MOD_LCTL,KC_BSPC)","KC_A",    "KC_S",    "KC_D",    "KC_F",                "KC_G",                "KC_BTN2",                                                 "KC_TRNS",      "KC_H",    "KC_J",    "KC_K",    "KC_L",     "KC_SCLN", "KC_QUOT",
+      "LCTL_T(KC_BSPC)","KC_A",    "KC_S",    "KC_D",    "KC_F",                "KC_G",                "KC_BTN2",                                                 "KC_TRNS",      "KC_H",    "KC_J",    "KC_K",    "KC_L",     "KC_SCLN", "KC_QUOT",
       "KC_RSFT",             "KC_Z",    "KC_X",    "KC_C",    "KC_V",                "KC_B",                "KC_BTN1",      "KC_BTN3",                 "KC_PGDN",      "KC_BSPC",      "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",   "KC_SLSH", "KC_MINS",
-                                                              "MT(MOD_LGUI,KC_DEL)", "MT(MOD_LALT,KC_ENT)", "LT(1,KC_SPC)", "LT(2,KC_ESC)",            "LT(1,KC_ENT)", "LT(2,KC_SPC)", "KC_TAB",  "KC_BSPC"
+                                                              "LGUI_T(KC_DEL)", "LALT_T(KC_ENT)", "LT(1,KC_SPC)", "LT(2,KC_ESC)",            "LT(1,KC_ENT)", "LT(2,KC_SPC)", "KC_TAB",  "KC_BSPC"
     ],
     [
       "KC_TRNS", "KC_EXLM", "KC_AT",   "KC_LCBR", "KC_RCBR", "KC_PIPE",                                                        "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_BSLS",

--- a/public/keymaps/g/glenpickle_chimera_ergo_default.json
+++ b/public/keymaps/g/glenpickle_chimera_ergo_default.json
@@ -5,7 +5,7 @@
   "layout": "LAYOUT",
   "layers": [
     [
-      "KC_LBRC",      "KC_1",    "MT(MOD_LCTL,KC_LBRC)", "MT(MOD_LALT,KC_MINS)", "LT(5,KC_EQL)", "KC_5",    "KC_6",    "MT(MOD_RGUI,KC_RBRC)", "MT(MOD_LALT,KC_1)", "MT(MOD_LCTL,KC_RBRC)", "KC_0",    "KC_RBRC",
+      "KC_LBRC",      "KC_1",    "LCTL_T(KC_LBRC)", "LALT_T(KC_MINS)", "LT(5,KC_EQL)", "KC_5",    "KC_6",    "RGUI_T(KC_RBRC)", "LALT_T(KC_1)", "LCTL_T(KC_RBRC)", "KC_0",    "KC_RBRC",
       "LT(4,KC_ESC)", "KC_Q",    "KC_W",                 "KC_E",                 "KC_R",         "KC_T",    "KC_Y",    "KC_U",                 "KC_I",              "KC_O",                 "KC_P",    "KC_QUOT",
       "KC_TAB",       "KC_A",    "KC_S",                 "KC_D",                 "KC_F",         "KC_G",    "KC_H",    "KC_J",                 "KC_K",              "KC_L",                 "KC_SCLN", "KC_ENT",
       "KC_LSPO",      "KC_Z",    "KC_X",                 "KC_C",                 "KC_V",         "KC_B",    "KC_N",    "KC_M",                 "KC_COMM",           "KC_DOT",               "KC_SLSH", "KC_RSPC",

--- a/public/keymaps/g/glenpickle_chimera_ls_default.json
+++ b/public/keymaps/g/glenpickle_chimera_ls_default.json
@@ -8,7 +8,7 @@
       "LT(4,KC_ESC)",         "KC_Q",         "KC_W",                 "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
       "KC_TAB",               "KC_A",         "KC_S",                 "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_ENT",
       "KC_LSPO",              "KC_Z",         "KC_X",                 "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSPC",
-      "MT(MOD_LCTL,KC_BSLS)", "LT(5,KC_EQL)", "MT(MOD_LALT,KC_MINS)", "KC_AMPR", "TG(2)",   "KC_SPC",  "KC_SPC",  "TG(3)",   "KC_ASTR", "KC_EXLM", "KC_LBRC", "MT(MOD_LCTL,KC_RBRC)"
+      "LCTL_T(KC_BSLS)", "LT(5,KC_EQL)", "LALT_T(KC_MINS)", "KC_AMPR", "TG(2)",   "KC_SPC",  "KC_SPC",  "TG(3)",   "KC_ASTR", "KC_EXLM", "KC_LBRC", "LCTL_T(KC_RBRC)"
     ],
     [
       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",

--- a/public/keymaps/g/glenpickle_chimera_ortho_default.json
+++ b/public/keymaps/g/glenpickle_chimera_ortho_default.json
@@ -5,9 +5,9 @@
   "layout": "LAYOUT",
   "layers": [
     [
-      "LT(4,KC_ESC)", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "MT(MOD_LCTL,KC_LBRC)",            "MT(MOD_LCTL,KC_RBRC)", "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_QUOT",
-      "KC_TAB",       "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "MT(MOD_LALT,KC_MINS)",            "MT(MOD_LALT,KC_1)",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_ENT",
-      "KC_LSPO",      "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "LT(5,KC_EQL)",                    "MT(MOD_RGUI,KC_8)",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSPC",
+      "LT(4,KC_ESC)", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "LCTL_T(KC_LBRC)",            "LCTL_T(KC_RBRC)", "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_QUOT",
+      "KC_TAB",       "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "LALT_T(KC_MINS)",            "LALT_T(KC_1)",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_ENT",
+      "KC_LSPO",      "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "LT(5,KC_EQL)",                    "RGUI_T(KC_8)",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSPC",
                                                        "TG(2)",   "KC_BSPC",                                                            "KC_SPC",  "TG(3)"
     ],
     [

--- a/public/keymaps/h/handwired_lagrange_default.json
+++ b/public/keymaps/h/handwired_lagrange_default.json
@@ -9,8 +9,8 @@
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",                 "KC_T",                                                   "KC_Y",    "KC_U",                "KC_I",    "KC_O",    "KC_P",    "KC_BSLS",
       "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",                 "KC_G",                                                   "KC_H",    "KC_J",                "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
       "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",                 "KC_B",                                                   "KC_N",    "KC_M",                "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
-      "KC_LCPO",            "KC_INS",  "KC_LBRC", "MT(MOD_LALT,KC_MINS)", "KC_BSPC", "KC_DEL",  "KC_PSCR",    "KC_PAUS", "KC_ENT",  "KC_SPC",  "MT(MOD_RALT,KC_EQL)", "KC_RBRC", "KC_DEL",             "KC_RCPC",
-                                                  "MT(MOD_LGUI,KC_HOME)", "KC_PGUP", "KC_END",                           "KC_LEFT", "KC_UP",   "MT(MOD_RGUI,KC_RGHT)",
+      "KC_LCPO",            "KC_INS",  "KC_LBRC", "LALT_T(KC_MINS)", "KC_BSPC", "KC_DEL",  "KC_PSCR",    "KC_PAUS", "KC_ENT",  "KC_SPC",  "RALT_T(KC_EQL)", "KC_RBRC", "KC_DEL",             "KC_RCPC",
+                                                  "LGUI_T(KC_HOME)", "KC_PGUP", "KC_END",                           "KC_LEFT", "KC_UP",   "RGUI_T(KC_RGHT)",
                                                                           "KC_PGDN",                                                "KC_DOWN"
     ],
     [

--- a/public/keymaps/h/handwired_pilcrow_default.json
+++ b/public/keymaps/h/handwired_pilcrow_default.json
@@ -8,7 +8,7 @@
       "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",                "KC_U",    "KC_I",    "KC_O",    "KC_P",
       "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",                "KC_J",    "KC_K",    "KC_L",    "KC_SCLN",
       "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",                "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",
-      "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(1)",   "KC_SPC",  "MT(MOD_LSFT,KC_SPC)", "MO(2)",   "MO(3)",   "KC_DEL",  "KC_ESC"
+      "KC_LCTL", "KC_LALT", "KC_LGUI", "MO(1)",   "KC_SPC",  "LSFT_T(KC_SPC)", "MO(2)",   "MO(3)",   "KC_DEL",  "KC_ESC"
     ],
     [
       "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR",       "KC_ASTR",       "KC_LPRN", "KC_RPRN",

--- a/public/keymaps/h/handwired_zergo_default.json
+++ b/public/keymaps/h/handwired_zergo_default.json
@@ -8,9 +8,9 @@
       "KC_ESC",                          "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",        "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",         "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",
       "KC_DEL",               "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC",
       "KC_TAB",               "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",     "LCTL(KC_LSFT)",     "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_BSLS",
-      "KC_LCTL",              "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                          "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "MT(MOD_RCTL,KC_ENT)",
-      "MT(MOD_LSFT,KC_HOME)", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",         "KC_BSPC",       "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RBRC", "MT(MOD_RSFT,KC_PGUP)",
-      "MT(MOD_LCTL,KC_END)",  "KC_NO",   "KC_NO",   "KC_LALT",            "KC_SPC",       "KC_ENT",        "LT(1,KC_SPC)",                  "KC_RALT", "KC_APP",  "KC_RGUI", "MT(MOD_RCTL,KC_PGDN)"
+      "KC_LCTL",              "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                          "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "RCTL_T(KC_ENT)",
+      "LSFT_T(KC_HOME)", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",         "KC_BSPC",       "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RBRC", "RSFT_T(KC_PGUP)",
+      "LCTL_T(KC_END)",  "KC_NO",   "KC_NO",   "KC_LALT",            "KC_SPC",       "KC_ENT",        "LT(1,KC_SPC)",                  "KC_RALT", "KC_APP",  "KC_RGUI", "RCTL_T(KC_PGDN)"
     ],
     [
       "_______",                         "_______", "_______", "_______", "_______",      "_______", "_______", "_______", "_______",       "_______", "_______", "_______", "QK_BOOT",

--- a/public/keymaps/k/kagizaraya_halberd_default.json
+++ b/public/keymaps/k/kagizaraya_halberd_default.json
@@ -8,7 +8,7 @@
       "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                "KC_TAB",  "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",
       "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                "KC_BSPC", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN",
       "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",                "KC_ENT",  "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",
-                            "KC_LGUI", "MO(1)",   "MT(MOD_LCTL,KC_ESC)", "KC_SPC",  "KC_LSFT", "MO(2)",   "KC_LALT"
+                            "KC_LGUI", "MO(1)",   "LCTL_T(KC_ESC)", "KC_SPC",  "KC_LSFT", "MO(2)",   "KC_LALT"
     ],
     [
       "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_TRNS", "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",

--- a/public/keymaps/k/keebio_dilly_default.json
+++ b/public/keymaps/k/keebio_dilly_default.json
@@ -6,8 +6,8 @@
   "layers": [
     [
       "KC_Q",              "KC_W",              "KC_E",              "KC_R",       "KC_T",         "KC_Y",       "KC_U",       "KC_I",              "KC_O",                 "KC_P",
-      "MT(MOD_LSFT,KC_A)", "KC_S",              "KC_D",              "LT(3,KC_F)", "KC_G",         "KC_H",       "KC_J",       "KC_K",              "KC_L",                 "MT(MOD_RSFT,KC_ESC)",
-      "MT(MOD_LCTL,KC_Z)", "MT(MOD_LALT,KC_X)", "MT(MOD_LGUI,KC_C)", "LT(4,KC_V)", "LT(2,KC_SPC)", "LT(1,KC_B)", "LT(5,KC_N)", "MT(MOD_RALT,KC_M)", "MT(MOD_RCTL,KC_BSPC)", "MT(MOD_RSFT,KC_ENT)"
+      "LSFT_T(KC_A)", "KC_S",              "KC_D",              "LT(3,KC_F)", "KC_G",         "KC_H",       "KC_J",       "KC_K",              "KC_L",                 "RSFT_T(KC_ESC)",
+      "LCTL_T(KC_Z)", "LALT_T(KC_X)", "LGUI_T(KC_C)", "LT(4,KC_V)", "LT(2,KC_SPC)", "LT(1,KC_B)", "LT(5,KC_N)", "RALT_T(KC_M)", "RCTL_T(KC_BSPC)", "RSFT_T(KC_ENT)"
     ],
     [
       "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",

--- a/public/keymaps/k/keyprez_bison_default.json
+++ b/public/keymaps/k/keyprez_bison_default.json
@@ -7,14 +7,14 @@
     [
       "KC_F1",   "KC_F2",   "KC_GRV",              "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                             "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_DEL",
       "KC_F3",   "KC_F4",   "KC_TAB",              "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                             "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
-      "KC_F5",   "KC_F6",   "MT(MOD_LCTL,KC_ESC)", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                             "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_BSPC", "MO(5)",
+      "KC_F5",   "KC_F6",   "LCTL_T(KC_ESC)", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                             "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_BSPC", "MO(5)",
       "KC_F7",   "KC_F8",   "KC_LSFT",             "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_MUTE",    "KC_MPLY", "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",  "KC_HOME", "KC_END",
                                                                          "KC_LGUI", "KC_LALT", "MO(2)",   "KC_BSPC",    "KC_SPC",  "MO(3)",   "KC_RALT", "KC_RGUI"
     ],
     [
       "KC_F1",   "KC_F2",   "KC_GRV",              "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                             "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_DEL",
       "KC_F3",   "KC_F4",   "KC_TAB",              "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",                             "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_LBRC", "KC_RBRC", "KC_BSLS",
-      "KC_F5",   "KC_F6",   "MT(MOD_LCTL,KC_ESC)", "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",                             "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT", "KC_BSPC", "MO(5)",
+      "KC_F5",   "KC_F6",   "LCTL_T(KC_ESC)", "KC_A",    "KC_R",    "KC_S",    "KC_T",    "KC_D",                             "KC_H",    "KC_N",    "KC_E",    "KC_I",    "KC_O",    "KC_QUOT", "KC_BSPC", "MO(5)",
       "KC_F7",   "KC_F8",   "KC_LSFT",             "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_MUTE",    "XXXXXXX", "KC_K",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",  "KC_HOME", "KC_END",
                                                                          "KC_LGUI", "KC_LALT", "MO(2)",   "KC_BSPC",    "KC_SPC",  "MO(3)",   "KC_RALT", "KC_RGUI"
     ],
@@ -35,7 +35,7 @@
     [
       "_______", "_______", "_______", "_______",           "_______",           "_______",           "_______",           "_______",                          "_______", "_______",           "_______",           "_______",           "_______",              "_______", "_______", "_______",
       "_______", "_______", "_______", "_______",           "_______",           "_______",           "_______",           "_______",                          "_______", "_______",           "_______",           "_______",           "_______",              "_______", "_______", "_______",
-      "_______", "_______", "_______", "MT(MOD_LGUI,KC_A)", "MT(MOD_LALT,KC_S)", "MT(MOD_LCTL,KC_D)", "MT(MOD_LSFT,KC_F)", "_______",                          "_______", "MT(MOD_RSFT,KC_J)", "MT(MOD_RCTL,KC_K)", "MT(MOD_RALT,KC_L)", "MT(MOD_RGUI,KC_SCLN)", "_______", "_______", "_______",
+      "_______", "_______", "_______", "LGUI_T(KC_A)", "LALT_T(KC_S)", "LCTL_T(KC_D)", "LSFT_T(KC_F)", "_______",                          "_______", "RSFT_T(KC_J)", "RCTL_T(KC_K)", "RALT_T(KC_L)", "RGUI_T(KC_SCLN)", "_______", "_______", "_______",
       "_______", "_______", "_______", "_______",           "_______",           "_______",           "_______",           "_______", "_______",    "_______", "_______", "_______",           "_______",           "_______",           "_______",              "_______", "_______", "_______",
                                                                                  "_______",           "_______",           "_______", "_______",    "_______", "_______",                      "_______",           "_______"
     ],

--- a/public/keymaps/k/keyprez_rhino_default.json
+++ b/public/keymaps/k/keyprez_rhino_default.json
@@ -7,7 +7,7 @@
     [
                                                                                                                                                      "KC_MUTE",
       "QK_GESC",             "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_LBRC", "KC_RBRC", "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_QUOT",
-      "MT(MOD_LCTL,KC_TAB)", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_HOME", "KC_PGUP", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_BSPC",
+      "LCTL_T(KC_TAB)", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_HOME", "KC_PGUP", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_BSPC",
       "KC_LSFT",             "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_END",  "KC_PGDN", "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_ENT",
                              "KC_LGUI", "MO(1)",   "KC_LALT", "MO(2)",              "KC_SPC",  "KC_SPC",             "KC_LEFT", "KC_UP",   "KC_DOWN", "KC_RGHT"
     ],

--- a/public/keymaps/m/maple_computing_c39_default.json
+++ b/public/keymaps/m/maple_computing_c39_default.json
@@ -6,7 +6,7 @@
   "layers": [
     [
       "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_BSPC",             "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_1",    "KC_2",
-      "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "MT(MOD_LSFT,KC_ENT)", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_3",    "KC_4",
+      "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "LSFT_T(KC_ENT)", "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_3",    "KC_4",
       "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "LT(1,KC_SPC)",        "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_5",    "KC_6"
     ],
     [

--- a/public/keymaps/m/miniaxe_default.json
+++ b/public/keymaps/m/miniaxe_default.json
@@ -8,7 +8,7 @@
       "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                   "KC_Y",                "KC_U",    "KC_I",                 "KC_O",    "KC_P",
       "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                   "KC_H",                "KC_J",    "KC_K",                 "KC_L",    "KC_SCLN",
       "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",                   "KC_N",                "KC_M",    "KC_COMM",              "KC_DOT",  "KC_SLSH",
-                            "KC_LGUI", "MO(1)",   "MT(MOD_LCTL,KC_ESC)",    "MT(MOD_LSFT,KC_SPC)", "MO(2)",   "MT(MOD_LALT,KC_BSPC)"
+                            "KC_LGUI", "MO(1)",   "LCTL_T(KC_ESC)",    "LSFT_T(KC_SPC)", "MO(2)",   "LALT_T(KC_BSPC)"
     ],
     [
       "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",       "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",

--- a/public/keymaps/m/mt_mt40_default.json
+++ b/public/keymaps/m/mt_mt40_default.json
@@ -6,9 +6,9 @@
   "layers": [
     [
       "KC_TAB",               "KC_Q",                 "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",                 "KC_BSPC",
-      "MT(MOD_LCTL,KC_ESC)",  "KC_A",                 "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN",              "MT(MOD_RCTL,KC_ENT)",
+      "LCTL_T(KC_ESC)",  "KC_A",                 "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN",              "RCTL_T(KC_ENT)",
       "KC_LSPO",              "KC_Z",                 "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",              "KC_RSPC",
-      "MT(MOD_LCTL,KC_QUOT)", "MT(MOD_LGUI,KC_LBRC)", "KC_LALT", "MO(3)",   "MO(1)",        "KC_SPC",        "MO(2)",   "MO(4)",   "KC_RALT", "MT(MOD_RGUI,KC_RBRC)", "MT(MOD_RCTL,KC_GRV)"
+      "LCTL_T(KC_QUOT)", "LGUI_T(KC_LBRC)", "KC_LALT", "MO(3)",   "MO(1)",        "KC_SPC",        "MO(2)",   "MO(4)",   "KC_RALT", "RGUI_T(KC_RBRC)", "RCTL_T(KC_GRV)"
     ],
     [
       "_______", "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "RGB_TOG", "RGB_MOD", "KC_P7",   "KC_P8",   "KC_P9",   "KC_PSLS", "_______",

--- a/public/keymaps/n/nacly_sodium42_default.json
+++ b/public/keymaps/n/nacly_sodium42_default.json
@@ -7,25 +7,25 @@
     [
       "KC_Q",              "KC_W",    "KC_E",       "KC_R",         "KC_T",                             "KC_Y",    "KC_U",       "KC_I",    "KC_O",    "KC_P",
       "KC_A",              "KC_S",    "LT(3,KC_D)", "LT(1,KC_F)",   "KC_G",                             "KC_H",    "LT(2,KC_J)", "KC_K",    "KC_L",    "KC_SCLN",
-      "MT(MOD_LSFT,KC_Z)", "KC_X",    "KC_C",       "KC_V",         "KC_B",                             "KC_N",    "KC_M",       "KC_COMM", "KC_DOT",  "MT(MOD_RSFT,KC_SLSH)",
+      "LSFT_T(KC_Z)", "KC_X",    "KC_C",       "KC_V",         "KC_B",                             "KC_N",    "KC_M",       "KC_COMM", "KC_DOT",  "RSFT_T(KC_SLSH)",
       "KC_LCTL",           "KC_LALT", "KC_LGUI",    "LT(2,KC_EQL)", "KC_BSPC", "KC_DEL",     "KC_ENT",  "KC_SPC",  "KC_LBRC",    "KC_RBRC", "KC_MINS", "KC_ESC"
     ],
     [
       "KC_F2",             "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",                            "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",
       "KC_NO",             "KC_NO",   "KC_NO",   "_______", "KC_NO",                            "KC_NO",   "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT",
-      "MT(MOD_LSFT,KC_Z)", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                            "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "MT(MOD_RSFT,KC_SLSH)",
+      "LSFT_T(KC_Z)", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                            "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "RSFT_T(KC_SLSH)",
       "KC_LGUI",           "KC_LALT", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",      "KC_HOME", "KC_END",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO"
     ],
     [
       "KC_MUTE",           "KC_VOLD", "KC_VOLU", "KC_NO",   "KC_NO",                            "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_BSLS",
       "KC_MPRV",           "KC_MPLY", "KC_MNXT", "KC_TAB",  "KC_NO",                            "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_QUOT",
-      "MT(MOD_LSFT,KC_Z)", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                            "KC_NO",   "_______", "KC_NO",   "KC_NO",   "MT(MOD_RSFT,KC_SLSH)",
+      "LSFT_T(KC_Z)", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",                            "KC_NO",   "_______", "KC_NO",   "KC_NO",   "RSFT_T(KC_SLSH)",
       "KC_LGUI",           "KC_LALT", "KC_NO",   "_______", "KC_F14",  "KC_F15",     "KC_ENT",  "KC_SPC",  "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO"
     ],
     [
       "KC_MUTE",           "KC_VOLD", "KC_VOLU", "KC_NO",        "KC_NO",                            "KC_NO",   "KC_7",    "KC_8",    "KC_9",    "KC_MINS",
       "KC_MPRV",           "KC_MPLY", "KC_MNXT", "KC_NO",        "KC_NO",                            "KC_NO",   "KC_4",    "KC_5",    "KC_6",    "KC_QUOT",
-      "MT(MOD_LSFT,KC_Z)", "KC_NO",   "_______", "KC_NO",        "KC_NO",                            "KC_NO",   "KC_1",    "KC_2",    "KC_3",    "MT(MOD_RSFT,KC_SLSH)",
+      "LSFT_T(KC_Z)", "KC_NO",   "_______", "KC_NO",        "KC_NO",                            "KC_NO",   "KC_1",    "KC_2",    "KC_3",    "RSFT_T(KC_SLSH)",
       "KC_LCTL",           "KC_LALT", "KC_LGUI", "LT(2,KC_EQL)", "KC_BSPC", "KC_DEL",     "KC_ENT",  "KC_0",    "KC_NO",   "KC_NO",   "KC_DOT",  "KC_NO"
     ]
   ]

--- a/public/keymaps/o/orthodox_rev1_default.json
+++ b/public/keymaps/o/orthodox_rev1_default.json
@@ -7,7 +7,7 @@
     [
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                                                                                     "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
       "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",               "KC_LEFT", "KC_DOWN",    "KC_UP",   "KC_RGHT",                        "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
-      "KC_LCTL", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "MO(3)",   "KC_BSPC", "KC_ENT",     "KC_RALT", "MT(MOD_LSFT,KC_SPC)", "MO(4)",   "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_LGUI"
+      "KC_LCTL", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "MO(3)",   "KC_BSPC", "KC_ENT",     "KC_RALT", "LSFT_T(KC_SPC)", "MO(4)",   "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_LGUI"
     ],
     [
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",                                                                         "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",

--- a/public/keymaps/o/orthodox_rev3_default.json
+++ b/public/keymaps/o/orthodox_rev3_default.json
@@ -7,7 +7,7 @@
     [
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                                                                                     "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
       "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",               "KC_LEFT", "KC_DOWN",    "KC_UP",   "KC_RGHT",                        "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
-      "KC_LCTL", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "MO(3)",   "KC_BSPC", "KC_ENT",     "KC_RALT", "MT(MOD_LSFT,KC_SPC)", "MO(4)",   "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_LGUI"
+      "KC_LCTL", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "MO(3)",   "KC_BSPC", "KC_ENT",     "KC_RALT", "LSFT_T(KC_SPC)", "MO(4)",   "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_LGUI"
     ],
     [
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",                                                                         "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",

--- a/public/keymaps/o/orthodox_rev3_teensy_default.json
+++ b/public/keymaps/o/orthodox_rev3_teensy_default.json
@@ -7,7 +7,7 @@
     [
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                                                                                     "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
       "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",               "KC_LEFT", "KC_DOWN",    "KC_UP",   "KC_RGHT",                        "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
-      "KC_LCTL", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "MO(3)",   "KC_BSPC", "KC_ENT",     "KC_RALT", "MT(MOD_LSFT,KC_SPC)", "MO(4)",   "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_LGUI"
+      "KC_LCTL", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "MO(3)",   "KC_BSPC", "KC_ENT",     "KC_RALT", "LSFT_T(KC_SPC)", "MO(4)",   "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_LGUI"
     ],
     [
       "KC_TAB",  "KC_Q",    "KC_W",    "KC_F",    "KC_P",    "KC_G",                                                                         "KC_J",    "KC_L",    "KC_U",    "KC_Y",    "KC_SCLN", "KC_BSPC",

--- a/public/keymaps/p/pearl_default.json
+++ b/public/keymaps/p/pearl_default.json
@@ -7,7 +7,7 @@
     [
       "QK_GESC",              "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_BSPC",
       "KC_TAB",               "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_ENT",
-      "MT(MOD_LSFT,KC_CAPS)", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
+      "LSFT_T(KC_CAPS)", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
                               "KC_LCTL", "KC_LALT", "KC_LGUI", "KC_LSFT",            "KC_SPC",  "KC_SPC",  "KC_APP",  "MO(1)"
     ],
     [

--- a/public/keymaps/p/polilla_rev1_default.json
+++ b/public/keymaps/p/polilla_rev1_default.json
@@ -9,7 +9,7 @@
       "KC_LBRC", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                                          "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_RBRC",
       "KC_TAB",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                                          "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
       "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "QK_GESC",    "KC_ENT",               "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",
-                            "KC_LALT", "KC_LGUI", "MO(1)",   "KC_BSPC", "KC_LCTL",    "MT(MOD_RALT,KC_BSLS)", "KC_SPC",  "MO(2)",   "KC_RWIN", "KC_CAPS"
+                            "KC_LALT", "KC_LGUI", "MO(1)",   "KC_BSPC", "KC_LCTL",    "RALT_T(KC_BSLS)", "KC_SPC",  "MO(2)",   "KC_RWIN", "KC_CAPS"
     ],
     [
       "XXXXXXX", "KC_F1",   "KC_F2",         "KC_F3",   "KC_F4",         "KC_F5",                            "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",

--- a/public/keymaps/p/program_yoink_staggered_default.json
+++ b/public/keymaps/p/program_yoink_staggered_default.json
@@ -7,8 +7,8 @@
     [
       "KC_ESC",  "KC_Q",                 "KC_W",    "KC_E",    "KC_R",    "KC_T",         "KC_Y",    "KC_U",    "KC_I",    "KC_O",                "KC_P",    "KC_BSPC", "KC_MUTE",
       "KC_TAB",  "KC_A",                 "KC_S",    "KC_D",    "KC_F",    "KC_G",         "KC_H",    "KC_J",    "KC_K",    "KC_L",                "KC_ENT",             "RGB_VAI",
-      "KC_LSFT", "KC_Z",                 "KC_X",    "KC_C",    "KC_V",    "KC_B",         "KC_N",    "KC_M",    "KC_COMM", "MT(MOD_RSFT,KC_DOT)",    "KC_UP",           "RGB_VAD",
-      "KC_LCTL", "MT(MOD_LALT,KC_CAPS)",                                  "LT(2,KC_SPC)",                       "LT(1,KC_DEL)",           "KC_LEFT", "KC_DOWN", "KC_RGHT"
+      "KC_LSFT", "KC_Z",                 "KC_X",    "KC_C",    "KC_V",    "KC_B",         "KC_N",    "KC_M",    "KC_COMM", "RSFT_T(KC_DOT)",    "KC_UP",           "RGB_VAD",
+      "KC_LCTL", "LALT_T(KC_CAPS)",                                  "LT(2,KC_SPC)",                       "LT(1,KC_DEL)",           "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
       "KC_MINS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC", "_______",

--- a/public/keymaps/s/splitkb_kyria_rev1_default.json
+++ b/public/keymaps/s/splitkb_kyria_rev1_default.json
@@ -6,19 +6,19 @@
   "layers": [
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_E"  ,   "KC_R" ,   "KC_T" ,                                        "KC_Y",   "KC_U" ,  "KC_I" ,   "KC_O" ,  "KC_P" , "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOT)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_V" ,   "KC_B" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_N",   "KC_M" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
                                       "MO(6)" , "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
-     "KC_TAB"  ,"KC_QUOTE","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINUS)",
+     "KC_TAB"  ,"KC_QUOT","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINS)",
      "KC_LSFT" ,"KC_SCLN", "KC_Q"   ,  "KC_J"  ,   "KC_K" ,   "KC_X" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_B",   "KC_M" ,  "KC_W" ,   "KC_V" ,  "KC_Z" , "KC_RSFT",
                                  "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_F"  ,   "KC_P" ,   "KC_B" ,                                        "KC_J",   "KC_L" ,  "KC_U" ,   "KC_Y" ,"KC_SCLN", "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOT)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_D" ,   "KC_V" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_K",   "KC_H" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
                                  "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],

--- a/public/keymaps/s/splitkb_kyria_rev1_default.json
+++ b/public/keymaps/s/splitkb_kyria_rev1_default.json
@@ -6,21 +6,21 @@
   "layers": [
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_E"  ,   "KC_R" ,   "KC_T" ,                                        "KC_Y",   "KC_U" ,  "KC_I" ,   "KC_O" ,  "KC_P" , "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","MT(MOD_RCTL, KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOTE)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_V" ,   "KC_B" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_N",   "KC_M" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
-                                      "MO(6)" , "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                      "MO(6)" , "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  ,"KC_QUOTE","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "MT(MOD_RCTL, KC_MINUS)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINUS)",
      "KC_LSFT" ,"KC_SCLN", "KC_Q"   ,  "KC_J"  ,   "KC_K" ,   "KC_X" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_B",   "KC_M" ,  "KC_W" ,   "KC_V" ,  "KC_Z" , "KC_RSFT",
-                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                 "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_F"  ,   "KC_P" ,   "KC_B" ,                                        "KC_J",   "KC_L" ,  "KC_U" ,   "KC_Y" ,"KC_SCLN", "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "MT(MOD_RCTL, KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOTE)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_D" ,   "KC_V" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_K",   "KC_H" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
-                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                 "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
       "_______", "_______", "_______", "_______", "_______", "_______",                                     "KC_PGUP", "KC_HOME", "KC_UP",   "KC_END",  "KC_VOLU", "KC_DEL",

--- a/public/keymaps/s/splitkb_kyria_rev1_proton_c_default.json
+++ b/public/keymaps/s/splitkb_kyria_rev1_proton_c_default.json
@@ -6,19 +6,19 @@
   "layers": [
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_E"  ,   "KC_R" ,   "KC_T" ,                                        "KC_Y",   "KC_U" ,  "KC_I" ,   "KC_O" ,  "KC_P" , "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOT)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_V" ,   "KC_B" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_N",   "KC_M" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
                                       "MO(6)" , "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
-     "KC_TAB"  ,"KC_QUOTE","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINUS)",
+     "KC_TAB"  ,"KC_QUOT","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINS)",
      "KC_LSFT" ,"KC_SCLN", "KC_Q"   ,  "KC_J"  ,   "KC_K" ,   "KC_X" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_B",   "KC_M" ,  "KC_W" ,   "KC_V" ,  "KC_Z" , "KC_RSFT",
                                  "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_F"  ,   "KC_P" ,   "KC_B" ,                                        "KC_J",   "KC_L" ,  "KC_U" ,   "KC_Y" ,"KC_SCLN", "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOT)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_D" ,   "KC_V" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_K",   "KC_H" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
                                  "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],

--- a/public/keymaps/s/splitkb_kyria_rev1_proton_c_default.json
+++ b/public/keymaps/s/splitkb_kyria_rev1_proton_c_default.json
@@ -6,21 +6,21 @@
   "layers": [
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_E"  ,   "KC_R" ,   "KC_T" ,                                        "KC_Y",   "KC_U" ,  "KC_I" ,   "KC_O" ,  "KC_P" , "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","MT(MOD_RCTL, KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOTE)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_V" ,   "KC_B" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_N",   "KC_M" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
-                                      "MO(6)" , "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                      "MO(6)" , "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  ,"KC_QUOTE","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "MT(MOD_RCTL, KC_MINUS)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINUS)",
      "KC_LSFT" ,"KC_SCLN", "KC_Q"   ,  "KC_J"  ,   "KC_K" ,   "KC_X" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_B",   "KC_M" ,  "KC_W" ,   "KC_V" ,  "KC_Z" , "KC_RSFT",
-                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                 "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_F"  ,   "KC_P" ,   "KC_B" ,                                        "KC_J",   "KC_L" ,  "KC_U" ,   "KC_Y" ,"KC_SCLN", "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "MT(MOD_RCTL, KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOTE)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_D" ,   "KC_V" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_K",   "KC_H" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
-                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                 "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
       "_______", "_______", "_______", "_______", "_______", "_______",                                     "KC_PGUP", "KC_HOME", "KC_UP",   "KC_END",  "KC_VOLU", "KC_DEL",

--- a/public/keymaps/s/splitkb_kyria_rev2_default.json
+++ b/public/keymaps/s/splitkb_kyria_rev2_default.json
@@ -6,19 +6,19 @@
   "layers": [
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_E"  ,   "KC_R" ,   "KC_T" ,                                        "KC_Y",   "KC_U" ,  "KC_I" ,   "KC_O" ,  "KC_P" , "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOT)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_V" ,   "KC_B" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_N",   "KC_M" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
                                       "MO(6)" , "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
-     "KC_TAB"  ,"KC_QUOTE","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINUS)",
+     "KC_TAB"  ,"KC_QUOT","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINS)",
      "KC_LSFT" ,"KC_SCLN", "KC_Q"   ,  "KC_J"  ,   "KC_K" ,   "KC_X" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_B",   "KC_M" ,  "KC_W" ,   "KC_V" ,  "KC_Z" , "KC_RSFT",
                                  "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_F"  ,   "KC_P" ,   "KC_B" ,                                        "KC_J",   "KC_L" ,  "KC_U" ,   "KC_Y" ,"KC_SCLN", "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOT)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_D" ,   "KC_V" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_K",   "KC_H" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
                                  "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],

--- a/public/keymaps/s/splitkb_kyria_rev2_default.json
+++ b/public/keymaps/s/splitkb_kyria_rev2_default.json
@@ -6,21 +6,21 @@
   "layers": [
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_E"  ,   "KC_R" ,   "KC_T" ,                                        "KC_Y",   "KC_U" ,  "KC_I" ,   "KC_O" ,  "KC_P" , "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","MT(MOD_RCTL, KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOTE)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_V" ,   "KC_B" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_N",   "KC_M" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
-                                      "MO(6)" , "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                      "MO(6)" , "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  ,"KC_QUOTE","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "MT(MOD_RCTL, KC_MINUS)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINUS)",
      "KC_LSFT" ,"KC_SCLN", "KC_Q"   ,  "KC_J"  ,   "KC_K" ,   "KC_X" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_B",   "KC_M" ,  "KC_W" ,   "KC_V" ,  "KC_Z" , "KC_RSFT",
-                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                 "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_F"  ,   "KC_P" ,   "KC_B" ,                                        "KC_J",   "KC_L" ,  "KC_U" ,   "KC_Y" ,"KC_SCLN", "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "MT(MOD_RCTL, KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOTE)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_D" ,   "KC_V" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_K",   "KC_H" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
-                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                 "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
       "_______", "_______", "_______", "_______", "_______", "_______",                                     "KC_PGUP", "KC_HOME", "KC_UP",   "KC_END",  "KC_VOLU", "KC_DEL",

--- a/public/keymaps/s/splitkb_kyria_rev2_proton_c_default.json
+++ b/public/keymaps/s/splitkb_kyria_rev2_proton_c_default.json
@@ -6,19 +6,19 @@
   "layers": [
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_E"  ,   "KC_R" ,   "KC_T" ,                                        "KC_Y",   "KC_U" ,  "KC_I" ,   "KC_O" ,  "KC_P" , "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOT)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_V" ,   "KC_B" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_N",   "KC_M" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
                                       "MO(6)" , "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
-     "KC_TAB"  ,"KC_QUOTE","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINUS)",
+     "KC_TAB"  ,"KC_QUOT","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINS)",
      "KC_LSFT" ,"KC_SCLN", "KC_Q"   ,  "KC_J"  ,   "KC_K" ,   "KC_X" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_B",   "KC_M" ,  "KC_W" ,   "KC_V" ,  "KC_Z" , "KC_RSFT",
                                  "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_F"  ,   "KC_P" ,   "KC_B" ,                                        "KC_J",   "KC_L" ,  "KC_U" ,   "KC_Y" ,"KC_SCLN", "KC_BSPC",
-     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOT)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_D" ,   "KC_V" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_K",   "KC_H" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
                                  "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],

--- a/public/keymaps/s/splitkb_kyria_rev2_proton_c_default.json
+++ b/public/keymaps/s/splitkb_kyria_rev2_proton_c_default.json
@@ -6,21 +6,21 @@
   "layers": [
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_E"  ,   "KC_R" ,   "KC_T" ,                                        "KC_Y",   "KC_U" ,  "KC_I" ,   "KC_O" ,  "KC_P" , "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","MT(MOD_RCTL, KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_S"   ,  "KC_D"  ,   "KC_F" ,   "KC_G" ,                                        "KC_H",   "KC_J" ,  "KC_K" ,   "KC_L" ,"KC_SCLN","RCTL_T(KC_QUOTE)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_V" ,   "KC_B" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_N",   "KC_M" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
-                                      "MO(6)" , "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                      "MO(6)" , "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)", "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  ,"KC_QUOTE","KC_COMM",  "KC_DOT",   "KC_P" ,   "KC_Y" ,                                        "KC_F",   "KC_G" ,  "KC_C" ,   "KC_R" ,  "KC_L" , "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "MT(MOD_RCTL, KC_MINUS)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_O"   ,  "KC_E"  ,   "KC_U" ,   "KC_I" ,                                        "KC_D",   "KC_H" ,  "KC_T" ,   "KC_N" ,  "KC_S" , "RCTL_T(KC_MINUS)",
      "KC_LSFT" ,"KC_SCLN", "KC_Q"   ,  "KC_J"  ,   "KC_K" ,   "KC_X" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_B",   "KC_M" ,  "KC_W" ,   "KC_V" ,  "KC_Z" , "KC_RSFT",
-                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                 "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
      "KC_TAB"  , "KC_Q" ,  "KC_W"   ,  "KC_F"  ,   "KC_P" ,   "KC_B" ,                                        "KC_J",   "KC_L" ,  "KC_U" ,   "KC_Y" ,"KC_SCLN", "KC_BSPC",
-     "MT(MOD_LCTL, KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "MT(MOD_RCTL, KC_QUOTE)",
+     "LCTL_T(KC_ESC)" , "KC_A" ,  "KC_R"   ,  "KC_S"  ,   "KC_T" ,   "KC_G" ,                                        "KC_M",   "KC_N" ,  "KC_E" ,   "KC_I" ,  "KC_O" , "RCTL_T(KC_QUOTE)",
      "KC_LSFT" , "KC_Z" ,  "KC_X"   ,  "KC_C"  ,   "KC_D" ,   "KC_V" , "KC_LBRC","KC_CAPS",     "MO(5)"  , "KC_RBRC", "KC_K",   "KC_H" ,"KC_COMM", "KC_DOT" ,"KC_SLSH", "KC_RSFT",
-                                 "MO(6)", "KC_LGUI", "MT(MOD_LALT, KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
+                                 "MO(6)", "KC_LGUI", "LALT_T(KC_ENT)", "KC_SPC" , "MO(3)"   ,     "MO(4)"    , "KC_SPC" ,"KC_RALT", "KC_RGUI", "KC_APP"
     ],
     [
       "_______", "_______", "_______", "_______", "_______", "_______",                                     "KC_PGUP", "KC_HOME", "KC_UP",   "KC_END",  "KC_VOLU", "KC_DEL",

--- a/public/keymaps/s/splitty_rev1_default.json
+++ b/public/keymaps/s/splitty_rev1_default.json
@@ -9,7 +9,7 @@
       "KC_RBRC", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                 "KC_APP",          "KC_DEL",  "KC_Y",         "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC",
       "KC_TAB",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                                               "KC_H",         "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
       "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",                 "LGUI(KC_TAB)",    "KC_ENT",  "KC_N",         "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_BSLS",
-                            "KC_LGUI", "KC_LALT", "KC_ESC",  "MT(MOD_LCTL,KC_BSPC)", "KC_LSFT",         "KC_RSFT", "LT(1,KC_SPC)", "KC_RCTL", "KC_RALT", "KC_RGUI"
+                            "KC_LGUI", "KC_LALT", "KC_ESC",  "LCTL_T(KC_BSPC)", "KC_LSFT",         "KC_RSFT", "LT(1,KC_SPC)", "KC_RCTL", "KC_RALT", "KC_RGUI"
     ],
     [
       "_______", "_______", "_______", "_______", "_______", "_______", "_______",    "_______", "_______", "_______", "_______", "_______", "_______", "QK_BOOT",

--- a/public/keymaps/t/terrazzo_default.json
+++ b/public/keymaps/t/terrazzo_default.json
@@ -7,7 +7,7 @@
     [
       "KC_MUTE",    "KC_ESC",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",         "KC_T",    "KC_Y",         "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
       "TZ_NXT",     "KC_LCTL", "KC_A",    "KC_S",    "KC_D",    "KC_F",         "KC_G",    "KC_H",         "KC_J",    "KC_K",    "KC_L",               "KC_ENT",
-      "TZ_PRV",     "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",         "KC_B",    "KC_N",         "KC_M",    "KC_COMM", "KC_DOT",             "MT(MOD_RSFT,KC_SLSH)",
+      "TZ_PRV",     "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",         "KC_B",    "KC_N",         "KC_M",    "KC_COMM", "KC_DOT",             "RSFT_T(KC_SLSH)",
       "TZ_OFF",                "KC_LGUI", "KC_RALT",            "LT(2,KC_SPC)",            "LT(1,KC_SPC)",            "MO(3)",   "MO(4)"
     ],
     [

--- a/public/keymaps/t/trashman_ketch_default.json
+++ b/public/keymaps/t/trashman_ketch_default.json
@@ -7,7 +7,7 @@
     [
       "QK_GESC", "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
       "KC_TAB",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_ENT",
-      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_UP",   "MT(MOD_RSFT,KC_SLSH)",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_UP",   "RSFT_T(KC_SLSH)",
       "KC_LCTL", "KC_LGUI", "KC_LALT", "MO(1)",              "KC_SPC",  "KC_SPC",             "MO(2)",   "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Replace MT(\<mod\>, \<kc\>) by \<mod\>_T(<kc>)

The _T(kc) alias looks pretty in the configurator while the MT alias
uses the unpretty ANY key style.

This commit was made by executing the following command:
```zsh
/qmk_configurator/public
❯ sed -i -E "s/MT\(MOD_(\w+),\s*(\w+)\)/\1_T(\2)/g" **/*.json
```

Before:
![Default kyria with MT()](https://user-images.githubusercontent.com/57645186/186538932-39a86258-1b92-4cc4-8ca5-9ee9b21f5f1d.png)

After:
![Default Kyria with the changes of this PR](https://user-images.githubusercontent.com/57645186/186539025-cf3ea783-69c8-4f02-a2cf-8bbe86e4e553.png)

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
