### PR TITLE
Add Scotto9 default keymap

### DIFF
--- a/public/keymaps/h/handwired_scottokeebs_scotto9_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scotto9_default.json
@@ -1,0 +1,14 @@
+{
+    "keyboard": "handwired/scottokeebs/scotto9",
+    "keymap": "default",
+    "commit": "1914fbd951ada70259a13b2d35282d299078fa0f",
+    "layout": "LAYOUT_ortho_3x3",
+    "layers": [
+        [
+            "KC_1",    "KC_2",    "KC_3",
+            "KC_4",    "KC_5",    "KC_6",
+            "KC_7",    "KC_8",    "KC_9"
+        ]
+    ]
+}
+  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add default keymap for the handwired scotto9 macropad.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
