### PR TITLE
Add ScottoMacrodeck default keymap

### DIFF
--- a/public/keymaps/h/handwired_scottokeebs_scottomacrodeck_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scottomacrodeck_default.json
@@ -1,0 +1,13 @@
+{
+    "keyboard": "handwired/scottokeebs/scottomacrodeck",
+    "keymap": "default",
+    "commit": "e55220dbe0a8ff760e6d295a7d48ccad1ffd50eb",
+    "layout": "LAYOUT",
+    "layers": [
+        [
+            "KC_1", "KC_2", "KC_3",
+            "KC_Q", "KC_W", "KC_E", "KC_R",
+            "KC_A", "KC_S", "KC_D", "KC_F"
+        ]
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add default keymap for the ScottoMacrodeck handwired macropad.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
