### PR TITLE
Clean up KB settings and app/media/mouse keycode tabs

### DIFF
--- a/src/store/modules/keycodes/app-media-mouse.js
+++ b/src/store/modules/keycodes/app-media-mouse.js
@@ -6,7 +6,9 @@ export default [
   { name: 'Power', code: 'KC_PWR', title: 'System Power Down' },
   { name: 'Sleep', code: 'KC_SLEP', title: 'System Sleep' },
   { name: 'Wake', code: 'KC_WAKE', title: 'System Wake' },
-  { width: 1250 },
+
+  { width: 500 },
+
   { name: 'Exec', code: 'KC_EXEC', title: 'Execute' },
   { name: 'Help', code: 'KC_HELP', title: 'Help' },
   {
@@ -23,7 +25,22 @@ export default [
   { name: 'Copy', code: 'KC_COPY', title: 'Copy' },
   { name: 'Paste', code: 'KC_PSTE', title: 'Paste' },
   { name: 'Find', code: 'KC_FIND', title: 'Find' },
+
   { width: 0 },
+
+  {
+    name: 'Bright ⏷',
+    code: 'KC_BRID',
+    title: 'Decrease the screen brightness (for laptops)'
+  },
+  {
+    name: 'Bright ⏶',
+    code: 'KC_BRIU',
+    title: 'Increase the screen brightness (for laptops)'
+  },
+
+  { width: 1500 },
+
   {
     name: 'Calc',
     code: 'KC_CALC',
@@ -44,7 +61,9 @@ export default [
     code: 'KC_MYCM',
     title: 'Launch My Computer (Windows)'
   },
+
   { width: 250 },
+
   {
     name: 'Browser Search',
     code: 'KC_WSCH',
@@ -87,40 +106,32 @@ export default [
     title: 'Browser Favorites (Windows)',
     width: 1500
   },
-  {
-    name: 'Brightness Up',
-    code: 'KC_BRIU',
-    title: 'Increase the brightness of screen (Laptop)',
-    width: 1500
-  },
-  {
-    name: 'Brightness Down',
-    code: 'KC_BRID',
-    title: 'Decrease the brightness of screen (Laptop)',
-    width: 1500
-  },
 
   { label: 'Multimedia Keys', width: 'label' },
 
-  { name: 'Prev', code: 'KC_MPRV', title: 'Previous Track' },
-  { name: 'Next', code: 'KC_MNXT', title: 'Next Track' },
-  { name: 'Mute', code: 'KC_MUTE', title: 'Mute Audio' },
-  { name: 'Vol ⏷', code: 'KC_VOLD', title: 'Volume Down' },
-  { name: 'Vol ⏶', code: 'KC_VOLU', title: 'Volume Up' },
-  { name: 'Media Stop', code: 'KC_MSTP', title: 'Media Stop' },
-  { name: 'Play', code: 'KC_MPLY', title: 'Play/Pause' },
-  { width: 250 },
+  { name: 'Prev Track', code: 'KC_MPRV', title: 'Previous Track' },
   {
     name: 'Rewind',
     code: 'KC_MRWD',
     title: 'Previous Track / Rewind (macOS)'
   },
+  { name: 'Play/Pause', code: 'KC_MPLY', title: 'Play/Pause' },
+  { name: 'Stop', code: 'KC_MSTP', title: 'Media Stop' },
   {
     name: 'FFwd',
     code: 'KC_MFFD',
     title: 'Next Track / Fast Forward (macOS)'
   },
+  { name: 'Next Track', code: 'KC_MNXT', title: 'Next Track' },
+
   { width: 250 },
+
+  { name: 'Mute', code: 'KC_MUTE', title: 'Mute Audio' },
+  { name: 'Vol ⏷', code: 'KC_VOLD', title: 'Volume Down' },
+  { name: 'Vol ⏶', code: 'KC_VOLU', title: 'Volume Up' },
+
+  { width: 250 },
+
   { name: 'Eject', code: 'KC_EJCT', title: 'Eject (macOS)' },
 
   { label: 'Mouse Keys', width: 'label' },
@@ -129,7 +140,9 @@ export default [
   { name: 'Mouse ⏷', code: 'MS_DOWN', title: 'Mouse Cursor Down' },
   { name: 'Mouse ⏴', code: 'MS_LEFT', title: 'Mouse Cursor Left' },
   { name: 'Mouse ⏵', code: 'MS_RGHT', title: 'Mouse Cursor Right' },
+
   { width: 250 },
+
   { name: 'Mouse 1', code: 'MS_BTN1', title: 'Mouse Button 1' },
   { name: 'Mouse 2', code: 'MS_BTN2', title: 'Mouse Button 2' },
   { name: 'Mouse 3', code: 'MS_BTN3', title: 'Mouse Button 3' },
@@ -138,12 +151,16 @@ export default [
   { name: 'Mouse 6', code: 'MS_BTN6', title: 'Mouse Button 6' },
   { name: 'Mouse 7', code: 'MS_BTN7', title: 'Mouse Button 7' },
   { name: 'Mouse 8', code: 'MS_BTN8', title: 'Mouse Button 8' },
+
   { width: 0 },
+
   { name: 'Mouse Whl ⏶', code: 'MS_WHLU', title: 'Mouse Wheel Up' },
   { name: 'Mouse Whl ⏷', code: 'MS_WHLD', title: 'Mouse Wheel Down' },
   { name: 'Mouse Whl ⏴', code: 'MS_WHLL', title: 'Mouse Wheel Left' },
   { name: 'Mouse Whl ⏵', code: 'MS_WHLR', title: 'Mouse Wheel Right' },
+
   { width: 250 },
+
   {
     name: 'Mouse Accel 0',
     code: 'MS_ACL0',
@@ -160,18 +177,22 @@ export default [
     title: 'Set mouse acceleration to 2'
   },
 
-  { label: 'Extra Fn Keys', width: 'label' },
+  { label: 'Extended F-Keys', width: 'label' },
 
   { name: 'F13', code: 'KC_F13' },
   { name: 'F14', code: 'KC_F14' },
   { name: 'F15', code: 'KC_F15' },
   { name: 'F16', code: 'KC_F16' },
+
   { width: 250 },
+
   { name: 'F17', code: 'KC_F17' },
   { name: 'F18', code: 'KC_F18' },
   { name: 'F19', code: 'KC_F19' },
   { name: 'F20', code: 'KC_F20' },
+
   { width: 250 },
+
   { name: 'F21', code: 'KC_F21' },
   { name: 'F22', code: 'KC_F22' },
   { name: 'F23', code: 'KC_F23' },

--- a/src/store/modules/keycodes/kb-settings.js
+++ b/src/store/modules/keycodes/kb-settings.js
@@ -1,32 +1,80 @@
 export default [
   { label: 'KeyboardSettings', group: true },
 
-  { label: 'Keyboard settings (persistent)', width: 'label' },
+  { label: 'Modifier Swapping', width: 'label' },
 
   {
-    name: 'Swap LCtl⇄Caps',
-    code: 'CL_SWAP',
-    title: 'Swap Left Control and Caps Lock',
+    name: 'Toggle Ctl⇄GUI',
+    code: 'CG_TOGG',
+    title: 'Toggle swapping both Control and GUI keys',
     width: 1500
   },
   {
-    name: 'Caps=LCtl',
-    code: 'CL_CTRL',
-    title: 'Treat Caps Lock as Left Control',
+    name: 'Swap Ctl⇄GUI',
+    code: 'CG_SWAP',
+    title: 'Swap both Ctrl and GUI keys',
     width: 1500
   },
+  {
+    name: 'Unswap Ctl⇄GUI',
+    code: 'CG_NORM',
+    title: 'Unswap both Ctrl and GUI keys',
+    width: 1500
+  },
+
+  { width: 250 },
+
   {
     name: 'Swap LCtl⇄LGUI',
     code: 'CG_LSWP',
-    title: 'Swap Left Control and GUI',
+    title: 'Swap Left Control and Left GUI',
     width: 1500
   },
   {
-    name: 'Swap RCtl⇄RGUI',
-    code: 'CG_RSWP',
-    title: 'Swap Right Control and GUI',
+    name: 'Unswap LCtl⇄LGUI',
+    code: 'CG_LNRM',
+    title: 'Unswap Left Control and Left GUI',
     width: 1500
   },
+
+  { width: 250 },
+
+  {
+    name: 'Swap RCtl⇄RGUI',
+    code: 'CG_RSWP',
+    title: 'Swap Right Control and Right GUI',
+    width: 1500
+  },
+  {
+    name: 'Unswap RCtl⇄RGUI',
+    code: 'CG_RNRM',
+    title: 'Unswap Right Control and Right GUI',
+    width: 1500
+  },
+
+  { width: 0 },
+
+  {
+    name: 'Toggle Alt⇄GUI',
+    code: 'AG_TOGG',
+    title: 'Toggle swapping both Alt and GUI keys',
+    width: 1500
+  },
+  {
+    name: 'Swap Alt⇄GUI',
+    code: 'AG_SWAP',
+    title: 'Swap both Alt and GUI keys',
+    width: 1500
+  },
+  {
+    name: 'Unswap Alt⇄GUI',
+    code: 'AG_NORM',
+    title: 'Unswap both Alt and GUI keys',
+    width: 1500
+  },
+
+  { width: 250 },
+
   {
     name: 'Swap LAlt⇄LGUI',
     code: 'AG_LSWP',
@@ -34,21 +82,33 @@ export default [
     width: 1500
   },
   {
+    name: 'Unswap LAlt⇄LGUI',
+    code: 'AG_LNRM',
+    title: 'Unswap Left Alt and Left GUI',
+    width: 1500
+  },
+
+  { width: 250 },
+
+  {
     name: 'Swap RAlt⇄RGUI',
     code: 'AG_RSWP',
     title: 'Swap Right Alt and Right GUI',
     width: 1500
   },
   {
-    name: 'Disable GUI',
-    code: 'GU_OFF',
-    title: 'Disable the GUI keys (useful when gaming)',
+    name: 'Unswap RAlt⇄RGUI',
+    code: 'AG_RNRM',
+    title: 'Unswap Right Alt and Right GUI',
     width: 1500
   },
+
+  { label: 'Other Key Swapping', width: 'label' },
+
   {
-    name: 'Swap `⇄Esc',
-    code: 'GE_SWAP',
-    title: 'Swap ` and Escape',
+    name: 'Toggle \\⇄Bspc',
+    code: 'BS_TOGG',
+    title: 'Toggle swapping Backslash and Backspace',
     width: 1500
   },
   {
@@ -58,25 +118,41 @@ export default [
     width: 1500
   },
   {
-    name: 'NKRO On',
-    code: 'NK_ON',
-    title: 'Force N-Key Rollover (NKRO) on',
+    name: 'Unswap \\⇄Bspc',
+    code: 'BS_NORM',
+    title: 'Unswap Backslash and Backspace',
+    width: 1500
+  },
+
+  { width: 0 },
+
+  { width: 1500 },
+  {
+    name: 'Swap `⇄Esc',
+    code: 'GE_SWAP',
+    title: 'Swap ` (grave) and Escape',
     width: 1500
   },
   {
-    name: 'Swap Alt⇄GUI',
-    code: 'AG_SWAP',
-    title: 'Swap Alt and GUI on both sides (for macOS)',
+    name: 'Unswap `⇄Esc',
+    code: 'GE_NORM',
+    title: 'Unswap ` (grave) and Escape',
+    width: 1500
+  },
+
+  { label: 'Caps Lock Behavior', width: 'label' },
+
+  {
+    name: 'Toggle LCtl⇄Caps',
+    code: 'CL_TOGG',
+    title: 'Toggle swapping Left Control and Caps Lock',
     width: 1500
   },
   {
-    name: 'Swap Ctl⇄GUI',
-    code: 'CG_SWAP',
-    title: 'Swap Ctrl and GUI on both sides (for macOS)',
+    name: 'Swap LCtl⇄Caps',
+    code: 'CL_SWAP',
+    title: 'Swap Left Control and Caps Lock',
     width: 1500
-  },
-  {
-    width: 0
   },
   {
     name: 'Unswap LCtl⇄Caps',
@@ -84,76 +160,71 @@ export default [
     title: 'Unswap Left Control and Caps Lock',
     width: 1500
   },
+
+  { width: 250 },
+
+  {
+    name: 'Caps=LCtl',
+    code: 'CL_CTRL',
+    title: 'Treat Caps Lock as Left Control',
+    width: 1500
+  },
+
+  { width: 0 },
+
+  {
+    name: 'Toggle Esc⇄Caps',
+    code: 'EC_TOGG',
+    title: 'Toggle swapping Escape and Caps Lock',
+    width: 1500
+  },
+  {
+    name: 'Swap Esc⇄Caps',
+    code: 'EC_SWAP',
+    title: 'Swap Escape and Caps Lock',
+    width: 1500
+  },
+  {
+    name: 'Unswap Esc⇄Caps',
+    code: 'EC_NORM',
+    title: 'Unswap Escape and Caps Lock',
+    width: 1500
+  },
+
+  { width: 250 },
+
   {
     name: 'Caps≠LCtl',
     code: 'CL_CAPS',
     title: 'Stop treating Caps Lock as Left Control',
     width: 1500
   },
+
+  { label: 'GUI Key Behavior (Windows/Command/Super)', width: 'label' },
+
+  { name: 'Toggle GUI', code: 'GU_TOGG', title: 'Toggle the GUI keys' },
+  { name: 'GUI On', code: 'GU_ON', title: 'Enable the GUI keys' },
   {
-    name: 'Unswap LCtl⇄LGUI',
-    code: 'CG_LNRM',
-    title: 'Unswap Left Control and GUI',
-    width: 1500
+    name: 'GUI Off',
+    code: 'GU_OFF',
+    title: 'Disable the GUI keys (useful when gaming)'
+  },
+
+  { label: 'N-Key Rollover', width: 'label' },
+
+  {
+    name: 'Toggle NKRO',
+    code: 'NK_TOGG',
+    title: 'Turn NKRO on or off'
   },
   {
-    name: 'Unswap RCtl⇄RGUI',
-    code: 'CG_RNRM',
-    title: 'Unswap Right Control and GUI',
-    width: 1500
-  },
-  {
-    name: 'Unswap LAlt⇄LGUI',
-    code: 'AG_LNRM',
-    title: 'Unswap Left Alt and Left GUI',
-    width: 1500
-  },
-  {
-    name: 'Unswap RAlt⇄RGUI',
-    code: 'AG_RNRM',
-    title: 'Unswap Right Alt and Right GUI',
-    width: 1500
-  },
-  {
-    name: 'Enable GUI',
-    code: 'GU_ON',
-    title: 'Enable the GUI keys',
-    width: 1500
-  },
-  {
-    name: 'Unswap `⇄Esc',
-    code: 'GE_NORM',
-    title: 'Unswap ` and Escape',
-    width: 1500
-  },
-  {
-    name: 'Unswap \\⇄Bspc',
-    code: 'BS_NORM',
-    title: 'Unswap Backslash and Backspace',
-    width: 1500
+    name: 'NKRO On',
+    code: 'NK_ON',
+    title: 'Turn NKRO on'
   },
   {
     name: 'NKRO Off',
     code: 'NK_OFF',
-    title: 'Force N-Key Rollover (NKRO) off',
-    width: 1500
-  },
-  {
-    name: 'Unswap Alt⇄GUI',
-    code: 'AG_NORM',
-    title: 'Unswap Alt and GUI on both sides (for macOS)',
-    width: 1500
-  },
-  {
-    name: 'Unswap Ctl⇄GUI',
-    code: 'CG_NORM',
-    title: 'Unswap Ctrl and GUI on both sides',
-    width: 1500
-  },
-  {
-    name: 'Toggle NKRO',
-    code: 'NK_TOGG',
-    title: 'Turn NKRO on or off',
-    width: 1500
+    title: 'Turn NKRO off'
   }
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Keyboard settings tab:
 - Keycodes are now grouped better, and more consistently named & described. Notably, there is a gap as the `GE_TOGG` keycode does not exist.

![image](https://github.com/user-attachments/assets/31869212-6e0a-45f7-8646-9eeb97209cda)

App/Media/Mouse tab:
 - Tweaked keycode spacing and ordering, in particular the multimedia keys, to make a little more intuitive sense (eg. placing prev/rewind/ffwd/next at either end of the play/pause and stop keys). The Application section could perhaps use some more refinement, but the height of the tab content area is currently hardcoded to 412px due to how the keycode elements are laid out, and adding more sections would overflow it.

![image](https://github.com/user-attachments/assets/ebdfb54a-5310-4acd-93c7-46229da1bbd8)
