### PR TITLE
Add ScottoStarter keymap

### DIFF
--- a/public/keymaps/h/handwired_scottokeebs_scottostarter_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scottostarter_default.json
@@ -1,0 +1,36 @@
+{
+  "keyboard": "handwired/scottokeebs/scottostarter",
+  "keymap": "default",
+  "commit": "e1c4b7ce30fde339f0f3c284aa5142bee66a6a4e",
+  "layout": "LAYOUT_ortho_4x11_8",
+  "layers": [
+    [
+      "KC_1",         "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_BSPC",
+      "KC_Q",         "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_TAB",
+      "KC_A",         "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",
+      "LSFT_T(KC_Z)", "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "RSFT_T(KC_SLSH)", "KC_ENT",
+      "KC_LCTL",      "KC_LGUI", "KC_LALT",            "KC_SPC",                        "MO(1)",   "MO(2)",   "KC_ESC",  "KC_CAPS"
+    ],
+    [
+      "KC_NO",           "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",           "KC_DEL",
+      "KC_UNDS",         "KC_MINS", "KC_PLUS", "KC_EQL",  "KC_COLN", "KC_GRV",  "KC_MRWD", "KC_MPLY", "KC_MFFD", "KC_NO",           "KC_TAB",
+      "KC_LCBR",         "KC_LPRN", "KC_RPRN", "KC_RCBR", "KC_PIPE", "KC_ESC",  "KC_LEFT", "KC_UP",   "KC_DOWN", "KC_RGHT",         "KC_QUOT",
+      "LSFT_T(KC_LBRC)", "KC_QUOT", "KC_DQUO", "KC_RBRC", "KC_SCLN", "KC_TILD", "KC_VOLD", "KC_MUTE", "KC_VOLU", "RSFT_T(KC_BSLS)", "KC_ENT",
+      "KC_LCTL",         "KC_LGUI", "KC_LALT",            "KC_SPC",                        "KC_TRNS", "KC_TRNS", "KC_ESC",          "KC_CAPS"
+    ],
+    [
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",           "KC_BSPC",
+      "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_CAPS", "KC_BSPC",         "KC_TAB",
+      "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",            "KC_QUOT",
+      "KC_LSFT", "KC_NO",   "KC_NO",   "KC_NO",   "MO(3)",   "KC_NO",   "KC_NO",   "KC_COMM", "KC_DOT",  "RSFT_T(KC_SLSH)", "KC_ENT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",            "KC_SPC",                        "KC_TRNS", "KC_TRNS", "KC_ESC",          "KC_CAPS"
+    ],
+    [
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_BSPC",
+      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "TO(4)",   "KC_TAB",
+      "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_QUOT",
+      "KC_F11",  "KC_NO",   "KC_NO",   "QK_BOOT", "KC_TRNS", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_F12",  "KC_ENT",
+      "KC_LCTL", "KC_LGUI", "KC_LALT",            "KC_SPC",                        "KC_TRNS", "KC_TRNS", "KC_ESC",  "KC_CAPS"
+    ]
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add default keymap for the ScottoStarter handwired keyboard.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
