### PR TITLE
Update Work Louder keymaps RGB keycodes

### DIFF
--- a/public/keymaps/w/work_louder_loop_rev1_default.json
+++ b/public/keymaps/w/work_louder_loop_rev1_default.json
@@ -1,17 +1,17 @@
 {
   "keyboard": "work_louder/loop/rev1",
   "keymap": "default",
-  "commit": "1184e0d9beb7322b0cea017e805d36d11e4f47f2",
+  "commit": "6fa11bf21913b5ccb531acc3c2baec963f4d384a",
   "layout": "LAYOUT",
   "layers": [
     [
-      "KC_MUTE", "KC_MPLY", "R_M_TOG", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "MO(1)"
+      "KC_MUTE", "KC_MPLY", "RM_TOGG", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "MO(1)"
     ],
     [
-      "QK_BOOT", "_______", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "MO(2)",   "_______"
+      "QK_BOOT", "_______", "UG_TOGG", "UG_NEXT", "UG_HUEU", "UG_HUED", "UG_SATU", "UG_SATD", "UG_VALU", "UG_VALD", "MO(2)",   "_______"
     ],
     [
-      "QK_BOOT", "_______", "R_M_TOG", "R_M_MOD", "R_M_HUI", "R_M_HUD", "R_M_SAI", "R_M_SAD", "R_M_VAI", "R_M_VAD", "_______", "_______"
+      "QK_BOOT", "_______", "RM_TOGG", "RM_NEXT", "RM_HUEU", "RM_HUED", "RM_SATU", "RM_SATD", "RM_VALU", "RM_VALD", "_______", "_______"
     ]
   ]
 }

--- a/public/keymaps/w/work_louder_loop_rev3_default.json
+++ b/public/keymaps/w/work_louder_loop_rev3_default.json
@@ -1,17 +1,17 @@
 {
   "keyboard": "work_louder/loop/rev3",
   "keymap": "default",
-  "commit": "1184e0d9beb7322b0cea017e805d36d11e4f47f2",
+  "commit": "6fa11bf21913b5ccb531acc3c2baec963f4d384a",
   "layout": "LAYOUT",
   "layers": [
     [
-      "KC_MUTE", "KC_MPLY", "R_M_TOG", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "MO(1)"
+      "KC_MUTE", "KC_MPLY", "RM_TOGG", "KC_F1",   "KC_F2",   "KC_F3",   "KC_F4",   "KC_F5",   "KC_F6",   "KC_F7",   "KC_F8",   "MO(1)"
     ],
     [
-      "QK_BOOT", "_______", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "MO(2)",   "_______"
+      "QK_BOOT", "_______", "UG_TOGG", "UG_NEXT", "UG_HUEU", "UG_HUED", "UG_SATU", "UG_SATD", "UG_VALU", "UG_VALD", "MO(2)",   "_______"
     ],
     [
-      "QK_BOOT", "_______", "R_M_TOG", "R_M_MOD", "R_M_HUI", "R_M_HUD", "R_M_SAI", "R_M_SAD", "R_M_VAI", "R_M_VAD", "_______", "_______"
+      "QK_BOOT", "_______", "RM_TOGG", "RM_NEXT", "RM_HUEU", "RM_HUED", "RM_SATU", "RM_SATD", "RM_VALU", "RM_VALD", "_______", "_______"
     ]
   ]
 }

--- a/public/keymaps/w/work_louder_work_board_rev1_default.json
+++ b/public/keymaps/w/work_louder_work_board_rev1_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "work_louder/work_board/rev1",
   "keymap": "default",
-  "commit": "aa33d8ba8e9ca78b7738eadd5401348c51d3d9d9",
+  "commit": "6fa11bf21913b5ccb531acc3c2baec963f4d384a",
   "layout": "LAYOUT",
   "layers": [
     [
@@ -23,8 +23,8 @@
       "_______", "_______", "_______", "_______", "MO(3)",   "_______", "_______", "_______", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
     ],
     [
-      "_______", "QK_BOOT", "_______", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_DEL",  "R_M_TOG",
-      "_______", "_______", "MU_NEXT", "R_M_TOG", "R_M_MOD", "R_M_HUI", "R_M_HUD", "R_M_SAI", "R_M_SAD", "R_M_VAI", "R_M_VAD", "_______",
+      "_______", "QK_BOOT", "_______", "UG_TOGG", "UG_NEXT", "UG_HUEU", "UG_HUED", "UG_SATU", "UG_SATD", "UG_VALU", "UG_VALD", "KC_DEL",  "RM_TOGG",
+      "_______", "_______", "MU_NEXT", "RM_TOGG", "RM_NEXT", "RM_HUEU", "RM_HUED", "RM_SATU", "RM_SATD", "RM_VALU", "RM_VALD", "_______",
       "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______",
       "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______"
     ]

--- a/public/keymaps/w/work_louder_work_board_rev3_default.json
+++ b/public/keymaps/w/work_louder_work_board_rev3_default.json
@@ -1,7 +1,7 @@
 {
   "keyboard": "work_louder/work_board/rev3",
   "keymap": "default",
-  "commit": "aa33d8ba8e9ca78b7738eadd5401348c51d3d9d9",
+  "commit": "6fa11bf21913b5ccb531acc3c2baec963f4d384a",
   "layout": "LAYOUT",
   "layers": [
     [
@@ -23,8 +23,8 @@
       "_______", "_______", "_______", "_______", "MO(3)",   "_______", "_______", "_______", "KC_MNXT", "KC_VOLD", "KC_VOLU", "KC_MPLY"
     ],
     [
-      "_______", "QK_BOOT", "_______", "RGB_TOG", "RGB_MOD", "RGB_HUI", "RGB_HUD", "RGB_SAI", "RGB_SAD", "RGB_VAI", "RGB_VAD", "KC_DEL",  "R_M_TOG",
-      "_______", "_______", "MU_NEXT", "R_M_TOG", "R_M_MOD", "R_M_HUI", "R_M_HUD", "R_M_SAI", "R_M_SAD", "R_M_VAI", "R_M_VAD", "_______",
+      "_______", "QK_BOOT", "_______", "UG_TOGG", "UG_NEXT", "UG_HUEU", "UG_HUED", "UG_SATU", "UG_SATD", "UG_VALU", "UG_VALD", "KC_DEL",  "RM_TOGG",
+      "_______", "_______", "MU_NEXT", "RM_TOGG", "RM_NEXT", "RM_HUEU", "RM_HUED", "RM_SATU", "RM_SATD", "RM_VALU", "RM_VALD", "_______",
       "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______",
       "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______", "_______"
     ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

```
./.build/obj_work_louder_loop_rev1_default_configurator/src/keymap.c:14:36: error: 'R_M_TOG' undeclared here (not in a function); did you mean 'RM_TOGG'?
```

`R_M_` keyboard-level keycodes no longer exist as they've been migrated to the core RGB Matrix keycodes.
