### PR TITLE
Fix some keymaps

### DIFF
--- a/public/keymaps/f/flehrad_downbubble_default.json
+++ b/public/keymaps/f/flehrad_downbubble_default.json
@@ -6,11 +6,11 @@
   "layers": [
     [
       "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",                                                     "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_PSCR", "KC_NUM",  "KC_HOME", "KC_TRNS",
-      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",                  "KC_PSLS", "KC_PAST", "KC_PMNS",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",  "KC_BSPC", "KC_TRNS", "KC_END",  "KC_PGUP",
-      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                  "KC_P7",   "KC_P8",   "KC_P9",   "KC_PPLS",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_DEL",  "KC_PGDN",
-      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                  "KC_P4",   "KC_P5",   "KC_P6",   "KC_TRNS",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
-      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",       "KC_P1",   "KC_P2",   "KC_P3",   "KC_PENT",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT", "KC_TRNS", "KC_UP",
-      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_BSPC",            "KC_SPC",                "KC_P0",   "KC_TRNS", "KC_PDOT", "KC_TRNS",    "KC_BSPC",            "KC_RALT", "KC_RGUI", "KC_APP",  "KC_RCTL",            "KC_LEFT", "KC_DOWN", "KC_RGHT"
+      "KC_GRV",  "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",    "KC_6",                  "KC_PSLS", "KC_PAST", "KC_PMNS",    "KC_7",    "KC_8",    "KC_9",    "KC_0",    "KC_MINS", "KC_EQL",             "KC_BSPC", "KC_END",  "KC_PGUP",
+      "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",                  "KC_P7",   "KC_P8",   "KC_P9",                 "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS", "KC_DEL",  "KC_PGDN",
+      "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",                  "KC_P4",   "KC_P5",   "KC_P6",   "KC_PPLS",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",
+      "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",       "KC_P1",   "KC_P2",   "KC_P3",                 "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT",            "KC_UP",
+      "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_BSPC",            "KC_SPC",                "KC_P0",              "KC_PDOT", "KC_PENT",    "KC_BSPC",            "KC_RALT", "KC_RGUI", "KC_APP",  "KC_RCTL",            "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ]
   ]
 }

--- a/public/keymaps/h/hardwareabstraction_handwire_default.json
+++ b/public/keymaps/h/hardwareabstraction_handwire_default.json
@@ -12,23 +12,9 @@
       "KC_LCTL",       "KC_LGUI", "KC_LALT",                                  "KC_SPC",                        "KC_RALT", "KC_APP",  "KC_LEFT",         "KC_DOWN", "KC_RGHT"
     ],
     [
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",        "KC_TRNS",        "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "ANY(KC_BZDWLD)", "ANY(KC_BZDWLI)", "ANY(KC_BZTOG)",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "HF_DWLD", "HF_DWLU",                          "HF_TOGG",
-      "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",        "KC_TRNS",        "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS",        "KC_TRNS",        "KC_TRNS"
-    ],
-    [
       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
-      "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
-    ],
-    [
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
-      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",            "KC_TRNS",
+      "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "HF_DWLD", "HF_DWLU",            "HF_TOGG",
       "KC_TRNS",            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
       "KC_TRNS", "KC_TRNS", "KC_TRNS",                                  "KC_TRNS",                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ]

