### PR TITLE
Fix LT functions by removing space

### DIFF
--- a/public/keymaps/h/handwired_scottokeebs_scotto36_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scotto36_default.json
@@ -5,10 +5,10 @@
     "layout": "LAYOUT_split_3x5_3",
     "layers": [
         [
-            "KC_Q",         "KC_W", "KC_E",    "KC_R",    "KC_T",           "KC_Y",          "KC_U",          "KC_I",     "KC_O",   "KC_P",
-            "KC_A",         "KC_S", "KC_D",    "KC_F",    "KC_G",           "KC_H",          "KC_J",          "KC_K",     "KC_L",   "KC_BSPC",
-            "LSFT_T(KC_Z)", "KC_X", "KC_C",    "KC_V",    "KC_B",           "KC_N",          "KC_M",          "KC_COMMA", "KC_DOT", "RSFT_T(KC_SLSH)",
-                                    "KC_LCTL", "KC_LALT", "LGUI_T(KC_SPC)", "LT(1, KC_TAB)", "LT(2, KC_ENT)", "KC_ESC"
+            "KC_Q",         "KC_W", "KC_E",    "KC_R",    "KC_T",           "KC_Y",         "KC_U",         "KC_I",     "KC_O",   "KC_P",
+            "KC_A",         "KC_S", "KC_D",    "KC_F",    "KC_G",           "KC_H",         "KC_J",         "KC_K",     "KC_L",   "KC_BSPC",
+            "LSFT_T(KC_Z)", "KC_X", "KC_C",    "KC_V",    "KC_B",           "KC_N",         "KC_M",         "KC_COMMA", "KC_DOT", "RSFT_T(KC_SLSH)",
+                                    "KC_LCTL", "KC_LALT", "LGUI_T(KC_SPC)", "LT(1,KC_TAB)", "LT(2,KC_ENT)", "KC_ESC"
         ],
         [
             "KC_UNDS",         "KC_MINS", "KC_PLUS", "KC_EQL",  "KC_COLN", "KC_GRV",   "KC_MRWD", "KC_MPLY", "KC_MFFD", "KC_DEL",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
`keyboards/scottokeebs/scotto36` needed the space between the comma and keycode removed in order for the configurator to pick up on it. `LT(1, KC_TAB)` needed to be `LT(1, KC_TAB)` along with other `LT()` functions.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
