### PR TITLE
Layout reset prompt when returning from "print keymap" or "test keyboard"

### DIFF
--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -210,7 +210,9 @@ export default {
   },
   async mounted() {
     await this.initializeKeyboards();
-    await this.loadDefault(true);
+    if (!this.isDirty) {
+      await this.loadDefault(true);
+    }
     await this.initTemplates();
   },
   methods: {

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -99,7 +99,7 @@ export default {
   name: 'ControllerTop',
   data: () => {
     return {
-      keymapName: '',
+      // keymapName: '',
       firstRun: true
     };
   },
@@ -117,8 +117,16 @@ export default {
     isFavoriteKeyboard() {
       return this.keyboard === this.configuratorSettings.favoriteKeyboard;
     },
-    realKeymapName() {
-      return this.$store.getters['app/keymapName'];
+    // realKeymapName() {
+    //   return this.$store.getters['app/keymapName'];
+    // },
+    keymapName: {
+      get() {
+        return this.$store.state.app.keymapName;
+      },
+      set(value) {
+        this.setKeymapName(value);
+      }
     },
     keyboard: {
       get() {
@@ -178,16 +186,16 @@ export default {
      * When changes happen locally we update the store.
      * When changes happen to the store we update the local version.
      */
-    keymapName: function (newKeymapName, oldKeymapName) {
-      if (newKeymapName !== oldKeymapName) {
-        this.updateKeymapName(newKeymapName);
-      }
-    },
-    realKeymapName: function (newName, oldName) {
-      if (newName !== oldName) {
-        this.keymapName = newName;
-      }
-    },
+    // keymapName: function (newKeymapName, oldKeymapName) {
+    //   if (newKeymapName !== oldKeymapName) {
+    //     this.updateKeymapName(newKeymapName);
+    //   }
+    // },
+    // realKeymapName: function (newName, oldName) {
+    //   if (newName !== oldName) {
+    //     this.keymapName = newName;
+    //   }
+    // },
     $route: function (to /*, from*/) {
       if (to.query) {
         const filter = to.query.filter;
@@ -260,7 +268,10 @@ export default {
           ).then(async () => {
             // clear the keymap name for the default keymap
             // otherwise it overrides the default getter
-            this.updateKeymapName('');
+
+            // this.updateKeymapName('');
+            this.setKeymapName('');
+
             const stats = await this.load_converted_keymap(data.layers);
             let msg = this.$t('statsTemplate', stats);
             if (stats.warnings.length > 0 || stats.errors.length > 0) {
@@ -396,12 +407,12 @@ export default {
           throw err;
         });
     },
-    updateKeymapName(newKeymapName) {
-      this.keymapName = newKeymapName;
-      this.setKeymapName(newKeymapName);
-    },
+    // updateKeymapName(newKeymapName) {
+    //   this.keymapName = newKeymapName;
+    //   this.setKeymapName(newKeymapName);
+    // },
     compile() {
-      let keymapName = this.realKeymapName;
+      let keymapName = this.keymapName;
       let _keymapName = this.exportKeymapName;
       // TODO extract this name function to the store
       keymapName =

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -99,7 +99,6 @@ export default {
   name: 'ControllerTop',
   data: () => {
     return {
-      // keymapName: '',
       firstRun: true
     };
   },
@@ -117,15 +116,12 @@ export default {
     isFavoriteKeyboard() {
       return this.keyboard === this.configuratorSettings.favoriteKeyboard;
     },
-    // realKeymapName() {
-    //   return this.$store.getters['app/keymapName'];
-    // },
     keymapName: {
       get() {
         return this.$store.state.app.keymapName;
       },
       set(value) {
-        this.setKeymapName(value);
+        this.updateKeymapName(value);
       }
     },
     keyboard: {
@@ -186,16 +182,6 @@ export default {
      * When changes happen locally we update the store.
      * When changes happen to the store we update the local version.
      */
-    // keymapName: function (newKeymapName, oldKeymapName) {
-    //   if (newKeymapName !== oldKeymapName) {
-    //     this.updateKeymapName(newKeymapName);
-    //   }
-    // },
-    // realKeymapName: function (newName, oldName) {
-    //   if (newName !== oldName) {
-    //     this.keymapName = newName;
-    //   }
-    // },
     $route: function (to /*, from*/) {
       if (to.query) {
         const filter = to.query.filter;
@@ -230,13 +216,13 @@ export default {
       'stopListening',
       'startListening',
       'previewRequested',
-      'setKeyboard',
-      'setKeymapName'
+      'setKeyboard'
     ]),
     ...mapActions('app', [
       'changeKeyboard',
       'fetchKeyboards',
       'loadDefaultKeymap',
+      'updateKeymapName',
       'setFavoriteKeyboard'
     ]),
     ...mapActions('keymap', ['initTemplates', 'load_converted_keymap']),
@@ -268,10 +254,7 @@ export default {
           ).then(async () => {
             // clear the keymap name for the default keymap
             // otherwise it overrides the default getter
-
-            // this.updateKeymapName('');
-            this.setKeymapName('');
-
+            this.updateKeymapName('');
             const stats = await this.load_converted_keymap(data.layers);
             let msg = this.$t('statsTemplate', stats);
             if (stats.warnings.length > 0 || stats.errors.length > 0) {
@@ -407,10 +390,6 @@ export default {
           throw err;
         });
     },
-    // updateKeymapName(newKeymapName) {
-    //   this.keymapName = newKeymapName;
-    //   this.setKeymapName(newKeymapName);
-    // },
     compile() {
       let keymapName = this.keymapName;
       let _keymapName = this.exportKeymapName;

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -257,6 +257,21 @@ const actions = {
     });
 
     commit('setKeypressListener', () => keypressListener);
+  },
+
+  /**
+   * update keymapName and set/clear dirty in store
+   */
+  async updateKeymapName({ commit, rootState }, _keymapName) {
+    const store = this;
+
+    commit('setKeymapName', _keymapName);
+    if (_keymapName !== '' && !rootState.keymap.dirty) {
+      store.commit('keymap/setDirty');
+    }
+    if (_keymapName === '' && rootState.keymap.dirty) {
+      store.commit('keymap/clearDirty');
+    }
   }
 };
 

--- a/src/store/modules/app/getters.js
+++ b/src/store/modules/app/getters.js
@@ -8,14 +8,6 @@ const getters = {
     return valid;
   },
   filter: (state) => state.filter,
-  /**
-   * keymapName
-   * @param {object} state of store
-   * @return {string} parsed filtered keymap name
-   */
-  keymapName: (state) => {
-    return state.keymapName.replace(/\s/g, '_').toLowerCase();
-  },
   exportKeymapName: (state) => {
     let exportName = state.keymapName.replace(/[\s/]/g, '_').toLowerCase();
     if (exportName === '') {

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -26,7 +26,6 @@ const mutations = {
   disablePreview(state) {
     state.isPreview = false;
     state.keyboards = state.keyboards.filter((k) => k !== PREVIEW_LABEL);
-    state.keymapName = '';
   },
   setKeyboard(state, _keyboard) {
     state.keyboard = _keyboard;


### PR DESCRIPTION
## Description

Change in `mounted()` in ControllerTop component fixes first issue - prompt "This will clear your keymap - are you sure you want to load default keymap?".

Other changes are related to bug's second part - force resetting keymap name input. My approach also relies on using `keymap.dirty` from store. I created action `updateKeymapName` that updates value in store and toggles `keymap.dirty` if value isn't empty.

If you have better idea how to fix this, I'm open to suggestions.

When I was fixing this issue I merged `realKeymapName` and `keymapName`. First one was value from store, second one was input's value. Changing one value was automatically updating another. Now `keymapName` uses computed property so it can be bound to input value and no warnings are thrown.

Fixed #796