### PR TITLE
Fix HHKB JP layout with hardcoded layout data

### DIFF
--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -130,6 +130,102 @@ const actions = {
       });
       return p;
     }
+    // Temporary fix for HHKB JP layout
+    if (state.keyboard === 'hhkb/jp') {
+      const fixedLayout = {
+        "keyboards": {
+          "hhkb/jp": {
+            "keyboard_name": "JP",
+            "manufacturer": "HHKB",
+            "maintainer": "qmk",
+            "usb": {
+              "vid": "0x4848",
+              "pid": "0x0002",
+              "device_version": "1.0.4"
+            },
+            "layouts": {
+              "LAYOUT_jp": {
+                "layout": [
+                  {"matrix": [0, 2], "x": 0, "y": 0},
+                  {"matrix": [3, 2], "x": 1, "y": 0},
+                  {"matrix": [6, 2], "x": 2, "y": 0},
+                  {"matrix": [2, 2], "x": 3, "y": 0},
+                  {"matrix": [1, 2], "x": 4, "y": 0},
+                  {"matrix": [5, 2], "x": 5, "y": 0},
+                  {"matrix": [7, 2], "x": 6, "y": 0},
+                  {"matrix": [10, 2], "x": 7, "y": 0},
+                  {"matrix": [9, 2], "x": 8, "y": 0},
+                  {"matrix": [8, 2], "x": 9, "y": 0},
+                  {"matrix": [11, 2], "x": 10, "y": 0},
+                  {"matrix": [14, 2], "x": 11, "y": 0},
+                  {"matrix": [15, 2], "x": 12, "y": 0},
+                  {"matrix": [13, 2], "x": 13, "y": 0},
+                  {"matrix": [12, 2], "x": 14, "y": 0},
+                  {"matrix": [0, 3], "x": 0, "y": 1, "w": 1.5},
+                  {"matrix": [6, 3], "x": 1.5, "y": 1},
+                  {"matrix": [2, 3], "x": 2.5, "y": 1},
+                  {"matrix": [1, 3], "x": 3.5, "y": 1},
+                  {"matrix": [5, 3], "x": 4.5, "y": 1},
+                  {"matrix": [7, 3], "x": 5.5, "y": 1},
+                  {"matrix": [10, 3], "x": 6.5, "y": 1},
+                  {"matrix": [9, 3], "x": 7.5, "y": 1},
+                  {"matrix": [8, 3], "x": 8.5, "y": 1},
+                  {"matrix": [11, 3], "x": 9.5, "y": 1},
+                  {"matrix": [14, 3], "x": 10.5, "y": 1},
+                  {"matrix": [15, 3], "x": 11.5, "y": 1},
+                  {"matrix": [13, 3], "x": 12.5, "y": 1},
+                  {"matrix": [6, 6], "x": 0, "y": 2, "w": 1.75},
+                  {"matrix": [2, 6], "x": 1.75, "y": 2},
+                  {"matrix": [1, 6], "x": 2.75, "y": 2},
+                  {"matrix": [5, 6], "x": 3.75, "y": 2},
+                  {"matrix": [7, 6], "x": 4.75, "y": 2},
+                  {"matrix": [10, 6], "x": 5.75, "y": 2},
+                  {"matrix": [9, 6], "x": 6.75, "y": 2},
+                  {"matrix": [8, 6], "x": 7.75, "y": 2},
+                  {"matrix": [11, 6], "x": 8.75, "y": 2},
+                  {"matrix": [14, 6], "x": 9.75, "y": 2},
+                  {"matrix": [15, 6], "x": 10.75, "y": 2},
+                  {"matrix": [13, 6], "x": 11.75, "y": 2},
+                  {"matrix": [12, 6], "x": 12.75, "y": 2},
+                  {"matrix": [0, 6], "x": 13.75, "y": 1, "w": 1.25, "h": 2},
+                  {"matrix": [0, 5], "x": 0, "y": 3, "w": 2},
+                  {"matrix": [6, 5], "x": 2, "y": 3},
+                  {"matrix": [2, 5], "x": 3, "y": 3},
+                  {"matrix": [1, 5], "x": 4, "y": 3},
+                  {"matrix": [5, 5], "x": 5, "y": 3},
+                  {"matrix": [7, 5], "x": 6, "y": 3},
+                  {"matrix": [10, 5], "x": 7, "y": 3},
+                  {"matrix": [9, 5], "x": 8, "y": 3},
+                  {"matrix": [8, 5], "x": 9, "y": 3},
+                  {"matrix": [11, 5], "x": 10, "y": 3},
+                  {"matrix": [14, 5], "x": 11, "y": 3},
+                  {"matrix": [15, 5], "x": 12, "y": 3},
+                  {"matrix": [13, 5], "x": 13, "y": 3},
+                  {"matrix": [12, 5], "x": 14, "y": 3},
+                  {"matrix": [0, 4], "x": 0, "y": 4},
+                  {"matrix": [3, 4], "x": 1.25, "y": 4},
+                  {"matrix": [6, 4], "x": 2.25, "y": 4},
+                  {"matrix": [2, 4], "x": 3.25, "y": 4},
+                  {"matrix": [1, 4], "x": 4.25, "y": 4},
+                  {"matrix": [7, 4], "x": 5.25, "y": 4, "w": 2.5},
+                  {"matrix": [9, 4], "x": 7.75, "y": 4},
+                  {"matrix": [8, 4], "x": 8.75, "y": 4},
+                  {"matrix": [11, 4], "x": 9.75, "y": 4},
+                  {"matrix": [14, 4], "x": 10.75, "y": 4},
+                  {"matrix": [15, 4], "x": 12, "y": 4},
+                  {"matrix": [13, 4], "x": 13, "y": 4},
+                  {"matrix": [12, 4], "x": 14, "y": 4}
+                ]
+              }
+            }
+          }
+        }
+      };
+      commit('setKeyboardMeta', fixedLayout);
+      commit('processLayouts', fixedLayout);
+      return { ok: true };
+    }
+
     const resp = await fetch(
       `${backend_keyboards_url}/${state.keyboard}/info.json`
     );


### PR DESCRIPTION
## Description

This PR adds a temporary hardcoded fix for the HHKB JP layout to resolve layout loading issues in the QMK Configurator.

## Problem

The HHKB JP keyboard (hhkb/jp) was not loading its layout correctly from the API, preventing users from configuring this keyboard in the configurator.

## Solution

Added a hardcoded `LAYOUT_jp` configuration directly in the `loadLayouts` action in `actions.js`. This ensures that when the hhkb/jp keyboard is selected, the configurator uses the inline layout data instead of attempting to fetch it from the API.

## Changes

- Modified `src/store/modules/app/actions.js` to include a conditional check for `hhkb/jp`
- Added complete layout data for LAYOUT_jp with proper matrix positions and coordinates
- Ensures the configurator works correctly for this specific keyboard

## Notes

This is a temporary fix that allows the configurator to work while a more permanent solution is developed. The hardcoded data matches the expected layout structure from the QMK firmware.