### PR TITLE
force `keyboardPath` to use lowercase folder names

### DIFF
--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -31,7 +31,7 @@ const actions = {
    * load the default keymap for the currently selected keyboard
    */
   async loadDefaultKeymap({ state }) {
-    const keyboardPath = state.keyboard.slice(0, 1);
+    const keyboardPath = state.keyboard.slice(0, 1).toLowerCase();
     // eslint-disable-next-line
     const keyboardName = state.keyboard.replace(/\//g, '_');
     const resp = await axios.get(


### PR DESCRIPTION
## Description

A long time ago, I worked out a method for previewing Configurator keymaps against still-pending `info.json` updates to `qmk/qmk_firmware`, which worked great when I was on Windows, which is case-insensitive. But now I've switched to Linux Mint as my main OS, and my method no longer works. :rofl: