### PR TITLE
Remove unused ISO toggle code

### DIFF
--- a/src/components/Keycodes.vue
+++ b/src/components/Keycodes.vue
@@ -81,9 +81,6 @@ export default {
     ...mapGetters('keycodes', ['keycodes']),
     ...mapState('app', ['configuratorSettings']),
     ...mapState('keycodes', ['searchFilter', 'searchCounters', 'active']),
-    defaultTab() {
-      return this.configuratorSettings.iso ? 'ISO/JIS' : 'ANSI';
-    },
     activeTab() {
       return this.keycodesByGroup[this.active];
     },

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -222,17 +222,13 @@ export default {
       'toggleDarkMode',
       'changeLanguage',
       'changeOSKeyboardLayout',
-      'toggleClearLayerDefault',
-      'toggleIso'
+      'toggleClearLayerDefault'
     ]),
     darkMode() {
       this.toggleDarkMode();
     },
     clearLayerDefault() {
       this.toggleClearLayerDefault();
-    },
-    iso() {
-      this.toggleIso();
     },
     help(key) {
       switch (key) {
@@ -253,9 +249,6 @@ export default {
           break;
         case 'osKeyboardLayout':
           this.helpText = this.$t('settingsPanel.osKeyboardLayout.help');
-          break;
-        case 'iso':
-          this.helpText = this.$t('settingsPanel.iso.help');
           break;
         case 'clearLayer':
           this.helpText = this.$t('settingsPanel.clearLayer.help');

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -142,6 +142,10 @@ const actions = {
     this.commit('keycodes/updateKeycodeNames');
     this.commit('keymap/updateKeycodeNames');
     this.commit(
+      'keycodes/changeActive',
+      state.configuratorSettings.iso ? 'ISO/JIS' : 'ANSI'
+    );
+    this.commit(
       'tester/setLayout',
       state.configuratorSettings.iso ? 'ISO' : 'ANSI'
     );

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -142,10 +142,6 @@ const actions = {
     this.commit('keycodes/updateKeycodeNames');
     this.commit('keymap/updateKeycodeNames');
     this.commit(
-      'keycodes/changeActive',
-      state.configuratorSettings.iso ? 'ISO/JIS' : 'ANSI'
-    );
-    this.commit(
       'tester/setLayout',
       state.configuratorSettings.iso ? 'ISO' : 'ANSI'
     );
@@ -164,17 +160,6 @@ const actions = {
       document.getElementsByTagName('html')[0].dataset.theme = '';
     }
     commit('setDarkmode', darkStatus);
-    await dispatch('saveConfiguratorSettings');
-  },
-  async toggleIso({ commit, state, dispatch }, init) {
-    let iso = state.configuratorSettings.iso;
-    if (!init) {
-      iso = !iso;
-    }
-    commit('setIso', iso);
-    this.commit('keymap/updateKeycodeNames');
-    this.commit('tester/setLayout', iso ? 'ISO' : 'ANSI');
-    await this.dispatch('tester/init');
     await dispatch('saveConfiguratorSettings');
   },
   async toggleClearLayerDefault({ commit, state, dispatch }) {
@@ -196,7 +181,6 @@ const actions = {
     await dispatch('fetchKeyboards');
     await dispatch('loadFavoriteKeyboard');
     await dispatch('toggleDarkMode', true);
-    await dispatch('toggleIso', true);
     await dispatch('loadLanguage');
     console.log('loadApplicationState End');
     commit('setAppInitialized', true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Remove unused code related to the Settings Panel ISO toggle, rendered obsolete by the addition of host OS keyboard layout support.
Note that this does *not* remove `configuratorSettings.iso` because it it still a helpful flag to use for the communication between the keycode updating logic and the key tester updating logic. The key tester must automatically switch between ISO and ANSI depending on what's the standard physical geometry for a given national layout. I initially wanted to remove `configuratorSettings.iso` as well but I forgot about that auto-layout-change behaviour from the key tester, hence the misleading branch name.
<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
