### PR TITLE
Improve `StatusPanel` collapse behaviour

### DIFF
--- a/src/components/StatusPanel.vue
+++ b/src/components/StatusPanel.vue
@@ -7,22 +7,18 @@
       readonly
       :class="terminalClasses"
     />
-    <label
-      for="toggle-terminal"
-      id="toggle-terminal-label"
-      :class="terminalClasses"
-      @click="toggleTerminal"
-      >{{ $t('toggleTerminal.label') }}</label
-    >
-    <font-awesome-icon
-      icon="chevron-up"
-      size="lg"
-      fixed-width
-      id="toggle-terminal"
-      :title="$t('toggleTerminal.title')"
-      :class="terminalClasses"
-      @click="toggleTerminal"
-    />
+    <div id="toggle-terminal" :class="terminalClasses" @click="toggleTerminal">
+      <label for="toggle-terminal-chevron" id="toggle-terminal-label">{{
+        $t('toggleTerminal.label')
+      }}</label>
+      <font-awesome-icon
+        icon="chevron-up"
+        size="lg"
+        fixed-width
+        id="toggle-terminal-chevron"
+        :title="$t('toggleTerminal.title')"
+      />
+    </div>
   </div>
 </template>
 <script>

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -272,42 +272,38 @@ button + button {
   position: relative;
 }
 
-#toggle-terminal-label {
-  cursor: pointer;
+#toggle-terminal {
+  top: 4px;
+  transition: top 0.5s cubic-bezier(0.16, 1, 0.3, 1);
   position: absolute;
-  top: -12px;
-  right: 59px;
-  color: #f8f8f2;
-  opacity: 0;
-  transform: scaleY(0);
-  transition: all 0.5s ease-out;
+  right: 20px;
+  display: flex;
+  align-items: center;
 }
-#toggle-terminal-label.collapsed {
-  opacity: 0.5;
-  color: #272822;
-  top: -22px;
-  transform: scaleY(1);
-  transition: all 0.25s 0.25s ease-out;
+#toggle-terminal.collapsed {
+  top: -32px;
 }
 
-#toggle-terminal {
+#toggle-terminal-label {
   cursor: pointer;
-  position: absolute;
-  top: 4px;
-  right: 21px;
+  opacity: 0;
+  transition: opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+#toggle-terminal.collapsed #toggle-terminal-label {
+  opacity: 0.5;
+}
+
+#toggle-terminal-chevron {
+  cursor: pointer;
   width: 36px;
   height: 27px;
   white-space: nowrap;
-  color: #f8f8f2;
   margin: 0;
-  transition: all 0.5s ease-out;
+  transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-#toggle-terminal.collapsed {
-  transition: all 0.5s ease-out;
-  top: -25px;
-  color: #272822;
-  transform: scaleY(-1);
+#toggle-terminal.collapsed #toggle-terminal-chevron {
+  transform: rotate(-180deg);
 }
 
 #terminal {
@@ -327,11 +323,10 @@ button + button {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   display: block;
-  transition: all 0.5s ease-out;
+  transition: height 0.5s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 #terminal.collapsed {
-  transition: all 0.5s ease-out;
   height: 0px;
   padding: 0 5px;
 }

--- a/src/scss/themes.scss
+++ b/src/scss/themes.scss
@@ -273,6 +273,12 @@ html {
       border-color: #ccc;
       color: #f8f8f2;
     }
+    #toggle-terminal-chevron {
+      color: #f8f8f2;
+    }
+    #toggle-terminal.collapsed #toggle-terminal-chevron {
+      color: unset;
+    }
     #controller-bottom {
       background: #eee;
       border-color: #ccc;
@@ -383,13 +389,10 @@ html[data-theme='dark'] {
   #toggle-terminal-label {
     color: #f8f8f2;
   }
-  #toggle-terminal-label.collapsed {
+  #toggle-terminal-chevron {
     color: #f8f8f2;
   }
-  #toggle-terminal {
-    color: #f8f8f2;
-  }
-  #toggle-terminal.collapsed {
+  #toggle-terminal.collapsed #toggle-terminal-chevron {
     color: #f8f8f2;
   }
   #visual-keymap {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When loading the page (and also when switching between dark mode and light mode) the border around the "terminal" output visibly fades from light to dark where the rest of the page doesn't. The CSS collapse transition is set to apply to all properties instead of just the height.

Since I was digging around this area in trying to fix it I figured I might as well make the whole collapse transition nicer. The simple `ease-out` function is replaced with [easeOutExpo](https://easings.net/#easeOutExpo), and instead of the label and chevron moving separately, I've wrapped them in a div which is the part that translates, while fading and rotating respectively.

Before:

https://github.com/user-attachments/assets/77d30742-8b8d-42f4-9813-058cf8e25995

After:

https://github.com/user-attachments/assets/9949bc5d-28c9-48ff-b4bc-f887a00866c8
