### PR TITLE
Border color fixes

### DIFF
--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -296,7 +296,7 @@ html {
     }
     #terminal {
       background: #272822;
-      border-color: #000;
+      border-color: #ccc;
       color: #f8f8f2;
     }
     #controller-bottom {
@@ -389,13 +389,16 @@ html[data-theme='dark'] {
   #controller-bottom {
     background-color: qmk_colors.$qmk-grey-dark;
     color: qmk_colors.$qmk-grey-light;
-    border-color: #0e0e0e;
+    border-color: #555;
   }
   .tester-key {
     background: #0c0c0c;
     &.detected {
       color: qmk_colors.$qmk-black;
     }
+  }
+  #terminal {
+    border-color: #555;
   }
   #toggle-terminal-label {
     color: #f8f8f2;
@@ -431,7 +434,7 @@ html[data-theme='dark'] {
   }
   .tab-area {
     background: qmk_colors.$qmk-grey-dark;
-    border-color: #2f2f2f;
+    border-color: #555;
   }
   .keycode-text:after,
   .keycode-container:after,
@@ -456,8 +459,8 @@ html[data-theme='dark'] {
     color: #bbb;
   }
   .tab {
-    border-color: #2f2f2f;
-    color: #555;
+    background-color: #444;
+    border-color: #555;
     &.active {
       color: qmk_colors.$qmk-grey-light;
       background-color: #464646;
@@ -490,7 +493,7 @@ html[data-theme='dark'] {
   .layer {
     background: qmk_colors.$qmk-grey-dark;
     border-color: #5a5a5a;
-    color: #0e0e0e;
+    color: #999;
     &:hover {
       background: #eee;
       color: #000;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- Adjusted dark mode border color for top section panels and keycode picker
- Adjusted dark mode keycode picker inactive tab background color
- Fixed inconsistent terminal border color
- Lightened inactive layer text color for readability

Before:
<img width="336" height="812" alt="image" src="https://github.com/user-attachments/assets/a1eedca7-75e1-4ca2-b698-7df00e4ad5aa" />
<img width="914" height="174" alt="image" src="https://github.com/user-attachments/assets/93a23a24-2476-4480-98a6-7039624af715" />
<img width="232" height="746" alt="image" src="https://github.com/user-attachments/assets/f79d545a-94d7-41f6-96af-53e49677003b" />

After:
<img width="336" height="812" alt="image" src="https://github.com/user-attachments/assets/5c20dca2-b2ea-4dbf-8884-332adfe107a3" />
<img width="914" height="174" alt="image" src="https://github.com/user-attachments/assets/7b1b5a08-b0a2-4d32-9365-8cc9fc1d9740" />
<img width="232" height="746" alt="image" src="https://github.com/user-attachments/assets/ea70c23b-e719-4bcd-a2c8-f1da3957df10" />
