### PR TITLE
Add hover state for buttons

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -276,7 +276,6 @@ button + button {
 }
 
 .label-button {
-  pointer-events: none;
   user-select: none;
 }
 

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -275,6 +275,11 @@ button + button {
   margin-left: 4px;
 }
 
+.label-button {
+  pointer-events: none;
+  user-select: none;
+}
+
 #status {
   position: relative;
 }

--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -92,6 +92,9 @@ html {
       background-color: #49ad4c;
       color: #fff;
       border-color: #000;
+      &:hover {
+        background-color: #50ba51;
+      }
     }
     .tab {
       background: #fff;
@@ -280,6 +283,9 @@ html {
       background-color: #49ad4c;
       color: white;
       border-color: #000;
+      &:hover {
+        background-color: #50ba51;
+      }
     }
     #compile:disabled,
     #fwFile:disabled,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<img width="395" height="111" alt="image" src="https://github.com/user-attachments/assets/6ae6c826-9d39-4d7a-bc3c-3c5f4d2fa8a4" />

Seems like `.ui-button` is intended as a common button class but it is used almost nowhere, and the styles are applied to specific IDs instead...

Also disabled selection & I-beam pointer for the "keymap.json" label.