### PR TITLE
Fix "Open keyboard folder on GitHub" color

### DIFF
--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -544,6 +544,6 @@ export default {
 #open-on-github {
   cursor: pointer;
   margin-left: 8px;
-  color: white;
+  color: unset;
 }
 </style>

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -544,6 +544,5 @@ export default {
 #open-on-github {
   cursor: pointer;
   margin-left: 8px;
-  color: unset;
 }
 </style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Small visual bug, in light mode the icon is hard to see. Using `unset` since removing the `color` would make it the link color.

<img width="119" height="89" alt="image" src="https://github.com/user-attachments/assets/dd111276-8fbc-40b2-9fed-287c313d58d0" />
<img width="154" height="113" alt="image" src="https://github.com/user-attachments/assets/2155f06b-d9d1-42fa-94ae-2879479d0d86" />
