### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/components/ControllerBottom.vue
+++ b/src/components/ControllerBottom.vue
@@ -506,10 +506,14 @@ export default {
   padding: 5px;
   border: 1px solid;
   border-radius: 5px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0 4px 16px;
   width: 400px;
 }
 .fixed-size {
   min-width: 150px;
+}
+.hide-small {
+  margin-left: 4px;
 }
 #export {
   border-radius: 4px 0 0 4px;

--- a/src/components/Keycodes.vue
+++ b/src/components/Keycodes.vue
@@ -184,6 +184,7 @@ export default {
   z-index: 100;
   cursor: pointer;
   margin-bottom: -1px;
+  user-select: none;
 }
 .end-tab input {
   padding: 3px 7px;

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -220,7 +220,7 @@ export default {
     sortedOSKeyboardLayouts: function () {
       // Locale-aware sort of the OS keyboard layouts by their labels.
       const translatedLayoutName = (osLayout) =>
-        this.$t(`settingsPanel.osKeyboardLayout.label.${osLayout}`);
+        this.$t(`settingsPanel.osKeyboardLayout.option.${osLayout}`);
       return [...this.osKeyboardLayouts].sort((a, b) =>
         translatedLayoutName(a).localeCompare(translatedLayoutName(b))
       );

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -135,6 +135,9 @@ export default {
 };
 </script>
 <style>
+.bes-controls {
+  user-select: none;
+}
 .bes-high-job-count {
   color: red;
 }

--- a/src/components/Veil.vue
+++ b/src/components/Veil.vue
@@ -1,5 +1,5 @@
 <template functional>
-  <transition name="fade" appear>
+  <transition name="veil" appear>
     <div class="veil-container" v-show="props.isVisible">
       <slot name="contents">Something to Unveil</slot>
     </div>
@@ -29,14 +29,14 @@ export default {
   height: 100%;
   z-index: 50000;
 }
-.fade-enter-active {
-  transition: all 0.5s ease;
+.veil-enter-active {
+  transition: opacity 0.2s ease-in-out;
 }
-.fade-leave-active {
-  transition: all 0.8s cubic-bezier(1, 0.5, 0.8, 1);
+.veil-leave-active {
+  transition: opacity 0.2s ease-in-out;
 }
-.fade-enter,
-.fade-leave-to {
+.veil-enter,
+.veil-leave-to {
   opacity: 0;
 }
 </style>

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -802,7 +802,7 @@ input[type='number']::-webkit-outer-spin-button {
 }
 
 input[type='number'] {
-  -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 .hint {

--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -122,7 +122,7 @@ html {
       color: rgba(0, 0, 0, 0.7);
     }
     .veil-container {
-      background: rgba(30, 30, 30, 0.3);
+      background: rgba(0, 0, 0, 0.4);
     }
     .letter-key-code,
     .letter-code,
@@ -368,8 +368,10 @@ html[data-theme='dark'] {
     h3 {
       color: #ddd;
     }
-    th {
+    th,
+    td {
       color: #bbb;
+      border-color: #444;
     }
     .print-keymap {
       background: #464646;
@@ -389,6 +391,10 @@ html[data-theme='dark'] {
   #controller-bottom {
     background-color: qmk_colors.$qmk-grey-dark;
     color: qmk_colors.$qmk-grey-light;
+    border-color: #555;
+  }
+  .input-url-modal {
+    background-color: qmk_colors.$qmk-grey-dark;
     border-color: #555;
   }
   .tester-key {

--- a/src/store/modules/keycodes/ansi.js
+++ b/src/store/modules/keycodes/ansi.js
@@ -298,6 +298,6 @@ export default [
   { name: '>', code: 'KC_GT', keys: '>', title: '>' },
   { name: ':', code: 'KC_COLN', keys: ':', title: ':' },
   { name: '|', code: 'KC_PIPE', keys: '|', title: '|' },
-  { name: '?', code: 'KC_QUES', keys: '?', title: '' },
+  { name: '?', code: 'KC_QUES', keys: '?', title: '?' },
   { name: '"', code: 'KC_DQUO', keys: '"', title: '"' }
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

An assortment of things that didn't quite look right.

- Fixed a bunch of warnings in console regarding host keyboard layout dropdown translations (because I missed changing one `label` -> `option`)
- `ControllerBottom`: Added some space between button icons and text (see below)
- Disabled text selection on keycode picker tabs and backend status
- Removed vendor prefix on `appearance: textfield;` for number inputs - Sass LSP was flagging it
- `Veil`: fixed keymap.json URL import modal transition naming collision and made it a little snappier
- Added proper dark mode styling for import modal:
  **Before**
  <img width="926" height="332" alt="image" src="https://github.com/user-attachments/assets/419a8291-8300-4e6e-9dac-d657da66146f" />
  **After**
  <img width="926" height="332" alt="image" src="https://github.com/user-attachments/assets/0c0662d2-9dd8-499c-9617-7b8e120f64e3" />
- Fixed dark mode border color on Print Keymap page:
  **Before**
  <img width="1016" height="488" src="https://github.com/user-attachments/assets/e8cef00a-a32f-4570-a7a8-5dbc3a210755" />
  **After**
  <img width="1016" height="488" src="https://github.com/user-attachments/assets/fee662f6-ce68-4265-8dbb-4ec2d370b224" />