### PR TITLE
Display `,` for KC_PDOT if layout is RU

### DIFF
--- a/src/i18n/keymap_extras/keymap_russian.js
+++ b/src/i18n/keymap_extras/keymap_russian.js
@@ -164,5 +164,7 @@ export default {
   QK_GESC: {
     name: 'Ё\nEsc',
     title: 'Esc normally, but Ё when Shift or GUI is active'
-  }
+  },
+
+  KC_PDOT: { name: ',', title: '' } // No RU alias exist in QMK
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`KC_PDOT` actually produces a comma, not a dot, if the keyboard layout is set to Russian.

![gnome keyboard layout viewer of the russian layout](https://github.com/qmk/qmk_configurator/assets/57645186/dc0e690f-9ac6-42c5-baac-e722a96fc92f)

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
