### PR TITLE
Improve keycode picker container keys

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -674,6 +674,7 @@ button {
   content: 'N/A';
 }
 
+.keycode-text,
 .keycode-container,
 .keycode-layer,
 .keycode-layer-container {
@@ -681,11 +682,12 @@ button {
   display: block;
 }
 
+.keycode-text:after,
 .keycode-container:after,
 .keycode-layer-container:after,
 .keycode-layer:after {
-  content: '';
-  width: 14px;
+  content: '…';
+  width: 24px;
   height: 14px;
   border-radius: 2px;
   border: 1px solid;

--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -153,6 +153,7 @@ html {
     .keycode-select {
       border-color: green !important;
     }
+    .keycode-text:after,
     .keycode-container:after,
     .keycode-layer-container:after,
     .keycode-layer:after {
@@ -428,6 +429,7 @@ html[data-theme='dark'] {
     background: qmk_colors.$qmk-grey-dark;
     border-color: #2f2f2f;
   }
+  .keycode-text:after,
   .keycode-container:after,
   .keycode-layer-container:after,
   .keycode-layer:after {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- The `Any` key now has an "input box" below it, to match the other container-type keys eg. the Layer- and Mod-Taps, both in the picker and the keymap itself
- Widened said input box and added an ellipsis, to further reinforce its purpose

![image](https://github.com/user-attachments/assets/f2dca6a6-bfc9-4141-b495-483dba990354)
