### PR TITLE
feat: support import/display/export of extra host keyboard layouts / languages

### DIFF
--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -120,7 +120,9 @@ export default {
       return this.meta ? this.meta.code !== 'KC_NO' : false;
     },
     displayLanguage() {
-      return this.meta.language_prefix
+      // The language label is only relevant for keymap legends
+      if (this.legends !== 'keymap') return;
+      return this.meta.language_prefix;
     },
     displayName() {
       switch (this.legends) {

--- a/src/components/BaseKey.vue
+++ b/src/components/BaseKey.vue
@@ -5,6 +5,7 @@
     @dragover.prevent="dragover" @dragenter.prevent="dragenter">{{ displayName }}<font-awesome-icon v-if="icon"
       size="2x" :icon="icon" /><template v-if="visible">
       <div v-if="visible" class="remove" @click.stop="remove">x</div>
+      <span v-if="visible" class="language">{{ displayLanguage }}</span>
     </template></div>
 </template>
 <script>
@@ -117,6 +118,9 @@ export default {
     },
     visible() {
       return this.meta ? this.meta.code !== 'KC_NO' : false;
+    },
+    displayLanguage() {
+      return this.meta.language_prefix
     },
     displayName() {
       switch (this.legends) {

--- a/src/components/ContainerKey.vue
+++ b/src/components/ContainerKey.vue
@@ -52,6 +52,8 @@ export default {
       return '';
     },
     displayLanguage() {
+      // The language label is only relevant for keymap legends
+      if (this.legends !== 'keymap') return;
       return this.meta.contents.language_prefix;
     },
     contentClasses() {

--- a/src/components/ContainerKey.vue
+++ b/src/components/ContainerKey.vue
@@ -20,7 +20,12 @@
     @dragenter.prevent="dragenterContents"
     @dragleave.prevent="dragleaveContents"
     @click.prevent.stop="clickContents"
-    >{{ contents }}</div></div><div
+    >{{ contents }}</div>
+    <span
+        v-if="visible"
+        class="language"
+      >{{ displayLanguage }}</span>
+    </div><div
         v-if="visible"
         class="remove"
         @click.stop="remove"
@@ -45,6 +50,9 @@ export default {
         return this.formatName(this.meta.contents.name);
       }
       return '';
+    },
+    displayLanguage() {
+      return this.meta.contents.language_prefix;
     },
     contentClasses() {
       let classes = [];

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -552,6 +552,23 @@ button {
   cursor: pointer;
 }
 
+.key .language {
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
+  padding-right: 3px;
+  font-size: 7px;
+  opacity: 0.7;
+}
+.key.key-container div .language {
+  padding-right: 8px;
+  padding-bottom: 1px;
+}
+.key.smaller .language {
+  padding-right: 2px;
+  padding-bottom: 2px;
+}
+
 .key:hover .remove {
   width: unset;
   height: unset;

--- a/src/store/keycodes.js
+++ b/src/store/keycodes.js
@@ -141,7 +141,7 @@ export const useKeycodesStore = defineStore('keycodes', {
           ({ code, keys, title }) =>
             code === searchTerm ||
             (isKeys && keys && keys === searchTerm) ||
-            title === searchTerm
+            title?.split(' ')?.[0] === searchTerm
         )
   },
   actions: {

--- a/src/store/keycodes.js
+++ b/src/store/keycodes.js
@@ -138,8 +138,10 @@ export const useKeycodesStore = defineStore('keycodes', {
       (state) =>
       (searchTerm, isKeys = false) =>
         state.keycodes.find(
-          ({ code, keys }) =>
-            code === searchTerm || (isKeys && keys && keys === searchTerm)
+          ({ code, keys, title }) =>
+            code === searchTerm ||
+            (isKeys && keys && keys === searchTerm) ||
+            title === searchTerm
         )
   },
   actions: {

--- a/src/store/keycodes.js
+++ b/src/store/keycodes.js
@@ -14,9 +14,10 @@ const keycodePickerTabLayout = {
   ANSI_ISO: [...ansi, ...iso_jis],
   ISO_ANSI: [...iso_jis, ...ansi],
   special: [...quantum, ...settings, ...media],
-  extra: Object.values(keymapExtras)
-    .map(({ keycodeLUT, prefix }) => {
+  extra: Object.fromEntries(
+    Object.entries(keymapExtras).map(([keymap, { keycodeLUT, prefix }]) => {
       const keycodes = [];
+
       Object.entries(keycodeLUT).forEach(([code, { name, title }]) => {
         if (title === undefined) {
           return;
@@ -43,9 +44,10 @@ const keycodePickerTabLayout = {
           title: code
         });
       });
-      return keycodes;
+
+      return [keymap, keycodes];
     })
-    .flat()
+  )
 };
 
 /**
@@ -113,7 +115,7 @@ function generateKeycodes(osKeyboardLayout, isSteno = false) {
     ...keycodes.map((keycodeObject) =>
       toLocaleKeycode(keycodeLUT, keycodeObject)
     ),
-    ...keycodePickerTabLayout.extra
+    ...keycodePickerTabLayout.extra[getOSKeyboardLayout()]
   ];
 }
 
@@ -153,8 +155,7 @@ export const useKeycodesStore = defineStore('keycodes', {
   state: () => ({
     keycodes: [
       ...keycodePickerTabLayout.ANSI_ISO,
-      ...keycodePickerTabLayout.special,
-      ...keycodePickerTabLayout.extra
+      ...keycodePickerTabLayout.special
     ],
     searchFilter: '',
     searchCounters: {

--- a/src/store/keycodes.js
+++ b/src/store/keycodes.js
@@ -13,7 +13,16 @@ import steno from './modules/keycodes/steno';
 const keycodePickerTabLayout = {
   ANSI_ISO: [...ansi, ...iso_jis],
   ISO_ANSI: [...iso_jis, ...ansi],
-  special: [...quantum, ...settings, ...media]
+  special: [...quantum, ...settings, ...media],
+  extra: Object.values(keymapExtras)
+    .map(({ keycodeLUT }) =>
+      Object.entries(keycodeLUT).map(([code, { name, title }]) => ({
+        code: title?.split(' ')[0], // split removes ' (dead)'
+        name,
+        title: code
+      }))
+    )
+    .flat()
 };
 
 /**
@@ -81,11 +90,7 @@ function generateKeycodes(osKeyboardLayout, isSteno = false) {
     ...keycodes.map((keycodeObject) =>
       toLocaleKeycode(keycodeLUT, keycodeObject)
     ),
-    ...Object.entries(keycodeLUT).map(([code, { name, title }]) => ({
-      code: title?.split(' ')[0],
-      name,
-      title: code
-    }))
+    ...keycodePickerTabLayout.extra
   ];
 }
 
@@ -125,7 +130,8 @@ export const useKeycodesStore = defineStore('keycodes', {
   state: () => ({
     keycodes: [
       ...keycodePickerTabLayout.ANSI_ISO,
-      ...keycodePickerTabLayout.special
+      ...keycodePickerTabLayout.special,
+      ...keycodePickerTabLayout.extra
     ],
     searchFilter: '',
     searchCounters: {

--- a/src/store/keycodes.js
+++ b/src/store/keycodes.js
@@ -77,9 +77,16 @@ function generateKeycodes(osKeyboardLayout, isSteno = false) {
     ...(isSteno ? steno : [])
   ];
   const { keycodeLUT } = keymapExtras[getOSKeyboardLayout()];
-  return keycodes.map((keycodeObject) =>
-    toLocaleKeycode(keycodeLUT, keycodeObject)
-  );
+  return [
+    ...keycodes.map((keycodeObject) =>
+      toLocaleKeycode(keycodeLUT, keycodeObject)
+    ),
+    ...Object.entries(keycodeLUT).map(([code, { name, title }]) => ({
+      code: title?.split(' ')[0],
+      name,
+      title: code
+    }))
+  ];
 }
 
 /**
@@ -138,10 +145,8 @@ export const useKeycodesStore = defineStore('keycodes', {
       (state) =>
       (searchTerm, isKeys = false) =>
         state.keycodes.find(
-          ({ code, keys, title }) =>
-            code === searchTerm ||
-            (isKeys && keys && keys === searchTerm) ||
-            title?.split(' ')?.[0] === searchTerm
+          ({ code, keys }) =>
+            code === searchTerm || (isKeys && keys && keys === searchTerm)
         )
   },
   actions: {

--- a/src/store/keycodes.js
+++ b/src/store/keycodes.js
@@ -15,10 +15,11 @@ const keycodePickerTabLayout = {
   ISO_ANSI: [...iso_jis, ...ansi],
   special: [...quantum, ...settings, ...media],
   extra: Object.values(keymapExtras)
-    .map(({ keycodeLUT }) =>
+    .map(({ keycodeLUT, prefix }) =>
       Object.entries(keycodeLUT).map(([code, { name, title }]) => ({
         code: title?.split(' ')[0], // split removes ' (dead)'
         name,
+        language_prefix: prefix,
         title: code
       }))
     )

--- a/src/store/keycodes.js
+++ b/src/store/keycodes.js
@@ -15,14 +15,36 @@ const keycodePickerTabLayout = {
   ISO_ANSI: [...iso_jis, ...ansi],
   special: [...quantum, ...settings, ...media],
   extra: Object.values(keymapExtras)
-    .map(({ keycodeLUT, prefix }) =>
-      Object.entries(keycodeLUT).map(([code, { name, title }]) => ({
-        code: title?.split(' ')[0], // split removes ' (dead)'
-        name,
-        language_prefix: prefix,
-        title: code
-      }))
-    )
+    .map(({ keycodeLUT, prefix }) => {
+      const keycodes = [];
+      Object.entries(keycodeLUT).forEach(([code, { name, title }]) => {
+        if (title === undefined) {
+          return;
+        }
+
+        let start = title.search(prefix + '_');
+        if (start < 0) {
+          return;
+        }
+
+        let end = start + prefix.length + 1;
+        while (
+          end < title.length &&
+          ((title.charCodeAt(end) >= 65 && title.charCodeAt(end) <= 90) ||
+            (title.charCodeAt(end) >= 48 && title.charCodeAt(end) <= 57))
+        ) {
+          end++;
+        }
+
+        keycodes.push({
+          code: title.substring(start, end),
+          name,
+          language_prefix: prefix,
+          title: code
+        });
+      });
+      return keycodes;
+    })
     .flat()
 };
 

--- a/src/store/modules/parse.js
+++ b/src/store/modules/parse.js
@@ -181,6 +181,7 @@ function parseKeycode(keycodesStore, keycode, stats) {
     }
     let internal = splitcode[1];
     internal = internal.split(')')[0];
+    metadata = keycodesStore.lookupKeycode(internal);
 
     // check for an OSM keycode
     if (maincode === 'OSM') {
@@ -189,13 +190,12 @@ function parseKeycode(keycodesStore, keycode, stats) {
     }
 
     //Check whether it is a layer switching code, mod-tap, or combo keycode
-    if (internal.includes('KC')) {
+    if (internal.includes('KC') || metadata?.code?.includes('KC')) {
       // Layer Tap keycode
       if (maincode === 'LT') {
         return newLayerContainerKey(keycodesStore, maincode, internal);
       }
       internal = longFormKeycodes[internal] || internal;
-      metadata = keycodesStore.lookupKeycode(internal);
       if (metadata === undefined) {
         stats.any += 1;
         return newAnyKey(keycodesStore, keycode);

--- a/src/store/modules/parse.js
+++ b/src/store/modules/parse.js
@@ -133,7 +133,8 @@ function newKey(metadata, keycode, obj) {
   var key = {
     name: metadata.name,
     code: keycode,
-    type: metadata.type
+    type: metadata.type,
+    language_prefix: metadata.language_prefix
   };
 
   if (obj !== undefined) {
@@ -190,7 +191,7 @@ function parseKeycode(keycodesStore, keycode, stats) {
     }
 
     //Check whether it is a layer switching code, mod-tap, or combo keycode
-    if (internal.includes('KC') || metadata?.title?.includes('KC')) {
+    if (internal.includes('KC') || metadata?.language_prefix !== undefined) {
       // Layer Tap keycode
       if (maincode === 'LT') {
         return newLayerContainerKey(keycodesStore, maincode, internal);

--- a/src/store/modules/parse.js
+++ b/src/store/modules/parse.js
@@ -190,7 +190,7 @@ function parseKeycode(keycodesStore, keycode, stats) {
     }
 
     //Check whether it is a layer switching code, mod-tap, or combo keycode
-    if (internal.includes('KC') || metadata?.code?.includes('KC')) {
+    if (internal.includes('KC') || metadata?.title?.includes('KC')) {
       // Layer Tap keycode
       if (maincode === 'LT') {
         return newLayerContainerKey(keycodesStore, maincode, internal);


### PR DESCRIPTION
Related https://github.com/qmk/qmk_configurator/issues/229

Enables uploading, displaying, and exporting keymaps of other languages.

Disclaimer: I do not at all know this codebase or the wider implications of this change. It works for me on my language/keymap and thus solve my problem. Hope some version of this can be implemented here as well.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Tested with 
[tenstad/qmk_firmware//keyboards/handwired/tenstad/keymaps/default/keymap.json](https://raw.githubusercontent.com/tenstad/qmk_firmware/1d0ed36092a0ca21b8a58e30b37be21106d9a8e8/keyboards/handwired/tenstad/keymaps/default/keymap.json)


<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

### Before

When importing a layout with `NO_` codes, it is displayed as e.g. `ANY(NO_T)` and `ANY(LSFT_T(NO_F))`, and also exported as that. It is therefore very difficult to see the layout, and an import-export breaks the layout by wrapping all keys with `NO_` codes inside `ANY( )`.

![image](https://github.com/user-attachments/assets/e589e963-a3b2-482b-aa8b-0de1c7469b79)

### After

When selecting _norwegian_ and importing a layout with `NO_` codes, it is now displayed correctly, and exported correctly (as-is). One can therefore import, swap some keys, and export - and still have a valid layout.

![image](https://github.com/user-attachments/assets/3d6a5c8b-4f1e-4fb4-9830-5fc556065c11)