### PR TITLE
Fix for `KC_NO` not triggering the InfoBar

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -645,10 +645,6 @@ button {
   z-index: 1001;
 }
 
-.keycode:empty:after {
-  content: 'N/A';
-}
-
 .keycode-text,
 .keycode-container,
 .keycode-layer,

--- a/src/store/modules/keycodes/quantum.js
+++ b/src/store/modules/keycodes/quantum.js
@@ -118,7 +118,7 @@ function makeOneShotModKey(code) {
 export default [
   { label: 'Quantum', width: 'label', group: true },
 
-  { name: '', code: 'KC_NO', title: 'Do nothing' },
+  { name: 'N/A', code: 'KC_NO', title: 'Do nothing' },
   {
     name: '▽',
     code: 'KC_TRNS',


### PR DESCRIPTION
PR #1428 introduced a check[^1] which allows hovering a keycode in the Keycode Selection array to trigger the InfoBar only if the key being hovered has a `name` property. This in turn caused hovering the `KC_NO` keycode to no longer trigger the InfoBar, because its `name` property was an empty string.[^2]

This commit sets the `name` property of the `KC_NO` keycode to 'N/A' in order to bypass the aforementioned check, and thus trigger the InfoBar.

*Before on top, after on bottom:*
<img width="640" height="292" alt="vlcsnap-2025-09-13-15h54m29s064" src="https://github.com/user-attachments/assets/c0c62870-0419-4b1b-bf93-c5377f44dba1" />


[^1]: https://github.com/qmk/qmk_configurator/blame/87751f5d9d93dd8995f31ac79ef601bdf50cb3bc/src/components/Keycodes.vue#L130
[^2]: https://github.com/qmk/qmk_configurator/blame/87751f5d9d93dd8995f31ac79ef601bdf50cb3bc/src/store/modules/keycodes/quantum.js#L121