### PR TITLE
correct keycodes for dactyl_manuform variants `5x7` and `6x7`

### DIFF
--- a/public/keymaps/h/handwired_dactyl_manuform_5x7_default.json
+++ b/public/keymaps/h/handwired_dactyl_manuform_5x7_default.json
@@ -7,12 +7,12 @@
     [
       "KC_ESC",        "KC_1",    "KC_2",               "KC_3",         "KC_4",    "KC_5",    "KC_6",
       "KC_TAB",        "KC_Q",    "KC_W",               "KC_E",         "KC_R",    "KC_T",    "KC_LBRC",
-      "KC_LCTL",       "KC_A",    "KC_S",               "KC_D",         "KC_F",    "KC_G",    "LCTL(LSFT(KC_T))",
+      "KC_LCTL",       "KC_A",    "KC_S",               "KC_D",         "KC_F",    "KC_G",    "RCS(KC_T)",
       "OSM(MOD_LSFT)", "KC_Z",    "KC_X",               "KC_C",         "KC_V",    "KC_B",
-      "KC_CAPS",       "KC_LGUI", "LCTL(LSFT(KC_TAB))", "LCTL(KC_TAB)",
+      "KC_CAPS",       "KC_LGUI", "RCS(KC_TAB)", "LCTL(KC_TAB)",
                                                                         "TT(1)",   "KC_SPC",
                                                                                               "KC_END",           "KC_HOME",
-                                                                                              "KC_PSCR",          "LCTL(LSFT(KC_ESC))",
+                                                                                              "KC_PSCR",          "RCS(KC_ESC)",
 
                        "KC_7",    "KC_8",               "KC_9",         "KC_0",    "KC_MINS", "KC_EQL",           "KC_GRV",
                        "KC_RBRC", "KC_Y",               "KC_U",         "KC_I",    "KC_O",    "KC_P",             "KC_BSLS",

--- a/public/keymaps/h/handwired_dactyl_manuform_6x7_default.json
+++ b/public/keymaps/h/handwired_dactyl_manuform_6x7_default.json
@@ -7,7 +7,7 @@
     [
       "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",      "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "_______",
       "_______", "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",       "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_LBRC", "KC_RBRC",
-      "_______", "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",       "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_QUOT", "KC_BACKSLASH",
+      "_______", "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",       "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_QUOT", "KC_BSLS",
       "_______", "KC_LSFT", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",       "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_LSFT", "_______",
       "_______", "KC_LCTL", "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",       "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH", "KC_LCTL", "_______",
                                        "KC_LBRC", "KC_RBRC",                                                "KC_PLUS", "KC_EQL",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

As titled
<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
