### PR TITLE
Put non-US ISO keys in their expected spots in sagittarius' default keymap

### DIFF
--- a/public/keymaps/c/cannonkeys_sagittarius_default.json
+++ b/public/keymaps/c/cannonkeys_sagittarius_default.json
@@ -1,14 +1,14 @@
 {
   "keyboard": "cannonkeys/sagittarius",
   "keymap": "default",
-  "commit": "495a61ad7a14bb7dd4022f1837fc18085026cfde",
+  "commit": "1a4a2782519a94a5c418ab7e8800c45b3e4d60cf",
   "layout": "LAYOUT_default",
   "layers": [
     [
       "KC_PGUP", "QK_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",                  "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_DEL",
       "KC_PGDN", "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                  "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",
-      "KC_HOME", "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                  "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUBS", "KC_ENT",  "KC_ENT",
-      "KC_END",  "KC_LSFT", "KC_NUHS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",       "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_RSFT",
+      "KC_HOME", "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                  "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUHS", "KC_ENT",  "KC_ENT",
+      "KC_END",  "KC_LSFT", "KC_NUBS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",       "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_RSFT",
                  "KC_LCTL", "KC_LGUI",                       "KC_LALT",            "MO(1)",      "KC_SPC",             "KC_SPC",                        "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

See PR qmk/qmk_firmware#18005

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
