### PR TITLE
add default keymap: era/era65

### DIFF
--- a/public/keymaps/e/era_era65_default.json
+++ b/public/keymaps/e/era_era65_default.json
@@ -1,0 +1,23 @@
+{
+  "keyboard": "era/era65",
+  "keymap": "default",
+  "commit": "",
+  "layout": "LAYOUT_65_combo",
+  "layers":
+  [
+	[
+		"QK_GESC", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_INS",
+        "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_DEL",
+        "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_NUHS", "KC_ENT",  "KC_PGUP",
+        "KC_LSFT", "KC_BSLS", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",   "KC_PGDN",
+        "KC_LCTL", "KC_LGUI", "KC_LALT",                                  "KC_SPC",                        "KC_RALT", "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+	],
+	[
+        "KC_GRV",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "_______", "_______",
+        "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "KC_PSCR", "KC_SCRL", "KC_PAUS", "KC_INS",
+        "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "KC_HOME",
+        "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "KC_MUTE", "KC_VOLD", "KC_VOLU", "_______", "_______", "_______", "KC_END",
+        "_______", "_______", "_______",                                  "_______",                       "_______", "_______", "_______", "_______", "_______", "_______"
+    ]
+  ]
+}

--- a/public/keymaps/e/era_era65_default.json
+++ b/public/keymaps/e/era_era65_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "era/era65",
   "keymap": "default",
-  "commit": "",
+  "commit": "4098ff5574ab8129b83239ed9de6f1820b31b686",
   "layout": "LAYOUT_65_combo",
   "layers":
   [

--- a/public/keymaps/e/era_era65_default.json
+++ b/public/keymaps/e/era_era65_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "era/era65",
   "keymap": "default",
-  "commit": "4098ff5574ab8129b83239ed9de6f1820b31b686",
+  "commit": "300a0def4e20507f20b61507ed3dc3c65f3bf6a0",
   "layout": "LAYOUT_65_combo",
   "layers":
   [


### PR DESCRIPTION
Add json default layout file for era/era65

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
