### PR TITLE
Add ScottoCMD and ScottoFrog default keymaps

### DIFF
--- a/public/keymaps/h/handwired_scottokeebs_scottocmd_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scottocmd_default.json
@@ -1,0 +1,37 @@
+{
+    "keyboard": "handwired/scottokeebs/scottocmd",
+    "keymap": "default",
+    "commit": "4e27bd2a9aa929c14d9562c949029af3c9b55c23",
+    "layout": "LAYOUT_ortho_4_3x10_4",
+    "layers": [
+        [
+                                                                                                       "KC_LCTL",      "KC_2",     "KC_3",         "KC_ESC",
+            "KC_TAB", "KC_Q",         "KC_W",  "KC_E",    "KC_R",    "KC_T",           "KC_Y",         "KC_U",         "KC_I",     "KC_O",         "KC_P",
+            "KC_ENT", "KC_A",         "KC_S",  "KC_D",    "KC_F",    "KC_G",           "KC_H",         "KC_J",         "KC_K",     "KC_L",         "KC_BSPC",
+                      "LSFT_T(KC_Z)", "KC_X",  "KC_C",    "KC_V",    "KC_B",           "KC_N",         "KC_M",         "KC_COMMA", "KC_DOT",       "RSFT_T(KC_SLSH)",
+                      "KC_LALT",                                     "LGUI_T(KC_SPC)",                                             "LT(1,KC_TAB)", "LT(2,KC_ENT)"
+        ],
+        [
+                                                                                                  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "KC_UNDS",         "KC_MINS", "KC_PLUS", "KC_EQL",  "KC_COLN", "KC_GRV",   "KC_MRWD", "KC_MPLY", "KC_MFFD", "KC_DEL",
+            "KC_TRNS", "KC_LCBR",         "KC_LPRN", "KC_RPRN", "KC_RCBR", "KC_PIPE", "KC_ESC",   "KC_LEFT", "KC_UP",   "KC_DOWN", "KC_RGHT",
+                       "LSFT_T(KC_LBRC)", "KC_QUOT", "KC_DQUO", "KC_RBRC", "KC_SCLN", "KC_TILDE", "KC_VOLD", "KC_MUTE", "KC_VOLU", "RSFT_T(KC_BSLS)",
+                       "KC_TRNS",                                          "KC_TRNS",                                   "KC_TRNS", "KC_TRNS" 
+        ],
+        [
+                                                                                         "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_CAPS", "KC_BSPC",
+            "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",
+                       "KC_LSFT", "KC_NO",   "KC_NO",   "KC_NO",   "MO(3)",   "KC_NO",   "KC_NO",   "KC_COMM", "KC_DOT",  "RSFT_T(KC_SLSH)",
+                       "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS" 
+        ],
+        [
+                                                                                         "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+            "KC_TRNS", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO", 
+            "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",
+                       "KC_F11",  "KC_NO",   "KC_NO",   "QK_BOOT", "KC_TRNS", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_F12",
+                       "KC_TRNS",                                  "KC_TRNS",                                  "KC_TRNS", "KC_TRNS" 
+        ]
+      ]
+  }
+  

--- a/public/keymaps/h/handwired_scottokeebs_scottofrog_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scottofrog_default.json
@@ -1,0 +1,14 @@
+{
+    "keyboard": "handwired/scottokeebs/scottofrog",
+    "keymap": "default",
+    "commit": "2d838d8ba9acb98f93cf2549e4296399b7d1a7b4",
+    "layout": "LAYOUT_ortho_3x5_5",
+    "layers": [
+        [
+                   "KC_Q", "KC_W", "KC_E",  "KC_W", "KC_R",
+                   "KC_A", "KC_S", "KC_D",  "KC_F", "KC_G",
+                   "KC_Z", "KC_X", "KC_C",  "KC_V", "KC_B",
+            "KC_NO", "KC_NO",      "KC_NO",       "KC_LCTL", "KC_SPC"
+        ]
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add default keymap for the ScottoCMD handwired keyboard.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
