### PR TITLE
Fix prop type check failure from initial InfoBar message state

### DIFF
--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -56,7 +56,7 @@ const state = {
   keypressListener: undefined,
   showSpinner: false,
   spinnerMsg: '',
-  message: '',
+  message: null,
   settingsPanelVisible: false,
   author: '',
   notes: '',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

```
[Vue warn]: Invalid prop: type check failed for prop "msg". Expected Object, got String with value "".
```
