### PR TITLE
Update InfoBar styling

### DIFF
--- a/src/components/InfoBar.vue
+++ b/src/components/InfoBar.vue
@@ -33,8 +33,8 @@ export default {
   font-size: 150%;
   opacity: 0.8;
   margin: 16px;
-  padding: 12px;
-  border-radius: 8px;
+  padding: 16px 24px;
+  border-radius: 100px;
 }
 
 .fadelong-enter-active,

--- a/src/components/InfoBar.vue
+++ b/src/components/InfoBar.vue
@@ -1,6 +1,8 @@
 <template functional>
   <transition name="fadelong" appear>
-    <div v-if="props.msg.length" class="bottom-fixed">{{ props.msg }}</div>
+    <div v-if="props.msg.length" class="bottom-fixed">
+      <div class="info-msg">{{ props.msg }}</div>
+    </div>
   </transition>
 </template>
 <script>
@@ -20,12 +22,19 @@ export default {
   z-index: 500;
   bottom: 0px;
   left: 0;
-  width: 100%;
+  right: 0;
+  max-width: fit-content;
+  margin-inline: auto;
+}
+
+.info-msg {
   text-align: center;
-  line-height: 250%;
   font-family: 'Roboto', sans-serif;
   font-size: 150%;
   opacity: 0.8;
+  margin: 16px;
+  padding: 12px;
+  border-radius: 8px;
 }
 
 .fadelong-enter-active,

--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -187,7 +187,7 @@ html {
     .key-contents:empty:before {
       color: #ccc;
     }
-    .bottom-fixed {
+    .info-msg {
       background: #add8e6;
       color: #222;
     }
@@ -420,7 +420,7 @@ html[data-theme='dark'] {
   #keycodes {
     background-color: inherit;
   }
-  .bottom-fixed,
+  .info-msg,
   .settings-panel--help-text {
     background: #194452;
     color: #ddd;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I thought this looked a little better.

Before
<img width="2586" height="256" alt="image" src="https://github.com/user-attachments/assets/14072fd0-d30d-478b-8734-69129f3b6b25" />

After
<img width="2586" height="256" alt="image" src="https://github.com/user-attachments/assets/7a918b76-08f0-4143-958d-ea364833a4a4" />
(colon instead of dash is from another experiment regarding language-specific keycodes)

Could also add a drop shadow, and IMO the background colour doesn't really fit with the rest of the UI, but I've left those for now.