### PR TITLE
Add ScottoNum default keymap

### DIFF
--- a/public/keymaps/h/handwired_scottokeebs_scottonum_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scottonum_default.json
@@ -1,0 +1,15 @@
+{
+    "keyboard": "handwired/scottokeebs/scottonum",
+    "keymap": "default",
+    "commit": "ca6921b1ba422e4276e45062a115bec854864a90",
+    "layout": "LAYOUT_numpad_4x5",
+    "layers": [
+        [
+            "KC_CIRCUMFLEX", "KC_KP_SLASH", "KC_KP_ASTERISK", "KC_KP_MINUS",
+            "KC_KP_7",       "KC_KP_8",      "KC_KP_9",        "KC_KP_PLUS",
+            "KC_KP_4",       "KC_KP_5",      "KC_KP_6",
+            "KC_KP_1",       "KC_KP_2",      "KC_KP_3",        "KC_KP_ENTER",
+            "KC_KP_0",       "KC_KP_DOT"
+        ]
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add default keymap for the ScottoNum handwired macropad.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
