### PR TITLE
fix: restore full destructure bindings and silence ESLint unused-var warnings

### DIFF
--- a/src/i18n/keymap_extras/convert_keymap_extras_header.js
+++ b/src/i18n/keymap_extras/convert_keymap_extras_header.js
@@ -123,8 +123,7 @@ function computeIntl2US(lines) {
   for (const aliasDefinition of lines.filter((line) =>
     kcAliasDefRegExp.test(line)
   )) {
-    // eslint-disable-next-line no-unused-vars
-    const [fullMatch, intlAlias, macroExpansion] =
+    const [, intlAlias, macroExpansion] =
       kcAliasDefRegExp.exec(aliasDefinition);
     const usAlias = translateToUS(macroExpansion, intl2us);
     intl2us.set(intlAlias, usAlias);
@@ -239,8 +238,7 @@ function convertLine(line, kcInfo, intl2us) {
 
   const copyrightRegExp = /(^.*)Copyright .*$/;
   if (copyrightRegExp.test(line)) {
-    // eslint-disable-next-line no-unused-vars
-    let [fullMatch, beforeCopyrightWord] = copyrightRegExp.exec(line);
+    let [, beforeCopyrightWord] = copyrightRegExp.exec(line);
     return (
       beforeCopyrightWord +
       'Copyright ' +
@@ -255,9 +253,7 @@ function convertLine(line, kcInfo, intl2us) {
   }
 
   if (kcAliasDefRegExp.test(line)) {
-    // eslint-disable-next-line no-unused-vars
-    let [fullMatch, intlAlias, macroExpansion, comment] =
-      kcAliasDefRegExp.exec(line);
+    let [fullMatch, , macroExpansion] = kcAliasDefRegExp.exec(line);
     const usMacroExpansion = translateToUS(macroExpansion, intl2us);
     let kcInfoLine = stringify(usMacroExpansion, kcInfo.get(usMacroExpansion));
     if (shiftedKc2shiftedAlias.has(usMacroExpansion)) {
@@ -336,9 +332,7 @@ function generateMissingShiftedAliasKcInfo(kcInfo) {
 
 function generateSpaceCadetKcInfo(kc, kcInfo) {
   const spaceCadetKeycodeRegExp = /([LR])([GASC])P([OC])/;
-  // eslint-disable-next-line no-unused-vars
-  let [fullMatch, handedness, modifier, variant] =
-    spaceCadetKeycodeRegExp.exec(kc);
+  let [, handedness, modifier, variant] = spaceCadetKeycodeRegExp.exec(kc);
   const table = new Map([
     ['L', 'Left'],
     ['R', 'Right'],


### PR DESCRIPTION
# Overview

This pull request fixes a critical bug in `convert_keymap_extras_header.js` that caused it to fail on all inputs. It restores the full destructure bindings and adds `// eslint-disable-next-line no-unused-vars` directives to preserve positional correctness while avoiding linting errors.

# Description
Commit https://github.com/qmk/qmk_configurator/commit/08282115f850453b3b135de7a9b81ae480dedb87 introduced a regression in the **`convert_keymap_extras_header.js` script** used for i18n keymap extras. 

Several destructuring assignments (`let [a, b, c] = function_call();`) had commented-out elements (e.g. /*fullMatch, */) to avoid `no-unused-vars` warnings. 

```
/home/username/Coding/qmk/configurator/src/i18n/keymap_extras/convert_keymap_extras_header.js
  126:12  error  'fullMatch' is assigned a value but never used  no-unused-vars
  241:10  error  'fullMatch' is assigned a value but never used  no-unused-vars
  256:21  error  'intlAlias' is assigned a value but never used  no-unused-vars
  256:48  error  'comment' is assigned a value but never used    no-unused-vars
  336:8   error  'fullMatch' is assigned a value but never used  no-unused-vars
  ```

It appears that these unused variables (which are indeed unused because only a subset of the destructured outputs of a function are used) were quickly commented out to get rid of the warning. Unfortunately, this broke the code because the variables were no longer assigned to the correct output of the function within the destructuring assignments (if you turn `let [a, b, c] = function_call();` into `let [a, /*b,*/ c] = function_call();`, variable `c` will point to what was intended to be `b`).

There are multiple ways to deal with this problem:

## Option 1: eslint disable comment
```js
// eslint-disable-next-line no-unused-vars
const [fullMatch, intlAlias, macroExpansion] = kcAliasDefRegExp.exec(line);
```
(does not make it clear which variable exactly is unused)

## Option 2:  Ignore variables with an underscore prefix

Add a rule in `eslint.config.js` to ignore the no-unused-vars warning for variables that start with an underscore:
```js
"rules": {
  "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }]
}
```
and then do this in the code:

```js
const [_fullMatch, intlAlias, macroExpansion] = kcAliasDefRegExp.exec(line);
```
(makes it clear which variable exactly is unused)

## Option 3: name all unused variables as `_`

Unfortunately, this option will not work. Consider the case of multiple ignored/unused variables in the destructured assignment of line 256 in function `convertLine`:

```js
256    let [fullMatch, _, macroExpansion, _] = kcAliasDefRegExp.exec(line);

/home/username/Coding/qmk/configurator/src/i18n/keymap_extras/convert_keymap_extras_header.js
  256:40  error  Parsing error: Identifier '_' has already been declared
```

---

For now, the PR adopts option 1 but this can be discussed.



# Affected functions
- computeIntl2US
- convertLine
- generateSpaceCadetKcInfo


Relevant discussion thread on Discord: https://discord.com/channels/440868230475677696/867530744116543508/1434968023113928848
