### PR TITLE
Add ScottoWing default keymap

### DIFF
--- a/public/keymaps/h/handwired_scottokeebs_scottowing_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scottowing_default.json
@@ -1,0 +1,32 @@
+{
+  "keyboard": "handwired/scottokeebs/scottowing",
+  "keymap": "default",
+  "commit": "4228f555516c6a1ea9f193b70120f862b74fb03c",
+  "layout": "LAYOUT_split_3x6_2",
+  "layers": [
+    [
+      "KC_TAB",  "KC_Q",         "KC_W",    "KC_E",    "KC_R",           "KC_T",         "KC_Y",         "KC_U",  "KC_I",    "KC_O",    "KC_P",            "KC_BSPC",
+      "KC_ENT",  "KC_A",         "KC_S",    "KC_D",    "KC_F",           "KC_G",         "KC_H",         "KC_J",  "KC_K",    "KC_L",    "KC_BSPC",         "KC_QUOT",
+      "KC_LSFT", "LSFT_T(KC_Z)", "KC_X",    "KC_C",    "KC_V",           "KC_B",         "KC_N",         "KC_M",  "KC_COMM", "KC_DOT",  "RSFT_T(KC_SLSH)", "KC_RSFT",
+                                 "KC_LGUI", "KC_LALT", "LGUI_T(KC_SPC)", "LT(1,KC_TAB)", "LT(2,KC_ENT)", "KC_ESC"
+    ],
+    [
+      "KC_TRNS", "KC_UNDS",         "KC_MINS", "KC_PLUS", "KC_EQL",  "KC_COLN",    "KC_GRV",  "KC_MRWD", "KC_MPLY", "KC_MFFD", "KC_DEL",
+      "KC_TRNS", "KC_LCBR",         "KC_LPRN", "KC_RPRN", "KC_RCBR", "KC_PIPE",    "KC_ESC",  "KC_LEFT", "KC_UP",   "KC_DOWN", "KC_RGHT",
+      "KC_TRNS", "LSFT_T(KC_LBRC)", "KC_QUOT", "KC_DQUO", "KC_RBRC", "KC_SCLN",    "KC_TILD", "KC_VOLD", "KC_MUTE", "KC_VOLU", "RSFT_T(KC_BSLS)",
+                                    "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_TRNS", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC",    "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_CAPS", "KC_BSPC",
+      "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",       "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",
+      "KC_TRNS", "KC_LSFT", "KC_NO",   "KC_NO",   "KC_NO",   "MO(3)",      "KC_NO",   "KC_NO",   "KC_COMM", "KC_DOT",  "RSFT_T(KC_SLSH)",
+                            "KC_TRNS", "KC_TRNS", "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ],
+    [
+      "KC_TRNS", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
+      "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",      "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",
+      "KC_TRNS", "KC_F11",  "KC_NO",   "KC_NO",   "QK_BOOT", "KC_TRNS",    "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_F12",
+                            "KC_TRNS", "KC_TRNS", "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS"
+    ]
+  ]
+}

--- a/public/keymaps/h/handwired_scottokeebs_scottowing_default.json
+++ b/public/keymaps/h/handwired_scottokeebs_scottowing_default.json
@@ -8,25 +8,25 @@
       "KC_TAB",  "KC_Q",         "KC_W",    "KC_E",    "KC_R",           "KC_T",         "KC_Y",         "KC_U",  "KC_I",    "KC_O",    "KC_P",            "KC_BSPC",
       "KC_ENT",  "KC_A",         "KC_S",    "KC_D",    "KC_F",           "KC_G",         "KC_H",         "KC_J",  "KC_K",    "KC_L",    "KC_BSPC",         "KC_QUOT",
       "KC_LSFT", "LSFT_T(KC_Z)", "KC_X",    "KC_C",    "KC_V",           "KC_B",         "KC_N",         "KC_M",  "KC_COMM", "KC_DOT",  "RSFT_T(KC_SLSH)", "KC_RSFT",
-                                 "KC_LGUI", "KC_LALT", "LGUI_T(KC_SPC)", "LT(1,KC_TAB)", "LT(2,KC_ENT)", "KC_ESC"
+                                            "KC_LALT", "LGUI_T(KC_SPC)", "LT(1,KC_TAB)", "LT(2,KC_ENT)"
     ],
     [
-      "KC_TRNS", "KC_UNDS",         "KC_MINS", "KC_PLUS", "KC_EQL",  "KC_COLN",    "KC_GRV",  "KC_MRWD", "KC_MPLY", "KC_MFFD", "KC_DEL",
-      "KC_TRNS", "KC_LCBR",         "KC_LPRN", "KC_RPRN", "KC_RCBR", "KC_PIPE",    "KC_ESC",  "KC_LEFT", "KC_UP",   "KC_DOWN", "KC_RGHT",
-      "KC_TRNS", "LSFT_T(KC_LBRC)", "KC_QUOT", "KC_DQUO", "KC_RBRC", "KC_SCLN",    "KC_TILD", "KC_VOLD", "KC_MUTE", "KC_VOLU", "RSFT_T(KC_BSLS)",
-                                    "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS", "KC_TRNS", "KC_TRNS"
+        "KC_TRNS", "KC_UNDS",         "KC_MINS", "KC_PLUS", "KC_EQL",  "KC_COLN", "KC_GRV",   "KC_MRWD", "KC_MPLY", "KC_MFFD", "KC_DEL",          "KC_TRNS",
+        "KC_TRNS", "KC_LCBR",         "KC_LPRN", "KC_RPRN", "KC_RCBR", "KC_PIPE", "KC_ESC",   "KC_LEFT", "KC_UP",   "KC_DOWN", "KC_RGHT",         "KC_TRNS",
+        "KC_TRNS", "LSFT_T(KC_LBRC)", "KC_QUOT", "KC_DQUO", "KC_RBRC", "KC_SCLN", "KC_TILDE", "KC_VOLD", "KC_MUTE", "KC_VOLU", "RSFT_T(KC_BSLS)", "KC_TRNS",
+                                                    "KC_TRNS", "KC_TRNS", "KC_TRNS",  "KC_TRNS"
     ],
     [
-      "KC_TRNS", "KC_EXLM", "KC_AT",   "KC_HASH", "KC_DLR",  "KC_PERC",    "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_CAPS", "KC_BSPC",
-      "KC_TRNS", "KC_1",    "KC_2",    "KC_3",    "KC_4",    "KC_5",       "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",
-      "KC_TRNS", "KC_LSFT", "KC_NO",   "KC_NO",   "KC_NO",   "MO(3)",      "KC_NO",   "KC_NO",   "KC_COMM", "KC_DOT",  "RSFT_T(KC_SLSH)",
-                            "KC_TRNS", "KC_TRNS", "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS"
+        "KC_TRNS", "KC_EXLM", "KC_AT", "KC_HASH", "KC_DLR",  "KC_PERC", "KC_CIRC", "KC_AMPR", "KC_ASTR", "KC_CAPS", "KC_BSPC",         "KC_TRNS",
+        "KC_TRNS", "KC_1",    "KC_2",  "KC_3",    "KC_4",    "KC_5",    "KC_6",    "KC_7",    "KC_8",    "KC_9",    "KC_0",            "KC_TRNS",
+        "KC_TRNS", "KC_LSFT", "KC_NO", "KC_NO",   "KC_NO",   "MO(3)",   "KC_NO",   "KC_NO",   "KC_COMM", "KC_DOT",  "RSFT_T(KC_SLSH)", "KC_TRNS",
+                                          "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ],
     [
-      "KC_TRNS", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",      "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",
-      "KC_TRNS", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",      "KC_F6",   "KC_F7",   "KC_F8",   "KC_F9",   "KC_F10",
-      "KC_TRNS", "KC_F11",  "KC_NO",   "KC_NO",   "QK_BOOT", "KC_TRNS",    "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_F12",
-                            "KC_TRNS", "KC_TRNS", "KC_TRNS",    "KC_TRNS", "KC_TRNS", "KC_TRNS"
+        "KC_TRNS", "KC_NO",  "KC_NO", "KC_NO", "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",  "KC_NO", "KC_NO", "KC_NO",  "KC_TRNS",
+        "KC_TRNS", "KC_F1",  "KC_F2", "KC_F3", "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",  "KC_F8", "KC_F9", "KC_F10", "KC_TRNS",
+        "KC_TRNS", "KC_F11", "KC_NO", "KC_NO", "QK_BOOT", "KC_TRNS", "KC_NO",   "KC_NO",  "KC_NO", "KC_NO", "KC_F12", "KC_TRNS",
+                                       "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
     ]
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add default keymap for the ScottoWing handwired keyboard.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
