### PR TITLE
Add Bubble75 Default Keymap

### DIFF
--- a/public/keymaps/b/bubble75_hotswap_default.json
+++ b/public/keymaps/b/bubble75_hotswap_default.json
@@ -2,7 +2,7 @@
     "keyboard": "bubble75/hotswap",
     "keymap": "default",
     "commit": "49f3ffa2640c6f84dd29a7f90b22ce22d0bcbea6",
-    "layout": "LAYOUT_all",
+    "layout": "LAYOUT",
     "layers": [
       [
       "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",             "KC_F13",

--- a/public/keymaps/b/bubble75_hotswap_default.json
+++ b/public/keymaps/b/bubble75_hotswap_default.json
@@ -1,0 +1,24 @@
+{
+    "keyboard": "bubble75/hotswap",
+    "keymap": "default",
+    "commit": "49f3ffa2640c6f84dd29a7f90b22ce22d0bcbea6",
+    "layout": "LAYOUT_all",
+    "layers": [
+      [
+      "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",             "KC_F13",
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_PGUP", 
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_PGDN",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT", "KC_ENT",             "KC_END",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT",            "KC_UP",   "KC_DEL",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",                       "KC_SPC",                                              "KC_RALT", "MO(1)",   "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "QK_BOOT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RGB_SAI",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "RGB_SAD",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "RGB_HUI",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "RGB_VAI", "RGB_HUD",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS",                       "RGB_MOD",                                             "RGB_TOG", "KC_TRNS", "RGB_SPD", "RGB_VAD", "RGB_SPI"
+      ]
+    ]
+  }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add support for Bubble75. Bubble75 is a compact exploded F-Row 75% keyboard with Per-Key RGB.
