### PR TITLE
softle/rev1: Fix default keymap

### DIFF
--- a/public/keymaps/s/sofle_rev1_default.json
+++ b/public/keymaps/s/sofle_rev1_default.json
@@ -27,8 +27,8 @@
     ],
     [
       "_______", "_______", "_______", "_______", "_______", "_______",                          "_______", "_______",    "_______", "_______",    "_______",    "_______",
-      "_______", "KC_INS",  "KC_PSCR", "KC_APP",  "XXXXXXX", "XXXXXXX", "                         KC_PGUP", "C(KC_LEFT)", "KC_UP",   "C(KC_RGHT)", "C(KC_BSPC)", "KC_BSPC",
-      "_______", "KC_LALT", "KC_LCTL", "KC_LSFT", "XXXXXXX", "KC_CAPS", "                         KC_PGDN", "KC_LEFT",    "KC_DOWN", "KC_RGHT",    "KC_DEL",     "KC_BSPC",
+      "_______", "KC_INS",  "KC_PSCR", "KC_APP",  "XXXXXXX", "XXXXXXX",                          "KC_PGUP", "C(KC_LEFT)", "KC_UP",   "C(KC_RGHT)", "C(KC_BSPC)", "KC_BSPC",
+      "_______", "KC_LALT", "KC_LCTL", "KC_LSFT", "XXXXXXX", "KC_CAPS",                          "KC_PGDN", "KC_LEFT",    "KC_DOWN", "KC_RGHT",    "KC_DEL",     "KC_BSPC",
       "_______", "C(KC_Z)", "C(KC_X)", "C(KC_C)", "C(KC_V)", "XXXXXXX", "_______",    "_______", "XXXXXXX", "KC_HOME",    "XXXXXXX", "KC_END",     "XXXXXXX",    "_______",
                             "_______", "_______", "_______", "MO(4)",   "_______",    "_______", "_______", "_______",    "_______", "_______"
     ],


### PR DESCRIPTION
## Description

For some reasons there were leading spaces inside some keycode values in the `sofle/rev` default keymap, which caused known keycodes like `KC_PGUP` and `KC_PGDN` to be displayed as “Any” keys.  This did not break the build, but some configurator users were confused: https://discord.com/channels/440868230475677696/867530744116543508/1121873710962442380 .

If this keymap was converted from C by some script, maybe it needs some fixing.