### PR TITLE
Add snes_macropad default keymap

### DIFF
--- a/public/keymaps/s/snes_macropad_default.json
+++ b/public/keymaps/s/snes_macropad_default.json
@@ -1,0 +1,35 @@
+{
+  "keyboard": "snes_macropad",
+  "keymap": "default",
+  "commit": "39d0a14258cbd1dd640405cdbc806dadb01521a8",
+  "layout": "LAYOUT",
+  "layers": [
+    [
+      "KC_P7",   "KC_P8",   "KC_P9",       "TO(1)"
+    , "KC_P4",   "KC_P5",   "KC_P6",       "LT(2, KC_PCMM)"
+    , "KC_P1",   "KC_P2",   "KC_P3",       "KC_P0"
+
+    , "KC_A",    "KC_S",    "KC_ENT",      "KC_BSPC"
+    , "KC_UP",   "KC_DOWN", "KC_LEFT",     "KC_RIGHT"
+    , "KC_X",    "KC_Z",    "LSFT(KC_F1)", "KC_TAB"
+    ],
+    [
+      "RGB_M_P",  "RGB_M_B", "RGB_TOG", "KC_NO"
+    , "RGB_MOD",  "RGB_HUI", "RGB_VAI", "TO(0)"
+    , "RGB_RMOD", "RGB_HUD", "RGB_VAD", "KC_NO"
+
+    , "KC_A",    "KC_B",    "KC_C",    "KC_D"
+    , "KC_E",    "KC_F",    "KC_G",    "KC_H"
+    , "KC_I",    "KC_J",    "KC_K",    "KC_L"
+    ],
+    [
+      "KC_PPLS", "KC_PMNS", "KC_PEQL", "KC_NO"
+    , "KC_PAST", "KC_PSLS", "KC_ENT",  "KC_TRNS"
+    , "KC_NUM",  "KC_NO",   "KC_NO",   "QK_BOOT"
+
+    , "KC_A",    "KC_B",    "KC_C",    "KC_D"
+    , "KC_E",    "KC_F",    "KC_G",    "KC_H"
+    , "KC_I",    "KC_J",    "KC_K",    "KC_L"
+    ]
+  ]
+}

--- a/public/keymaps/s/snes_macropad_default.json
+++ b/public/keymaps/s/snes_macropad_default.json
@@ -6,7 +6,7 @@
   "layers": [
     [
       "KC_P7",   "KC_P8",   "KC_P9",       "TO(1)"
-    , "KC_P4",   "KC_P5",   "KC_P6",       "LT(2, KC_PCMM)"
+    , "KC_P4",   "KC_P5",   "KC_P6",       "LT(2,KC_PCMM)"
     , "KC_P1",   "KC_P2",   "KC_P3",       "KC_P0"
 
     , "KC_A",    "KC_S",    "KC_ENT",      "KC_BSPC"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Adds a default keymap for snes_macropad.
<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
