### PR TITLE
Slight adjustment to keycode picker for dark mode

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -637,7 +637,7 @@ button {
   height: 32px;
   margin: 0px 5px 5px 0px;
   border: 1px solid;
-  border-radius: 2px;
+  border-radius: 3px;
   box-sizing: border-box;
   display: flex;
   justify-content: space-around;

--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -453,7 +453,7 @@ html[data-theme='dark'] {
   }
 
   .keycode {
-    background: #0c0c0c;
+    background: #1c1c1c;
     color: white;
     border-color: #0e0e0e;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Lightened the dark mode background colour slightly, and increased the border radius by 1px, since (at least to me) they just look like solid black squares. I didn't even realise there was a border on them since I almost never use light mode.

Before:
![image](https://github.com/user-attachments/assets/c90d5bb1-aa08-4d9b-8559-b6bd4be31e86)
After:
![image](https://github.com/user-attachments/assets/dd7ec816-23d4-4eb1-8084-c233fc0d3c18)
