### PR TITLE
fix: show the name instead of the code in print view

### DIFF
--- a/src/components/PrintKey.vue
+++ b/src/components/PrintKey.vue
@@ -30,14 +30,14 @@ export default {
         return this.formatName(this.breakLines(this.meta.text));
       }
       if (this.meta.type === 'layer-container') {
-        return `${this.meta.name.toUpperCase()},\n${this.formatName(
-          this.meta.contents.code
+        return `${this.meta.name.toUpperCase()}\n${this.formatName(
+          this.meta.contents.name
         )}`;
       }
       if (this.meta.type === 'container') {
-        return `${this.meta.name.toUpperCase()}\n(${this.formatName(
-          this.meta.contents.code
-        )})`;
+        return `${this.meta.name.toUpperCase()}\n${this.formatName(
+          this.meta.contents.name
+        )}`;
       }
       return this.formatName(this.breakLines(this.meta.name));
     }


### PR DESCRIPTION
Issue [1363](https://github.com/qmk/qmk_configurator/issues/1363)

Change the PrintKey to show the `.name` instead of the `.code` attribute because it's less human friendly. Remove some of the extraneous formatting around the element.

This stems slightly from the different way we render Key components in the printing vs editing.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
