### PR TITLE
Do not uppercase single letter key legends

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -291,7 +291,7 @@ export default {
       );
     },
     formatName(name) {
-      return name.length === 1 ? name.toUpperCase() : name;
+      return name;
     },
     remove() {
       this.setSelected(this.id);

--- a/src/components/Keycode.vue
+++ b/src/components/Keycode.vue
@@ -60,7 +60,7 @@ export default {
       return classes.join(' ');
     },
     displayName() {
-      return this.name.length === 1 ? this.name.toUpperCase() : this.name;
+      return this.name;
     },
     displayTitle() {
       return this.title ? `${this.code}\n${this.title}` : this.code;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It is not necessary and in the cases of OS keyboard layouts like French (France) or French (Switzerland) that have lowercase letters as the shift keysyms, it is wrong.

`FR_MICR` incorrectly displayed as capital µ which looks visually identical to capital latin M which also happens to be KC_CLN.
![Capital M and Capital Mu in French layout](https://user-images.githubusercontent.com/57645186/188436070-ed8714cd-6ef4-49e6-8394-d500aaf426c2.png)

FR-Swiss diaeresis keys incorrectly displayed in capital form even though the actual output is lowercase:
![FR-swiss diaeresis highlighted](https://user-images.githubusercontent.com/57645186/188434571-e9c6c8d4-4328-4c87-a976-4fcbe238b232.png)

(Screenshots done with the #1165 PR)

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
