### PR TITLE
Consolidate button styles

### DIFF
--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -13,8 +13,8 @@
             />
           </div>
           <div>
-            <button @click="importUrlkeymap">Load</button>
-            <button @click="closeVeil">cancel</button>
+            <button class="ui-button" @click="importUrlkeymap">Load</button>
+            <button class="ui-button" @click="closeVeil">cancel</button>
           </div>
         </div>
       </template>
@@ -22,6 +22,7 @@
     <div class="botctrl-1-1">
       <button
         id="export"
+        class="ui-button"
         v-tooltip.bottom="$t('downloadJSON.title')"
         @click="exportJSON"
       >
@@ -30,6 +31,7 @@
       <span class="label-button">{{ $t('downloadJSON.label') }}</span>
       <button
         id="import"
+        class="ui-button"
         v-tooltip.bottom="$t('importJSON.title')"
         @click="importKeymap"
       >
@@ -37,6 +39,7 @@
       </button>
       <button
         id="import-url"
+        class="ui-button"
         v-tooltip.bottom="$t('importUrlJSON.title')"
         @click="openVeil"
       >
@@ -59,6 +62,7 @@
       </a>
       <button
         id="printkeymaps"
+        class="ui-button"
         v-tooltip.bottom="$t('printKeymap.title')"
         @click="printKeymaps"
       >
@@ -67,6 +71,7 @@
       </button>
       <button
         id="testkeys"
+        class="ui-button"
         v-tooltip.bottom="$t('testKeys.title')"
         @click="testKeys"
       >
@@ -97,7 +102,7 @@
         id="source"
         v-tooltip="$t('downloadSource.title')"
         :disabled="disableDownloadSource"
-        class="fixed-size"
+        class="fixed-size ui-button"
         @click="downloadSource"
       >
         <font-awesome-icon icon="download" size="lg" fixed-width />
@@ -105,6 +110,7 @@
       </button>
       <button
         id="fwFile"
+        class="ui-button"
         v-tooltip="$t('downloadFirmware.title')"
         :disabled="disableDownloadBinary"
         @click="downloadFirmware"
@@ -517,9 +523,6 @@ export default {
 }
 #import {
   border-radius: 0 4px 4px 0;
-}
-#import-url {
-  border-radius: 4px;
 }
 .input-url-modal label {
   padding-right: 5px;

--- a/src/components/ControllerTop.vue
+++ b/src/components/ControllerTop.vue
@@ -68,6 +68,7 @@
       <div class="topctrl-controls">
         <button
           id="load-default"
+          class="ui-button"
           v-tooltip="$t('loadDefault.title')"
           @click="loadDefault"
         >
@@ -75,6 +76,7 @@
         </button>
         <button
           id="compile"
+          class="ui-button"
           v-tooltip="$t('compile.title')"
           :disabled="compileDisabled"
           @click="compile"

--- a/src/components/LayerControl.vue
+++ b/src/components/LayerControl.vue
@@ -13,11 +13,7 @@
         @click="clicked(layer.id)"
       >{{ layer.name }}</div>
     </div>
-    <button
-      class="clear-button"
-      v-tooltip="$t('layer.title')"
-      @click="clearLayer"
-    >
+    <button class="ui-button" v-tooltip="$t('layer.title')" @click="clearLayer">
       <font-awesome-icon icon="trash" size="lg" fixed-width />
     </button>
   </div>
@@ -78,13 +74,3 @@ export default {
   }
 };
 </script>
-<style>
-.clear-button {
-  line-height: 100%;
-  margin: 0;
-  border-radius: 3px;
-  border: 0px solid;
-  padding: 6px 8px;
-  cursor: pointer;
-}
-</style>

--- a/src/components/VisualTesterKeymap.vue
+++ b/src/components/VisualTesterKeymap.vue
@@ -431,12 +431,10 @@ export default {
 }
 .layout-btn-select {
   line-height: 120%;
-  margin: 0px 4px 0px 0px;
   border-radius: 3px;
   border: 0px solid;
   padding: 6px 12px;
   cursor: pointer;
-  margin-bottom: 10px;
 }
 .volume {
   margin-right: 10px;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -248,27 +248,16 @@ a img {
   vertical-align: middle;
 }
 
-#compile,
-#fwFile,
-#toolbox,
-#source,
-#export,
-#import,
-#import-url,
-#settings,
-#printkeymaps,
-#testkeys,
-#leaveTest,
-#resetTest,
-#load-default,
 .ui-button {
   line-height: 120%;
   border-radius: 3px;
-  // background-color: #49ad4c;
-  // color: white;
-  border: 0px solid #000;
+  border: none;
   padding: 5px 8px;
   cursor: pointer;
+
+  &:disabled {
+    cursor: unset;
+  }
 }
 
 button + button {
@@ -347,22 +336,9 @@ button + button {
   padding: 0 5px;
 }
 
-#compile {
-  margin-right: 0px;
-}
-
 #fileImport,
 #infoPreview {
   display: none;
-}
-
-#compile:disabled,
-#fwFile:disabled,
-#toolbox:disabled,
-#source:disabled {
-  // background: #ccc;
-  // color: #999;
-  cursor: unset;
 }
 
 select,

--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -88,14 +88,6 @@ html {
       background: #4b0082;
       color: #ffa500;
     }
-    .clear-button {
-      background-color: #49ad4c;
-      color: #fff;
-      border-color: #000;
-      &:hover {
-        background-color: #50ba51;
-      }
-    }
     .tab {
       background: #fff;
       border-color: #ccc;
@@ -265,34 +257,16 @@ html {
       border-color: #fff;
     }
 
-    #compile,
-    #fwFile,
-    #toolbox,
-    #source,
-    #export,
-    #import,
-    #import-url,
-    #settings,
-    #printkeymaps,
-    #testkeys,
-    #leavePrint,
-    #leaveTest,
-    #resetTest,
-    #load-default,
     .ui-button {
       background-color: #49ad4c;
       color: white;
-      border-color: #000;
       &:hover {
         background-color: #50ba51;
       }
-    }
-    #compile:disabled,
-    #fwFile:disabled,
-    #toolbox:disabled,
-    #source:disabled {
-      background: #ccc;
-      color: #999;
+      &:disabled {
+        background: #ccc;
+        color: #999;
+      }
     }
     #terminal {
       background: #272822;

--- a/src/views/Test.vue
+++ b/src/views/Test.vue
@@ -1,10 +1,15 @@
 <template>
   <div class="visual-tester">
-    <button id="leaveTest" @click="gohome()">
+    <button id="leaveTest" class="ui-button" @click="gohome()">
       <font-awesome-icon icon="chevron-left" size="lg" fixed-width />
       {{ $t('tester.back.label') }}
     </button>
-    <button id="resetTest" :title="$t('tester.reset.title')" @click="reset()">
+    <button
+      id="resetTest"
+      class="ui-button"
+      :title="$t('tester.reset.title')"
+      @click="reset()"
+    >
       <font-awesome-icon icon="undo" size="lg" fixed-width />
       {{ $t('tester.reset.label') }}
     </button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Button styles were applied to specific element IDs, rather than them using the existing `.ui-button` class.

No visual changes, except for the layer clear button which had 1px more top & bottom padding, and the key tester layout selector buttons, where there was an extra 4px margin on the right.
