### PR TITLE
Add default keymap: keaboard/rev1

### DIFF
--- a/public/keymaps/k/keaboard_rev1_default.json
+++ b/public/keymaps/k/keaboard_rev1_default.json
@@ -1,0 +1,27 @@
+{
+  "keyboard": "keaboard/rev1",
+  "keymap": "default",
+  "commit": "999200c05a376638b0c9e6f383c9e0e0aef69a34",
+  "layout": "LAYOUT",
+  "layers":
+  [
+    [
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                                   "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_BSPC",
+      "KC_ESC",  "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                                   "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_F2",            "KC_F12",  "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_BSLS",
+      "KC_DEL",  "KC_LALT", "KC_LCTL", "KC_LGUI",            "MO(1)",   "KC_ENT",           "KC_SPC",  "MO(2)",              "KC_LEFT", "KC_DOWN", "KC_UP",   "KC_RGHT"
+    ],
+    [
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",                                   "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",                                "KC_TRNS", "KC_MINS", "KC_EQL",  "KC_LBRC", "KC_RBRC", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",          "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",          "KC_TRNS", "KC_TRNS",            "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
+    ],
+    [
+      "KC_TILD", "KC_EXLM",  "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC",                                "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_LPRN", "KC_RPRN", "KC_TRNS",
+      "KC_TRNS", "KC_F1",    "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",                                  "KC_F6",   "KC_UNDS", "KC_PLUS", "KC_LCBR", "KC_RCBR", "KC_DQUO",
+      "KC_TRNS", "KC_F7",    "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_TRNS",          "KC_TRNS", "KC_F12",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_PIPE",
+      "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS",            "KC_TRNS", "KC_TRNS",          "KC_TRNS", "KC_TRNS",            "KC_HOME", "KC_PGDN", "KC_PGUP", "KC_END"
+    ]
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Add default keymap for keaboard/rev1

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

Add default keymap for keaboard/rev1.

QMK Firmware PR: https://github.com/qmk/qmk_firmware/pull/19816
