### PR TITLE
Basketweave piit79

### DIFF
--- a/public/keymaps/b/basketweave_piit79_default.json
+++ b/public/keymaps/b/basketweave_piit79_default.json
@@ -2,7 +2,7 @@
   "keyboard": "basketweave",
   "keymap": "default",
   "commit": "b7771ec25b96f2b88a7fa4201081e10ca6fbb9d4",
-  "layout": "LAYOUT_default",
+  "layout": "LAYOUT_piit79",
   "layers": [
     [
       "QK_GESC", "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_PGUP",

--- a/public/keymaps/b/basketweave_piit79_default.json
+++ b/public/keymaps/b/basketweave_piit79_default.json
@@ -1,0 +1,22 @@
+{
+  "keyboard": "basketweave",
+  "keymap": "default",
+  "commit": "b7771ec25b96f2b88a7fa4201081e10ca6fbb9d4",
+  "layout": "LAYOUT_default",
+  "layers": [
+    [
+      "QK_GESC", "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_PGUP",
+      "KC_INS",  "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_PGDN",
+      "KC_MUTE",  "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT", "KC_DEL",
+                 "KC_LSFT", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_RSFT", "KC_UP",
+                 "KC_LCTL", "KC_LALT",            "KC_SPC",             "MO(1)",              "KC_SPC",             "KC_RALT", "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+    ],
+    [
+      "KC_TRNS", "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "QK_BOOT", "KC_TRNS", "KC_TRNS", "KC_INS",  "KC_TRNS", "KC_TRNS", "KC_PSCR", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MPLY",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_INS",             "KC_TRNS",
+                 "KC_LSFT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_MUTE", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_RSFT", "KC_PGUP",
+                 "KC_LCTL", "KC_LALT",            "KC_TRNS",            "KC_TRNS",            "KC_TRNS",            "KC_RALT", "KC_RCTL", "KC_HOME", "KC_PGDN", "KC_END"
+    ]
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

Add piit79 layout.
From his website :
"Modified by [piit79](https://github.com/piit79) of 42. Keebs. This is revision 1.9 which features the following modifications:

Symmetric 3-key macro cluster on the right
Support for two rotary encoders, one on each side, either in the top or the bottom macro position. A standard switch can also be used instead of each encoder
Split backspace support"

## Description

Just added his layout from his github.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
