### PR TITLE
Use v-tooltip for "Summon Wizard" button

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,14 +20,7 @@
       :class="helpClasses"
       :title="$t('help.label')"
       @click="toggleTutorial"
-      @mouseenter="
-        setMessage($t('help.label'));
-        hover = true;
-      "
-      @mouseleave="
-        setMessage('');
-        hover = false;
-      "
+      v-tooltip.bottom-end="$t('help.label')"
     >
       <font-awesome-icon
         v-show="!snowflakes && !tutorialEnabled"
@@ -143,12 +136,7 @@ export default {
     window.removeEventListener('beforeunload', this.showConfirmationPrompt);
   },
   methods: {
-    ...mapMutations([
-      'setShowSpinner',
-      'setSettingsPanel',
-      'toggleTutorial',
-      'setMessage'
-    ]),
+    ...mapMutations(['setShowSpinner', 'setSettingsPanel', 'toggleTutorial']),
     ...mapActions('app', ['loadApplicationState']),
     randomPotatoFact() {
       const len = size(this.$t('potato'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This appears to be the only UI element, apart from the settings panel and the keycode picker, which uses the bottom "message" bar as a "tooltip" rather than `v-tooltip`.
