### PR TITLE
Add ScottoFrog default keymap

### DIFF
--- a/public/keymaps/h/handwired_scottokeebs_scottofrog_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scottofrog_default.json
@@ -1,0 +1,14 @@
+{
+    "keyboard": "handwired/scottokeebs/scottofrog",
+    "keymap": "default",
+    "commit": "2d838d8ba9acb98f93cf2549e4296399b7d1a7b4",
+    "layout": "LAYOUT_ortho_3x5_5",
+    "layers": [
+        [
+                   "KC_Q", "KC_W", "KC_E",  "KC_W", "KC_R",
+                   "KC_A", "KC_S", "KC_D",  "KC_F", "KC_G",
+                   "KC_Z", "KC_X", "KC_C",  "KC_V", "KC_B",
+            "KC_NO", "KC_NO",      "KC_NO",       "KC_LCTL", "KC_SPC"
+        ]
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add default keymap for the ScottoFrog handwired macropad.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