--- a/public/keymaps/k/keychron_q11_ansi_encoder_default.json
+++ b/public/keymaps/k/keychron_q11_ansi_encoder_default.json
@@ -1,8 +1,8 @@
 {
   "keyboard": "keychron/q11/ansi_encoder",
   "keymap": "default",
-  "commit": "c9f619124d41637ece157570703423c3890cb6c2",
-  "layout": "LAYOUT_ansi_91",
+  "commit": "bf3a80d86c10a03793ea0621ccec4a04ac14b94b",
+  "layout": "LAYOUT_91_ansi",
   "layers": [
     [
       "KC_MUTE", "KC_ESC",  "KC_BRID", "KC_BRIU", "KC_MCTL", "KC_LPAD", "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "KC_INS",  "KC_DEL",  "KC_MUTE",
@@ -10,7 +10,7 @@
       "_______", "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_PGDN",
       "_______", "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",             "KC_HOME",
       "_______", "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT", "KC_UP",
-      "_______", "KC_LCTL", "KC_LOPT", "KC_LCMD", "MO(1)",                         "KC_SPC",  "KC_SPC",                        "KC_RCMD", "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+      "_______", "KC_LCTL", "KC_LOPT", "KC_LCMD", "MO(1)",              "KC_SPC",                        "KC_SPC",             "KC_RCMD", "MO(1)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
       "RGB_TOG", "_______", "KC_F1",    "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "_______", "_______", "RGB_TOG",
@@ -18,7 +18,7 @@
       "_______", "RGB_TOG", "RGB_MOD",  "RGB_VAI", "RGB_HUI", "RGB_SAI", "RGB_SPI", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______",            "_______",
       "_______", "_______", "RGB_RMOD", "RGB_VAD", "RGB_HUD", "RGB_SAD", "RGB_SPD", "_______", "_______", "_______", "_______", "_______", "_______",            "_______",            "_______",
       "_______", "_______",             "_______", "_______", "_______", "_______", "_______", "NK_TOGG", "_______", "_______", "_______", "_______",            "_______", "_______",
-      "_______", "_______", "_______",  "_______", "_______",                       "_______", "_______",                       "_______", "_______", "_______", "_______", "_______", "_______"
+      "_______", "_______", "_______",  "_______", "_______",            "_______",                       "_______",            "_______", "_______", "_______", "_______", "_______", "_______"
     ],
     [
       "KC_MUTE", "KC_ESC",  "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",  "KC_F11",  "KC_F12",  "KC_INS",  "KC_DEL",  "KC_MUTE",
@@ -26,7 +26,7 @@
       "_______", "KC_TAB",  "KC_Q",    "KC_W",    "KC_E",    "KC_R",    "KC_T",    "KC_Y",    "KC_U",    "KC_I",    "KC_O",    "KC_P",    "KC_LBRC", "KC_RBRC", "KC_BSLS",            "KC_PGDN",
       "_______", "KC_CAPS", "KC_A",    "KC_S",    "KC_D",    "KC_F",    "KC_G",    "KC_H",    "KC_J",    "KC_K",    "KC_L",    "KC_SCLN", "KC_QUOT",            "KC_ENT",             "KC_HOME",
       "_______", "KC_LSFT",            "KC_Z",    "KC_X",    "KC_C",    "KC_V",    "KC_B",    "KC_N",    "KC_M",    "KC_COMM", "KC_DOT",  "KC_SLSH",            "KC_RSFT", "KC_UP",
-      "_______", "KC_LCTL", "KC_LWIN", "KC_LALT", "MO(3)",                         "KC_SPC",  "KC_SPC",                        "KC_RALT", "MO(3)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
+      "_______", "KC_LCTL", "KC_LWIN", "KC_LALT", "MO(3)",              "KC_SPC",                        "KC_SPC",             "KC_RALT", "MO(3)",   "KC_RCTL", "KC_LEFT", "KC_DOWN", "KC_RGHT"
     ],
     [
       "RGB_TOG", "_______", "KC_BRID",  "KC_BRIU", "G(KC_TAB)", "G(KC_E)", "RGB_VAD", "RGB_VAI", "KC_MPRV", "KC_MPLY", "KC_MNXT", "KC_MUTE", "KC_VOLD", "KC_VOLU", "_______", "_______", "RGB_TOG",
@@ -34,7 +34,7 @@
       "_______", "RGB_TOG", "RGB_MOD",  "RGB_VAI", "RGB_HUI",   "RGB_SAI", "RGB_SPI", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______",            "_______",
       "_______", "_______", "RGB_RMOD", "RGB_VAD", "RGB_HUD",   "RGB_SAD", "RGB_SPD", "_______", "_______", "_______", "_______", "_______", "_______",            "_______",            "_______",
       "_______", "_______",             "_______", "_______",   "_______", "_______", "_______", "NK_TOGG", "_______", "_______", "_______", "_______",            "_______", "_______",
-      "_______", "_______", "_______",  "_______", "_______",                         "_______", "_______",                       "_______", "_______", "_______", "_______", "_______", "_______"
+      "_______", "_______", "_______",  "_______", "_______",              "_______",                       "_______",            "_______", "_______", "_______", "_______", "_______", "_______"
     ]
   ]
 }


### PR DESCRIPTION
`flehrad/downbubble`: `error: macro "LAYOUT_standard" passed 109 arguments, but takes just 104`
`hardwareabstraction/handwire`: `error: 'KC_BZDWLD' undeclared here (not in a function); did you mean 'HF_DWLD'?`
`keychron/q11/ansi_encoder`: `error: implicit declaration of function 'LAYOUT_ansi_91'`