### PR TITLE
Fix legends display for Layer-Tap keys

### DIFF
--- a/src/components/LayerContainerKey.vue
+++ b/src/components/LayerContainerKey.vue
@@ -14,7 +14,7 @@
     @dragover.prevent="dragover"
     @dragenter="dragenter"
     @dragleave="dragleave"
-  ><div>LT {{ meta.layer }}<div
+  ><div>{{ layerDisplayName }}<div
   v-if="isShowingKeymapLegends"
   class="key-contents"
   :class="contentClasses"
@@ -43,6 +43,12 @@ export default {
       const contents =
         (this.meta.contents && this.meta.contents.code) || 'KC_NO';
       return `LT(${this.meta.layer}, ${contents})`;
+    },
+    layerDisplayName() {
+      if (this.isShowingKeymapLegends) {
+        return `LT ${this.meta.layer}`;
+      }
+      return this.displayName;
     },
     contents() {
       if (this.meta.contents) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Didn't realise `LT()` is a special case here.
